### PR TITLE
swinst_apt: Use dpkg for modified date

### DIFF
--- a/agent/mibgroup/host/data_access/swinst_apt.c
+++ b/agent/mibgroup/host/data_access/swinst_apt.c
@@ -33,17 +33,14 @@
 
 config_require(date_n_time)
 
-char pkg_directory[SNMP_MAXBUF];
 static char apt_fmt[SNMP_MAXBUF];
-static char file[SNMP_MAXBUF];
 
 /* ---------------------------------------------------------------------
  */
 void
 netsnmp_swinst_arch_init(void)
 {
-    strlcpy(pkg_directory, "/var/lib/dpkg/info", sizeof(pkg_directory));
-    snprintf(apt_fmt, SNMP_MAXBUF, "%%%d[^#]#%%%d[^#]#%%%d[^#]#%%%d[^#]#%%%d[^#]#%%%d[^#]#%%%ds",
+    snprintf(apt_fmt, SNMP_MAXBUF, "%%%d[^#]#%%%d[^#]#%%%d[^#]#%%%d[^#]#%%%d[^#]#%%%d[^#]#%%%d[^#]#%%lld",
 	SNMP_MAXBUF-1, SNMP_MAXBUF-1, SNMP_MAXBUF-1, SNMP_MAXBUF-1,
 	SNMP_MAXBUF-1, SNMP_MAXBUF-1, SNMP_MAXBUF-1);
 }
@@ -60,7 +57,7 @@ netsnmp_swinst_arch_shutdown(void)
 int
 netsnmp_swinst_arch_load( netsnmp_container *container, u_int flags)
 {
-    FILE *p = popen("dpkg-query --show --showformat '${Package}#${Version}#${Section}#${Priority}#${Essential}#${Architecture}#${Status}\n'", "r");
+    FILE *p = popen("dpkg-query --show --showformat '${Package}#${Version}#${Section}#${Priority}#${Essential}#${Architecture}#${Status}#${db-fsys:Last-Modified}\n'", "r");
     char package[SNMP_MAXBUF];
     char version[SNMP_MAXBUF];
     char section[SNMP_MAXBUF];
@@ -68,8 +65,8 @@ netsnmp_swinst_arch_load( netsnmp_container *container, u_int flags)
     char essential[SNMP_MAXBUF];
     char arch[SNMP_MAXBUF];
     char status[SNMP_MAXBUF];
+    long long last_modified;
     char buf[BUFSIZ];
-    struct stat stat_buf;
     netsnmp_swinst_entry *entry;
     u_char *date_buf;
     size_t date_len;
@@ -87,7 +84,7 @@ netsnmp_swinst_arch_load( netsnmp_container *container, u_int flags)
             continue;   /* error already logged by function */
         CONTAINER_INSERT(container, entry);
 
-	sscanf(buf, apt_fmt, package, version, section, priority, essential, arch, status);
+	sscanf(buf, apt_fmt, package, version, section, priority, essential, arch, status, &last_modified);
 	if (strstr(status, "not-installed"))
 	    continue;
 
@@ -99,21 +96,10 @@ netsnmp_swinst_arch_load( netsnmp_container *container, u_int flags)
                         ? 2      /* operatingSystem */
                         : 4;     /*  application    */
 
-        /* get the last mod date */
-        snprintf(file, sizeof(file), "%s/%s.list", pkg_directory, package);
-        if(stat(file, &stat_buf) != -1) {
-            date_buf = date_n_time(&stat_buf.st_mtime, &date_len);
-            entry->swDate_len = date_len;
-            memcpy(entry->swDate, date_buf, entry->swDate_len);
-        } else {
-            /* somewhy some files include :arch in .list name */
-            snprintf(file, sizeof(file), "%s/%s:%s.list", pkg_directory, package, arch);
-            if(stat(file, &stat_buf) != -1) {
-                date_buf = date_n_time(&stat_buf.st_mtime, &date_len);
-                entry->swDate_len = date_len;
-                memcpy(entry->swDate, date_buf, entry->swDate_len);
-            }
-        }
+	date_buf = date_n_time((time_t*)(&last_modified), &date_len);
+        entry->swDate_len = date_len;
+        memcpy(entry->swDate, date_buf, entry->swDate_len);
+
         /* FIXME, or fallback to whatever nonsesnse was here before, or leave it uninitialied?
              else {
         entry->swDate_len = 8;


### PR DESCRIPTION
Instead of trawling through dpkg's files, let dpkg-query tell us
when the package was last modified. It means if the directory
changes or any other internal changes happen, this will still
keep working.

db-sys:Last-Modified field has been in since dpkg-query 1.19.3
which means it works for Debian stable (Buster) onwards.

References:
 https://bugs.debian.org/905668