### PR TITLE
avoid snmpps null deref for SNMP_NOSUCHOBJECT

### DIFF
--- a/apps/snmpps.c
+++ b/apps/snmpps.c
@@ -337,44 +337,52 @@ collect_perf(netsnmp_session *ss, struct hrSWRunTable **fproc)
         proc.hrSWRunIndex = vlp->name[base_length];
 
         vlp2 = response->variables;
-        if (vlp2->type == SNMP_NOSUCHINSTANCE) goto next;
+        if (vlp2->type == SNMP_NOSUCHINSTANCE ||
+            vlp2->type == SNMP_NOSUCHOBJECT) goto next;
         len = vlp2->val_len;
         proc.hrSWRunName = malloc(len+1);
         memcpy(proc.hrSWRunName, vlp2->val.string, len);
         proc.hrSWRunName[len] = '\0';
 
         vlp2 = vlp2->next_variable;
-        if (vlp2->type == SNMP_NOSUCHINSTANCE) goto next;
+        if (vlp2->type == SNMP_NOSUCHINSTANCE ||
+            vlp2->type == SNMP_NOSUCHOBJECT) goto next;
         proc.hrSWRunID = *vlp2->val.integer;
 
         vlp2 = vlp2->next_variable;
-        if (vlp2->type == SNMP_NOSUCHINSTANCE) goto next;
+        if (vlp2->type == SNMP_NOSUCHINSTANCE ||
+            vlp2->type == SNMP_NOSUCHOBJECT) goto next;
         len = vlp2->val_len;
         proc.hrSWRunPath = malloc(len+1);
         memcpy(proc.hrSWRunPath, vlp2->val.string, len);
         proc.hrSWRunPath[len] = '\0';
 
         vlp2 = vlp2->next_variable;
-        if (vlp2->type == SNMP_NOSUCHINSTANCE) goto next;
+        if (vlp2->type == SNMP_NOSUCHINSTANCE ||
+            vlp2->type == SNMP_NOSUCHOBJECT) goto next;
         len = vlp2->val_len;
         proc.hrSWRunParameters = malloc(len+1);
         memcpy(proc.hrSWRunParameters, vlp2->val.string, len);
         proc.hrSWRunParameters[len] = '\0';
 
         vlp2 = vlp2->next_variable;
-        if (vlp2->type == SNMP_NOSUCHINSTANCE) goto next;
+        if (vlp2->type == SNMP_NOSUCHINSTANCE ||
+            vlp2->type == SNMP_NOSUCHOBJECT) goto next;
         proc.hrSWRunType = *vlp2->val.integer;
 
         vlp2 = vlp2->next_variable;
-        if (vlp2->type == SNMP_NOSUCHINSTANCE) goto next;
+        if (vlp2->type == SNMP_NOSUCHINSTANCE ||
+            vlp2->type == SNMP_NOSUCHOBJECT) goto next;
         proc.hrSWRunStatus = *vlp2->val.integer;
 
         vlp2 = vlp2->next_variable;
-        if (vlp2->type == SNMP_NOSUCHINSTANCE) goto next;
+        if (vlp2->type == SNMP_NOSUCHINSTANCE ||
+            vlp2->type == SNMP_NOSUCHOBJECT) goto next;
         proc.hrSWRunPerfCPU = *vlp2->val.integer;
 
         vlp2 = vlp2->next_variable;
-        if (vlp2->type == SNMP_NOSUCHINSTANCE) goto next;
+        if (vlp2->type == SNMP_NOSUCHINSTANCE ||
+            vlp2->type == SNMP_NOSUCHOBJECT) goto next;
         proc.hrSWRunPerfMem = *vlp2->val.integer;
 
         count++;


### PR DESCRIPTION
Handle SNMP_NOSUCHOBJECT as well as SNMP_NOSUCHINSTANCE. If snmpps/snmptop are pointed at an agent which doesn't provide the required objects, before this change it tries to dereference a null pointer when setting the variables (noticed against OpenBSD snmpd which only implements part of hrSWRunPerf and misses CPU/Mem).