### PR TITLE
Add new config option to limit max number of interfaces for IF-MIB

### DIFF
--- a/agent/mibgroup/if-mib/data_access/interface.c
+++ b/agent/mibgroup/if-mib/data_access/interface.c
@@ -946,7 +946,7 @@ _free_interface_config(void)
 static void
 _parse_ifmib_max_num_ifaces(const char *token, char *cptr)
 {
-    long long_val;
+    int temp_max;
     char *name, *st;
 
     errno = 0;
@@ -955,13 +955,12 @@ _parse_ifmib_max_num_ifaces(const char *token, char *cptr)
         config_perror("Missing NUMBER parameter");
         return;
     }
-    long_val = strtol(cptr, NULL, 10);
-    if (errno) {
-           config_perror("Error converting parameter");
-           return;
+    if (sscanf(cptr, "%d", &temp_max) != 1) {
+        config_perror("Error converting parameter");
+        return;
     }
 
-    ifmib_max_num_ifaces = (int) long_val;
+    ifmib_max_num_ifaces = temp_max;
 }
 
 

--- a/agent/mibgroup/if-mib/data_access/interface.c
+++ b/agent/mibgroup/if-mib/data_access/interface.c
@@ -6,6 +6,7 @@
 #include <net-snmp/net-snmp-config.h>
 #include <net-snmp/net-snmp-features.h>
 #include <net-snmp/net-snmp-includes.h>
+#include <errno.h>
 
 #include <net-snmp/agent/net-snmp-agent-includes.h>
 #include <net-snmp/library/snmp_enum.h>
@@ -33,6 +34,7 @@ static netsnmp_conf_if_list *conf_list = NULL;
 static int need_wrap_check = -1;
 static int _access_interface_init = 0;
 static netsnmp_include_if_list *include_list;
+static int ifmib_max_num_ifaces = 0;
 
 /*
  * local static prototypes
@@ -45,6 +47,7 @@ static void _access_interface_entry_release(netsnmp_interface_entry * entry,
 #endif
 static void _access_interface_entry_save_name(const char *name, oid index);
 static void _parse_interface_config(const char *token, char *cptr);
+static void _parse_ifmib_max_num_ifaces(const char *token, char *cptr);
 static void _free_interface_config(void);
 static void _parse_include_if_config(const char *token, char *cptr);
 static void _free_include_if_config(void);
@@ -69,6 +72,11 @@ init_interface(void)
     snmpd_register_config_handler("interface", _parse_interface_config,
                                   _free_interface_config,
                                   "name type speed");
+
+    snmpd_register_config_handler("ifmib_max_num_ifaces",
+                                  _parse_ifmib_max_num_ifaces,
+                                  NULL,
+                                  "IF-MIB MAX Number of ifaces");
 
     snmpd_register_config_handler("include_ifmib_iface_prefix",
                                   _parse_include_if_config,
@@ -803,6 +811,30 @@ netsnmp_access_interface_entry_overrides(netsnmp_interface_entry *entry)
 }
 
 /*
+ * ifmib_max_num_ifaces config token
+ *
+ * Users may configure a maximum number if interfaces for
+ * the IF-MIB to include. This is useful in case there are
+ * a large number of interfaces (bridges, bonds, SVIs) that
+ * can slow things down.
+ */
+int netsnmp_access_interface_max_reached(const char *name)
+{
+    if (!name)
+        return FALSE;
+
+    if (ifmib_max_num_ifaces == 0)
+        /* nothing was set as a max so we include it all */
+        return FALSE;
+
+    if (netsnmp_arch_interface_index_find(name) > ifmib_max_num_ifaces)
+        /* We have gone over the max configured iface count */
+        return TRUE;
+
+    return FALSE;
+}
+
+/*
  * include_ifmib_iface_prefix config token
  *
  * If and only if there is an iface prefix name match, we return TRUE.
@@ -907,6 +939,31 @@ _free_interface_config(void)
     }
     conf_list = NULL;
 }
+
+/*
+ * Maximum number of interfaces to include in IF-MIB
+ */
+static void
+_parse_ifmib_max_num_ifaces(const char *token, char *cptr)
+{
+    long long_val;
+    char *name, *st;
+
+    errno = 0;
+    name = strtok_r(cptr, " \t", &st);
+    if (!name) {
+        config_perror("Missing NUMBER parameter");
+        return;
+    }
+    long_val = strtol(cptr, NULL, 10);
+    if (errno) {
+           config_perror("Error converting parameter");
+           return;
+    }
+
+    ifmib_max_num_ifaces = (int) long_val;
+}
+
 
 /*
  * include interface config token

--- a/agent/mibgroup/if-mib/data_access/interface_linux.c
+++ b/agent/mibgroup/if-mib/data_access/interface_linux.c
@@ -724,6 +724,9 @@ netsnmp_arch_interface_container_load(netsnmp_container* container,
 	if (!netsnmp_access_interface_include(ifstart))
 		continue;
 
+	if (netsnmp_access_interface_max_reached(ifstart))
+		/* we may need to stop tracking ifaces if a max was set */
+		continue;
         /*
          * set address type flags.
          * the only way I know of to check an interface for

--- a/agent/mibgroup/ip-mib/data_access/ipaddress_ioctl.c
+++ b/agent/mibgroup/ip-mib/data_access/ipaddress_ioctl.c
@@ -175,6 +175,9 @@ _netsnmp_ioctl_ipaddress_container_load_v4(netsnmp_container *container,
         if (!netsnmp_access_interface_include(ifrp->ifr_name))
             continue;
 
+	if (netsnmp_access_interface_max_reached(ifrp->ifr_name))
+            /* we may need to stop tracking ifaces if a max was set */
+            continue;
         /*
          */
         entry = netsnmp_access_ipaddress_entry_create();

--- a/agent/mibgroup/ip-mib/data_access/ipaddress_linux.c
+++ b/agent/mibgroup/ip-mib/data_access/ipaddress_linux.c
@@ -225,6 +225,7 @@ _load_v6(netsnmp_container *container, int idx_offset)
     char            if_name[IFNAMSIZ+1];/* +1 for '\0' because of the ugly sscanf below */ 
     u_char          *buf;
     int             if_index, pfx_len, scope, flags, rc = 0;
+    int             iface_counter;
     size_t          in_len, out_len;
     netsnmp_ipaddress_entry *entry;
     _ioctl_extras           *extras;
@@ -264,6 +265,10 @@ _load_v6(netsnmp_container *container, int idx_offset)
                     addr, if_index, pfx_len, scope, flags, if_name));
 
         if (!netsnmp_access_interface_include(if_name))
+            continue;
+
+	if (netsnmp_access_interface_max_reached(if_name))
+            /* we may need to stop tracking ifaces if a max was set */
             continue;
         /*
          */

--- a/include/net-snmp/data_access/interface.h
+++ b/include/net-snmp/data_access/interface.h
@@ -289,6 +289,7 @@ netsnmp_conf_if_list *
 netsnmp_access_interface_entry_overrides_get(const char * name);
 
 int netsnmp_access_interface_include(const char * name);
+int netsnmp_access_interface_max_reached(const char * name);
 
 /**---------------------------------------------------------------------*/
 

--- a/man/snmpd.conf.5.def
+++ b/man/snmpd.conf.5.def
@@ -92,6 +92,16 @@ will be an integer multiple of the number of variables requested times
 the calculated number of repeats allow to fit below this number.
 .IP
 Also note that processing of maxGetbulkRepeats is handled first.
+.IP "ifmib_max_num_ifaces NUM"
+Sets the maximum number of interfaces included in IF-MIB data collection.
+For servers with a large number of interfaces (ppp, dummy, bridge, etc)
+the IF-MIB processing will take a large chunk of CPU for ioctl calls
+(on Linux). Setting a reasonable maximum for the CPU used will
+reduce the CPU load for IF-MIB processing.  For example, configuring
+"ifmib_max_num_ifaces 500" will include only the first 500 interfaces
+based on ifindex and ignore all others for IF-MIB processing.
+.IP
+The default (without this configured) is to include all interfaces.
 .IP "include_ifmib_iface_prefix PREFIX1 PREFIX2 ..."
 Sets the interface name prefixes to include in the IF-MIB data collection.
 For servers with a large number of interfaces (ppp, dummy, bridge, etc)


### PR DESCRIPTION
This patch introduces a new config option "ifmib_max_num_ifaces NUM"
This patch sets the maximum number of interfaces included in IF-MIB
data collection.  For servers with a large number of interfaces
(ppp, dummy, bridge, etc) the IF-MIB processing will take a large
chunk of CPU for ioctl calls (on Linux). Setting a reasonable
maximum number of ifaces for the CPU used will reduce the CPU
load for IF-MIB processing.  For example, configuring
"ifmib_max_num_ifaces 500" will include only the first 500
interfaces based on ifindex and ignore all others for IF-MIB
processing.  If missing, the default is to not limit the maximum
number of interfaces (current default).

Signed-off-by: Sam Tannous <stannous@cumulusnetworks.com>