### PR TITLE
Handle a memory leak when contextName is used in the PDU. The memory …

### DIFF
--- a/agent/mibgroup/agentx/subagent.c
+++ b/agent/mibgroup/agentx/subagent.c
@@ -503,6 +503,10 @@ handle_agentx_packet(int operation, netsnmp_session * session, int reqid,
      */
 
     internal_pdu = snmp_clone_pdu(pdu);
+
+    /* Free the contextName memory since that pointer is overwritten by community */
+    SNMP_FREE(internal_pdu->contextName);
+
     internal_pdu->contextName = (char *) internal_pdu->community;
     internal_pdu->contextNameLen = internal_pdu->community_len;
     internal_pdu->community = NULL;


### PR DESCRIPTION
We found that the internalPDU->contextName was assigned to the internalPDU->community resulting in losing the reference to the assigned memory of internalPDU->contextName. This memory is never free'ed when the internalPDU is deallocated. I tested the issue in 5.3, 5.8 and master branch. The issue does not happen if contextName is not used

Proposed fix:
contextNames memory should be freed before assignment to community, so that the memory is not lost.

This is discussed further in issue #58 along with a valgrind report.