### PR TITLE
Linux VRF iface on Trap sink IP address not being set

### DIFF
--- a/snmplib/transports/snmpUDPIPv4BaseDomain.c
+++ b/snmplib/transports/snmpUDPIPv4BaseDomain.c
@@ -301,6 +301,17 @@ netsnmp_udpipv4base_transport_with_source(const struct netsnmp_ep *ep,
     if (NULL == bind_addr)
         return t;
 
+    /* for Linux VRF Traps we try to bind the iface if clientaddr is not set */
+    if (ep && ep->iface && t->sock) {
+        rc =  netsnmp_bindtodevice(t->sock, ep->iface);
+        if (rc)
+            DEBUGMSGTL(("netsnmp_udpbase", "VRF: Could not bind socket %d bound to %s\n",
+                        t->sock, ep->iface));
+        else
+            DEBUGMSGTL(("netsnmp_udpbase", "VRF: Bound socket %d bound to %s\n",
+                        t->sock, ep->iface));
+    }
+
     rc = netsnmp_udpipv4base_transport_bind(t, bind_addr, flags);
     if (rc) {
         netsnmp_transport_free(t);

--- a/snmplib/transports/snmpUDPIPv4BaseDomain.c
+++ b/snmplib/transports/snmpUDPIPv4BaseDomain.c
@@ -302,13 +302,13 @@ netsnmp_udpipv4base_transport_with_source(const struct netsnmp_ep *ep,
         return t;
 
     /* for Linux VRF Traps we try to bind the iface if clientaddr is not set */
-    if (ep && ep->iface && t->sock) {
+    if (ep && ep->iface) {
         rc =  netsnmp_bindtodevice(t->sock, ep->iface);
         if (rc)
-            DEBUGMSGTL(("netsnmp_udpbase", "VRF: Could not bind socket %d bound to %s\n",
+            DEBUGMSGTL(("netsnmp_udpbase", "VRF: Could not bind socket %d to %s\n",
                         t->sock, ep->iface));
         else
-            DEBUGMSGTL(("netsnmp_udpbase", "VRF: Bound socket %d bound to %s\n",
+            DEBUGMSGTL(("netsnmp_udpbase", "VRF: Bound socket %d to %s\n",
                         t->sock, ep->iface));
     }
 


### PR DESCRIPTION
For Linux VRF support in Traps, this patch fixes an issue
(#12) where configuring and iface on the sink IP address
was not being bound (via SO_BINDTODEVICE) to the socket.
This was broken for versions 1, 2c, and 3.

While a clientaddr setting in snmp.conf could fix this,
a user would have to find and set a source IP address
in the VRF to be used. This patch does not require
setting a clientaddr but simply binds the iface
provided in the sink IP address (target) to the
session socket that will be used.

Signed-off-by: Sam Tannous <stannous@cumulusnetworks.com>