### PR TITLE
Solve the memory leak in RHEL8

### DIFF
--- a/agent/mibgroup/host/data_access/swinst_rpm.c
+++ b/agent/mibgroup/host/data_access/swinst_rpm.c
@@ -75,6 +75,9 @@ netsnmp_swinst_arch_init(void)
     snprintf( pkg_directory, SNMP_MAXPATH, "%s/Packages", dbpath );
     SNMP_FREE(rpmdbpath);
     dbpath = NULL;
+#ifdef HAVE_RPMGETPATH
+    rpmFreeRpmrc();
+#endif
     if (-1 == stat( pkg_directory, &stat_buf )) {
         snmp_log(LOG_ERR, "Can't find directory of RPM packages");
         pkg_directory[0] = '\0';

--- a/agent/mibgroup/host/hr_swinst.c
+++ b/agent/mibgroup/host/hr_swinst.c
@@ -220,6 +220,9 @@ init_hr_swinst(void)
             snprintf(path, sizeof(path), "%s/packages.rpm", swi->swi_dbpath);
         path[ sizeof(path)-1 ] = 0;
         swi->swi_directory = strdup(path);
+#ifdef HAVE_RPMGETPATH
+        rpmFreeRpmrc();
+#endif
     }
 #else
 #  ifdef _PATH_HRSW_directory


### PR DESCRIPTION
Based on the RHEL Bugzilla, Adding the rpmFreeRpmrc() before the exit function solves the memory leak if the function calls the rpmReadConfigFiles(). The sniff test at my side works fine. 