### PR TITLE
Reduce CPU load for IF-MIB on Linux servers with large number of interfaces

### DIFF
--- a/agent/mib_modules.c
+++ b/agent/mib_modules.c
@@ -65,6 +65,8 @@ init_mib_modules(void)
 {
     static int once = 0;
 
+    netsnmp_include_interface_init();
+
 #ifdef USING_IF_MIB_DATA_ACCESS_INTERFACE_MODULE
     netsnmp_access_interface_init();
 #endif

--- a/agent/mibgroup/etherlike-mib/data_access/dot3stats_linux.c
+++ b/agent/mibgroup/etherlike-mib/data_access/dot3stats_linux.c
@@ -124,6 +124,9 @@ dot3stats_interface_ioctl_ifindex_get (int fd, const char *name) {
     struct ifreq    ifrq;
     int rc = 0;
 
+    if (!netsnmp_access_interface_include(name))
+        return 0;
+
     DEBUGMSGTL(("access:dot3StatsTable:interface_ioctl_ifindex_get", "called\n"));
                  
     rc = _dot3Stats_ioctl_get(fd, SIOCGIFINDEX, &ifrq, name);

--- a/agent/mibgroup/if-mib/data_access/interface_linux.c
+++ b/agent/mibgroup/if-mib/data_access/interface_linux.c
@@ -721,6 +721,9 @@ netsnmp_arch_interface_container_load(netsnmp_container* container,
          */
         *stats++ = 0; /* null terminate name */
 
+	if (!netsnmp_access_interface_include(ifstart))
+		continue;
+
         /*
          * set address type flags.
          * the only way I know of to check an interface for

--- a/agent/mibgroup/ip-mib/data_access/ipaddress_ioctl.c
+++ b/agent/mibgroup/ip-mib/data_access/ipaddress_ioctl.c
@@ -282,7 +282,6 @@ _netsnmp_ioctl_ipaddress_container_load_v4(netsnmp_container *container,
         if (ioctl(sd, SIOCGIFFLAGS, ifrp) < 0) {
             snmp_log(LOG_ERR,
                      "error getting if_flags for interface %d\n", i);
-            netsnmp_access_ipaddress_entry_free(bcastentry);
             netsnmp_access_ipaddress_entry_free(entry);
             continue;
         }

--- a/agent/mibgroup/ip-mib/data_access/ipaddress_ioctl.c
+++ b/agent/mibgroup/ip-mib/data_access/ipaddress_ioctl.c
@@ -172,6 +172,9 @@ _netsnmp_ioctl_ipaddress_container_load_v4(netsnmp_container *container,
             continue;
         }
 
+        if (!netsnmp_access_interface_include(ifrp->ifr_name))
+            continue;
+
         /*
          */
         entry = netsnmp_access_ipaddress_entry_create();

--- a/agent/mibgroup/ip-mib/data_access/ipaddress_linux.c
+++ b/agent/mibgroup/ip-mib/data_access/ipaddress_linux.c
@@ -262,6 +262,9 @@ _load_v6(netsnmp_container *container, int idx_offset)
         DEBUGMSGTL(("access:ipaddress:container",
                     "addr %s, index %d, pfx %d, scope %d, flags 0x%X, name %s\n",
                     addr, if_index, pfx_len, scope, flags, if_name));
+
+        if (!netsnmp_access_interface_include(if_name))
+            continue;
         /*
          */
         entry = netsnmp_access_ipaddress_entry_create();

--- a/include/net-snmp/data_access/interface.h
+++ b/include/net-snmp/data_access/interface.h
@@ -204,6 +204,11 @@ typedef struct _conf_if_list {
 
     typedef netsnmp_conf_if_list conf_if_list; /* backwards compat */
 
+typedef struct _include_if_list {
+    const char     *name;
+    struct _include_if_list *next;
+} netsnmp_include_if_list;
+
 /**---------------------------------------------------------------------*/
 /*
  * ACCESS function prototypes
@@ -282,6 +287,15 @@ void netsnmp_access_interface_entry_overrides(netsnmp_interface_entry *);
 
 netsnmp_conf_if_list *
 netsnmp_access_interface_entry_overrides_get(const char * name);
+
+/*
+ * Check if the interface has to be ignored (1: true, 0: false)
+ */
+int netsnmp_access_interface_ignore(const char * name);
+
+/* Check if the interface has to be included (1: true, 0: false)
+ */
+int netsnmp_access_interface_include(const char * name);
 
 /**---------------------------------------------------------------------*/
 

--- a/man/snmpd.conf.5.def
+++ b/man/snmpd.conf.5.def
@@ -92,6 +92,16 @@ will be an integer multiple of the number of variables requested times
 the calculated number of repeats allow to fit below this number.
 .IP
 Also note that processing of maxGetbulkRepeats is handled first.
+.IP "include_ifmib_iface_prefix PREFIX1 PREFIX2 ..."
+Sets the interface name prefixes to include in the IF-MIB data collection.
+For servers with a large number of interfaces (ppp, dummy, bridge, etc)
+the IF-MIB processing will take a large chunk of CPU for ioctl calls
+(on Linux). A set of space separated interface name prefixes will
+reduce the CPU load for IF-MIB processing.  For example, configuring
+"include_ifmib_iface_prefix eth dummy lo" will include only interfaces
+with these prefixes and ignore all others for IF-MIB processing.
+.IP
+The default (without this configured) is to include all interfaces.
 .SS SNMPv3 Configuration - Real Security
 SNMPv3 is added flexible security models to the SNMP packet structure
 so that multiple security solutions could be used.  SNMPv3 was


### PR DESCRIPTION
Reduce CPU load for IF-MIB on Linux servers with large number of interfaces

This patch introduces a new configution option to limit the number
of interfaces that the IF-MIB will process.  On Linux servers with a
large number of interfaces (ppp, dummy, bridge, etc.), the IF-MIB
timer based stats collector can take a large amount of CPU processing.

The new config option "include_ifmib_iface_prefix" takes a space
separated string of ifname prefixes ("eth lo bridg") and will only
include interfaces with these prefixes in the IF-MIB tables.

If this config option is not present (the default), all interfaces
will continue to be processed in the IF-MIB.

This patch is largely based on work by Collet Thibaut from 

https://sourceforge.net/p/net-snmp/patches/1352/ 

Signed-off-by: Sam Tannous <stannous@cumulusnetworks.com>