### PR TITLE
Fix hrSWRunPath reported string length

### DIFF
--- a/agent/mibgroup/host/data_access/swrun_procfs_status.c
+++ b/agent/mibgroup/host/data_access/swrun_procfs_status.c
@@ -56,7 +56,7 @@ netsnmp_arch_swrun_container_load( netsnmp_container *container, u_int flags)
     DIR                 *procdir = NULL;
     struct dirent       *procentry_p;
     FILE                *fp;
-    int                  pid, i;
+    int                  pid, i, ret;
     unsigned long long   cpu;
     char                 buf[BUFSIZ], buf2[BUFSIZ], *cp, *cp1;
     netsnmp_swrun_entry *entry;
@@ -129,24 +129,26 @@ netsnmp_arch_swrun_container_load( netsnmp_container *container, u_int flags)
         if (cp != NULL) {
             /*
              *     argv[0]   is hrSWRunPath
-             */ 
-            entry->hrSWRunPath_len = snprintf(entry->hrSWRunPath,
-                                       sizeof(entry->hrSWRunPath)-1, "%s", buf);
+             */
+            ret = snprintf(entry->hrSWRunPath,
+                           sizeof(entry->hrSWRunPath), "%s", buf);
+
+            if (ret < sizeof(entry->hrSWRunPath))
+                entry->hrSWRunPath_len = ret;
+            else
+                entry->hrSWRunPath_len = sizeof(entry->hrSWRunPath) - 1;
+
             /*
              * Stitch together argv[1..] to construct hrSWRunParameters
              */
-            cp = buf + entry->hrSWRunPath_len+1;
-            while ( 1 ) {
-                while (*cp)
-                    cp++;
-                if ( '\0' == *(cp+1))
-                    break;      /* '\0''\0' => End of command line */
-                *cp = ' ';
-            }
+            for (cp = buf + ret; ! (*cp == '\0' && *(cp + 1) == '\0'); cp++)
+                    if (*cp == '\0')
+                            *cp = ' ';
+
             entry->hrSWRunParameters_len
                 = sprintf(entry->hrSWRunParameters, "%.*s",
                           (int)sizeof(entry->hrSWRunParameters) - 1,
-                          buf + entry->hrSWRunPath_len + 1);
+                          buf + ret + 1);
         } else {
             /* empty /proc/PID/cmdline, it's probably a kernel thread */
             entry->hrSWRunPath_len = 0;


### PR DESCRIPTION
```
snprintf (...) return value is the number of characters (excluding the
terminating null byte) which would have been written to the final string
if enough space had been available.
```

The length of the string reported was not correct because of this.

snmpget would then misinterpret the value like :

iso.3.6.1.2.1.25.4.2.1.4.19031 = Hex-STRING: 2F 74 6D 70 2F 6C 6F 6F 6F
6F 6F 6F 6F 6F 6F 6F
6F 6F 6F 6F 6F 6F 6F 6F 6F 6F 6F 6F 6F 6F 6F 6F
6F 6F 6F 6F 6F 6F 6F 6F 6F 6F 6F 6F 6F 6F 6F 6F
6F 6F 6F 6F 6F 6F 6F 6F 6F 6F 6F 6F 6F 6F 6F 6F
6F 6F 6F 6F 6F 6F 6F 6F 6E 67 2F 6C 6F 6F 6F 6F
6F 6F 6F 6F 6F 6F 6F 6F 6F 6F 6F 6F 6F 6F 6F 6F
6F 6F 6F 6F 6F 6F 6F 6F 6F 6F 6F 6F 6F 6F 6F 6F
6F 6F 6F 6F 6F 6F 6F 6F 6F 6F 6F 6F 6F 6F 6F 00
00 2D 70 6F 20 2D 72 61 6F 65 6B 72 6B 20 65 72
61 7A 00 00 00 00

after the patch :

iso.3.6.1.2.1.25.4.2.1.4.19031 = STRING:
"/tmp/loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong/loooooooooooooooooooooooooooooooooooooooooooooooooooo"

Signed-off-by: Benjamin Hesmans <benjamin.hesmans@tessares.net>