### PR TITLE
mib2c: fix size_t format specifier in mfd generated code

### DIFF
--- a/local/mib2c-conf.d/mfd-access-container-cached-defines.m2i
+++ b/local/mib2c-conf.d/mfd-access-container-cached-defines.m2i
@@ -358,7 +358,7 @@ $example_end
 @end@ # example
 
     DEBUGMSGT(("verbose:${context}:${context}_container_load",
-               "inserted %d records\n", count));
+               "inserted %" NETSNMP_PRIz "u records\n", count));
 
     return MFD_SUCCESS;
 } /* ${context}_container_load */


### PR DESCRIPTION
Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>