### PR TITLE
mib2c: use struct counter64 instead of U64 in generated code

### DIFF
--- a/README
+++ b/README
@@ -356,6 +356,7 @@ THANKS
     Anders Wallin <wallinux@gmail.com>
     Andrew Stormont <andy-js@users.sourceforge.net>
     Keith Mendoza <keith@icei.org>
+    Igor Ryzhov <iryzhov@nfware.com>
 
   We've probably forgotten people on this list.  Let us know if you've
   contributed code and we've left you out.

--- a/local/mib2c
+++ b/local/mib2c
@@ -148,7 +148,7 @@ while($#ARGV >= 0) {
 	       "UNSIGNED32", "u_long",
 	       "UINTEGER", "u_long",
 	       "OBJECTID", "oid",
-	       "COUNTER64", "U64",
+	       "COUNTER64", "struct counter64",
 	       "COUNTER", "u_long",
 	       "IPADDR", "in_addr_t",
 	       "BITS", "char",

--- a/local/mib2c-conf.d/generic-ctx-get.m2i
+++ b/local/mib2c-conf.d/generic-ctx-get.m2i
@@ -91,7 +91,7 @@
     $m2c_ctx_lhs = $m2c_ctx_rhs$m2c_ctx_lm;
     memcpy( $m2c_ctx_lh, $m2c_ctx_rh, $m2c_ctx_rhs$m2c_ctx_cm );
 @else@
-@   if $node.decl =~ /U64/i@ #              ASN_COUNTER64
+@   if $node.decl =~ /struct counter64/i@ #              ASN_COUNTER64
     ${m2c_ctx_lh}.high = ${m2c_ctx_rh}.high;
     ${m2c_ctx_lh}.low = ${m2c_ctx_rh}.low;
 @   else@

--- a/local/mib2c-conf.d/m2c_setup_node.m2i
+++ b/local/mib2c-conf.d/m2c_setup_node.m2i
@@ -60,7 +60,7 @@
 @      eval $m2c_node_skip_get = 1@
 @    end@
 @  else@
-@    eval $m2c_decl = $node.decl@
+@    eval $m2c_decl = "$node.decl"@
  @  end@ // enums
 ########################################################################
 ## find max size

--- a/local/mib2c-conf.d/node-get.m2i
+++ b/local/mib2c-conf.d/node-get.m2i
@@ -83,7 +83,7 @@ ${node}_get( ${context}_rowreq_ctx *rowreq_ctx, $m2c_node_param_ref )
 @       include generic-get-char.m2i@
 @    elsif $node.decl =~ /oid/i@ #                    ASN_OBJECT_ID
 @       include generic-get-oid.m2i@
-@    elsif $node.decl =~ /U64/i@ #                    ASN_COUNTER64
+@    elsif $node.decl =~ /struct counter64/i@ #                    ASN_COUNTER64
 @       include generic-get-U64.m2i@
 @    else@
 @        print ERROR: unknown node.decl: $node.decl@


### PR DESCRIPTION
The U64 typedef was replaced with struct counter64 in net-snmp
code because of the conflicts with Perl headers. But mib2c still
generates the code with U64.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>