### PR TITLE
Add regex support for include_ifmib_iface_prefix

### DIFF
--- a/agent/mibgroup/if-mib/data_access/interface.c
+++ b/agent/mibgroup/if-mib/data_access/interface.c
@@ -870,11 +870,11 @@ int netsnmp_access_interface_include(const char *name)
     for (if_ptr = include_list; if_ptr; if_ptr = if_ptr->next) {
 #if HAVE_PCRE_H
         if (pcre_exec(if_ptr->regex_ptr, NULL, name, strlen(name), 0, 0, found_ndx, 3) >= 0)
-	{
+        {
             return TRUE;
-	}
+        }
 #elif HAVE_REGEX_H
-	if (regexec(if_ptr->regex_ptr, name, NULL, NULL, NULL) == 0) {
+        if (regexec(if_ptr->regex_ptr, name, NULL, NULL, NULL) == 0) {
             return TRUE;
         }
 #else

--- a/agent/mibgroup/if-mib/data_access/interface.c
+++ b/agent/mibgroup/if-mib/data_access/interface.c
@@ -1074,6 +1074,9 @@ _free_include_if_config(void)
         if_next = if_ptr->next;
 #if HAVE_PCRE_H
         free(if_ptr->regex_ptr);
+#elif HAVE_REGEX_H
+        regfree(if_ptr->regex_ptr);
+        free(if_ptr->regex_ptr);
 #endif
         free(if_ptr->name);
         free(if_ptr);

--- a/include/net-snmp/data_access/interface.h
+++ b/include/net-snmp/data_access/interface.h
@@ -10,6 +10,12 @@
 extern          "C" {
 #endif
 
+#if HAVE_PCRE_H
+#include <pcre.h>
+#elif HAVE_REGEX_H
+#include <regex.h>
+#endif
+
 /*
  * define flags to indicate the availability of certain data
  */
@@ -205,6 +211,11 @@ typedef struct _conf_if_list {
     typedef netsnmp_conf_if_list conf_if_list; /* backwards compat */
 
 typedef struct _include_if_list {
+#if HAVE_PCRE_H
+    pcre                    *regex_ptr;
+#elif HAVE_REGEX_H
+    regex_t                 *regex_ptr;
+#endif
     char                    *name;
     struct _include_if_list *next;
 } netsnmp_include_if_list;

--- a/man/snmpd.conf.5.def
+++ b/man/snmpd.conf.5.def
@@ -109,7 +109,9 @@ the IF-MIB processing will take a large chunk of CPU for ioctl calls
 (on Linux). A set of space separated interface name prefixes will
 reduce the CPU load for IF-MIB processing.  For example, configuring
 "include_ifmib_iface_prefix eth dummy lo" will include only interfaces
-with these prefixes and ignore all others for IF-MIB processing.
+with these prefixes and ignore all others for IF-MIB processing. If
+regex support is compiled in, each of the prefixes is a regular
+expression (which is not permitted to contain a space or tab character).
 .IP
 The default (without this configured) is to include all interfaces.
 .SS SNMPv3 Configuration - Real Security


### PR DESCRIPTION
This patch builds upon commit 76ad71101ce0a4db50f5ab9dd025b13874456b55 which added the include_ifmib_iface_prefix configuration option to instead utilise regular expressions rather than string comparisons. The use case is a common situation where you might have thousands of interfaces named like eth3.stag.ctag and you still want to SNMP monitor eth3 but not all of the other interfaces. Specifying eth3 in the current code would cause all the interfaces to be picked up.