### PR TITLE
Drop extra semi-colon

### DIFF
--- a/include/net-snmp/library/tools.h
+++ b/include/net-snmp/library/tools.h
@@ -158,15 +158,14 @@ extern          "C" {
  * @note res may be the same variable as one of the operands. In other
  *   words, &a == &res || &b == &res may hold.
  */
-#define NETSNMP_TIMERADD(a, b, res)                  \
-{                                                    \
-    (res)->tv_sec  = (a)->tv_sec  + (b)->tv_sec;     \
-    (res)->tv_usec = (a)->tv_usec + (b)->tv_usec;    \
-    if ((res)->tv_usec >= 1000000L) {                \
-        (res)->tv_usec -= 1000000L;                  \
-        (res)->tv_sec++;                             \
-    }                                                \
-}
+#define NETSNMP_TIMERADD(a, b, res) do {              \
+        (res)->tv_sec  = (a)->tv_sec  + (b)->tv_sec;  \
+        (res)->tv_usec = (a)->tv_usec + (b)->tv_usec; \
+        if ((res)->tv_usec >= 1000000L) {             \
+            (res)->tv_usec -= 1000000L;               \
+            (res)->tv_sec++;                          \
+        }                                             \
+      } while (0)
 
 /**
  * Compute res = a - b.
@@ -176,15 +175,14 @@ extern          "C" {
  * @note res may be the same variable as one of the operands. In other
  *   words, &a == &res || &b == &res may hold.
  */
-#define NETSNMP_TIMERSUB(a, b, res)                             \
-{                                                               \
-    (res)->tv_sec  = (a)->tv_sec  - (b)->tv_sec - 1;            \
-    (res)->tv_usec = (a)->tv_usec - (b)->tv_usec + 1000000L;    \
-    if ((res)->tv_usec >= 1000000L) {                           \
-        (res)->tv_usec -= 1000000L;                             \
-        (res)->tv_sec++;                                        \
-    }                                                           \
-}
+#define NETSNMP_TIMERSUB(a, b, res) do {                         \
+        (res)->tv_sec  = (a)->tv_sec  - (b)->tv_sec - 1;         \
+        (res)->tv_usec = (a)->tv_usec - (b)->tv_usec + 1000000L; \
+        if ((res)->tv_usec >= 1000000L) {                        \
+            (res)->tv_usec -= 1000000L;                          \
+            (res)->tv_sec++;                                     \
+        }                                                        \
+    } while (0)
 
 #define ENGINETIME_MAX	2147483647      /* ((2^31)-1) */
 #define ENGINEBOOT_MAX	2147483647      /* ((2^31)-1) */

--- a/include/net-snmp/library/tools.h
+++ b/include/net-snmp/library/tools.h
@@ -143,11 +143,12 @@ extern          "C" {
      *      preprocessor in context.  Limited to a single error return value.
      *      Temporary hack at best.
      */
-#define QUITFUN(e, l)			\
-	if ( (e) != SNMPERR_SUCCESS) {	\
-		rval = SNMPERR_GENERR;	\
-		goto l ;		\
-	}
+#define QUITFUN(e, l) do {               \
+          if ( (e) != SNMPERR_SUCCESS) { \
+             rval = SNMPERR_GENERR;      \
+             goto l ;                    \
+          }                              \
+        } while (0)
 
 /**
  * Compute res = a + b.

--- a/snmplib/scapi.c
+++ b/snmplib/scapi.c
@@ -4,7 +4,7 @@
  */
 /*
  * Portions of this file are copyrighted by:
- * Copyright © 2003 Sun Microsystems, Inc. All rights reserved.
+ * Copyright Â© 2003 Sun Microsystems, Inc. All rights reserved.
  * Use is subject to license terms specified in the COPYING file
  * distributed with the Net-SNMP package.
  *
@@ -113,11 +113,12 @@ netsnmp_feature_child_of(usm_scapi, usm_support);
 
 #ifdef QUITFUN
 #undef QUITFUN
-#define QUITFUN(e, l)					\
-	if (e != SNMPERR_SUCCESS) {			\
-		rval = SNMPERR_SC_GENERAL_FAILURE;	\
-		goto l ;				\
-	}
+#define QUITFUN(e, l) do {                      \
+          if (e != SNMPERR_SUCCESS) {           \
+             rval = SNMPERR_SC_GENERAL_FAILURE; \
+             goto l ;                           \
+          }                                     \
+        } while (0)
 #endif
 
 #ifdef NETSNMP_USE_INTERNAL_CRYPTO

--- a/snmplib/snmpusm.c
+++ b/snmplib/snmpusm.c
@@ -4,7 +4,7 @@
  */
 /*
  * Portions of this file are copyrighted by:
- * Copyright © 2003 Sun Microsystems, Inc. All rights reserved.
+ * Copyright Â© 2003 Sun Microsystems, Inc. All rights reserved.
  * Use is subject to license terms specified in the COPYING file
  * distributed with the Net-SNMP package.
  *
@@ -347,7 +347,7 @@ static int
 usm_set_usmStateReference_name(struct usmStateReference *ref,
                                char *name, size_t name_len)
 {
-    MAKE_ENTRY(ref, char, name, name_len, usr_name, usr_name_length);
+    MAKE_ENTRY(ref, char, name, name_len, usr_name, usr_name_length)
 }
 
 static int
@@ -356,7 +356,7 @@ usm_set_usmStateReference_engine_id(struct usmStateReference *ref,
                                     size_t engine_id_len)
 {
     MAKE_ENTRY(ref, u_char, engine_id, engine_id_len,
-               usr_engine_id, usr_engine_id_length);
+               usr_engine_id, usr_engine_id_length)
 }
 
 static int
@@ -365,7 +365,7 @@ usm_set_usmStateReference_auth_protocol(struct usmStateReference *ref,
                                         size_t auth_protocol_len)
 {
     MAKE_ENTRY(ref, oid, auth_protocol, auth_protocol_len,
-               usr_auth_protocol, usr_auth_protocol_length);
+               usr_auth_protocol, usr_auth_protocol_length)
 }
 
 static int
@@ -373,7 +373,7 @@ usm_set_usmStateReference_auth_key(struct usmStateReference *ref,
                                    u_char * auth_key, size_t auth_key_len)
 {
     MAKE_ENTRY(ref, u_char, auth_key, auth_key_len,
-               usr_auth_key, usr_auth_key_length);
+               usr_auth_key, usr_auth_key_length)
 }
 
 static int
@@ -382,7 +382,7 @@ usm_set_usmStateReference_priv_protocol(struct usmStateReference *ref,
                                         size_t priv_protocol_len)
 {
     MAKE_ENTRY(ref, oid, priv_protocol, priv_protocol_len,
-               usr_priv_protocol, usr_priv_protocol_length);
+               usr_priv_protocol, usr_priv_protocol_length)
 }
 
 static int
@@ -390,7 +390,7 @@ usm_set_usmStateReference_priv_key(struct usmStateReference *ref,
                                    u_char * priv_key, size_t priv_key_len)
 {
     MAKE_ENTRY(ref, u_char, priv_key, priv_key_len,
-               usr_priv_key, usr_priv_key_length);
+               usr_priv_key, usr_priv_key_length)
 }
 
 static int


### PR DESCRIPTION
When compiling with clang-cl, there are quiet a number of these warnings:
```
empty expression statement has no effect; remove unnecessary ';' to silence this warning 
```
Hence, ensure all *loop-macro* are enclosed in a `do { ... ] while (0)` block.... 
except to macro in `snmplib/snmpussm.c`.