### PR TITLE
Perl can notify empty octet string

### DIFF
--- a/perl/SNMP/SNMP.xs
+++ b/perl/SNMP/SNMP.xs
@@ -1022,11 +1022,11 @@ as_uint:
       case TYPE_OPAQUE:
         vars->type = ASN_OCTET_STR;
 as_oct:
-        vars->val.string = netsnmp_malloc(len);
-        vars->val_len = len;
-        if (val && len)
+        if (val && len) {
+            vars->val.string = netsnmp_malloc(len);
+            vars->val_len = len;
             memcpy((char *)vars->val.string, val, len);
-        else {
+        } else {
             ret = FAILURE;
             vars->val.string = (u_char *) netsnmp_strdup("");
             vars->val_len = 0;

--- a/perl/SNMP/SNMP.xs
+++ b/perl/SNMP/SNMP.xs
@@ -1027,7 +1027,8 @@ as_oct:
             vars->val_len = len;
             memcpy((char *)vars->val.string, val, len);
         } else {
-            ret = FAILURE;
+            if (! val)
+                ret = FAILURE;
             vars->val.string = (u_char *) netsnmp_strdup("");
             vars->val_len = 0;
         }


### PR DESCRIPTION
This works:

```
my $sess = new SNMP::TrapSession(
    DestHost => 'kosh',
    Community => 'public',
    Version => '2c',
);

# $SNMP::verbose = 1;

$sess->trap(
    oid => '.1.3.6.1.2.5',
    [
        ['sysLocation', 0, "here"],
    ]
);

```

If I change the `sysLocation` to the empty string, no notification is sent, but because of #64, `$sess->{ErrorNum}` and `$sess->{ErrorStr}` don't indicate any problem. Setting `$SNMP::verbose = 1;` yields this warning:

     error:trap v2: adding varbind at /usr/lib/x86_64-linux-gnu/perl5/5.24/SNMP.pm line 1292.

This PR makes it possible to send traps with OCTET STRING-s of length 0, just like you get with:

    snmptrap -v2c -cpublic kosh '' 1.3.6.1.2.5 sysLocation.0 s ''