### PR TITLE
libsnmp: Cast signed char to signed int when setting value

### DIFF
--- a/snmplib/snmp_client.c
+++ b/snmplib/snmp_client.c
@@ -888,8 +888,8 @@ snmp_set_var_value(netsnmp_variable_list * vars,
         }
         else if (vars->val_len == sizeof(char)) {
             if (ASN_INTEGER == vars->type) {
-                const char      *val_char 
-                    = (const char *) value;
+                const signed char   *val_char
+                    = (const signed char *) value;
                 *(vars->val.integer) = (long) *val_char;
             } else {
                     const u_char    *val_uchar

--- a/testing/fulltests/unit-tests/T023varbind_set_var_value_int8_clib.c
+++ b/testing/fulltests/unit-tests/T023varbind_set_var_value_int8_clib.c
@@ -1,0 +1,26 @@
+/* HEADER Testing snmp_set_var_value() */
+
+OK(1 == 1, "true");
+
+{
+    signed char values[] = { -128, -23, -1, 1, 42, 127, 0 };
+    int i;
+
+    for ( i = 0; values[i]; i++ )
+    {
+        netsnmp_variable_list variable;
+        int ec;
+
+        variable.next_variable = NULL;
+        variable.type = ASN_INTEGER;
+        variable.val.string = NULL;
+        variable.val.integer = NULL;
+        variable.val_len = 0;
+
+        ec = snmp_set_var_value( &variable, &(values[i]), 1 );
+
+        OK( ec == 0, "snmp_set_var_value() should succeed" );
+        OKF( *(variable.val.integer) == values[i], ("%ld =?= %d",
+             *(variable.val.integer), values[i]) );
+    }
+}


### PR DESCRIPTION
We have an INT8 in a MIB, an Integer32(-128..127) to be more specific.
In a custom software we call 'snmp_pdu_add_variable()' with
type == ASN_INTEGER and len == 1. Deeper down the code path, we come to
'snmp_set_var_value()' and this part:

        else if (vars->val_len == sizeof(char)) {
            if (ASN_INTEGER == vars->type) {
                const char      *val_char
                    = (const char *) value;
                *(vars->val.integer) = (long) *val_char;
            } else {
                    const u_char    *val_uchar
                    = (const u_char *) value;
                *(vars->val.integer) = (unsigned long) *val_uchar;
            }

Obviously the intent is to cast depending on whether the integer is
supposed to be signed or not, but although he jumps to the right code
path here, the result in vars->val.integer is wrong then. It does not
work with type 'char' like above.

We got values looking unsigned added to our pdu which we set to our
net-snmp server then and got them back unsigned on SNMP get requests
later, for example we fed an int8_t with value -32 we read back 224.

So this patch explicitly uses type 'signed char' which works for us.

Compiler is gcc 4.7 and we're cross-compiling for
arm-v5te-linux-gnueabi on Linux.

Signed-off-by: Alexander Dahl <ada@thorsis.com>