### PR TITLE
Drop HAVE_GETFSSTAT in Check_HR_FileSys_AutoFs

### DIFF
--- a/agent/mibgroup/host/hr_filesys.c
+++ b/agent/mibgroup/host/hr_filesys.c
@@ -841,7 +841,6 @@ Check_HR_FileSys_NFS (void)
 int
 Check_HR_FileSys_AutoFs(void)
 {
-#if HAVE_GETFSSTAT
     if (HRFS_entry->HRFS_type != NULL && 
 #if defined(MNTTYPE_AUTOFS)
         !strcmp(HRFS_entry->HRFS_type, MNTTYPE_AUTOFS)
@@ -849,7 +848,6 @@ Check_HR_FileSys_AutoFs(void)
         !strcmp(HRFS_entry->HRFS_type, "autofs")
 #endif
         )
-#endif /* HAVE_GETFSSTAT */
         return 1;  /* AUTOFS */
 
     return 0; /* no AUTOFS */


### PR DESCRIPTION
GETFSSTAT doesn't exist in Linux, and the preprocessor directive
looks unnecessary in this function.

Reference:
https://sourceforge.net/p/net-snmp/patches/1350/

gcc -E without that commit:

int
Check_HR_FileSys_AutoFs(void)
{
        return 1;

    return 0;
}

gcc -E with that commit:

int
Check_HR_FileSys_AutoFs(void)
{
    if (HRFS_entry->HRFS_type != NULL &&

        !strcmp(HRFS_entry->HRFS_type, "autofs")

        )
        return 1;

    return 0;
}