### PR TITLE
V5 7 patches

### DIFF
--- a/agent/mibgroup/mibII/interfaces.c
+++ b/agent/mibgroup/mibII/interfaces.c
@@ -1976,7 +1976,7 @@ Interface_Scan_NextInt(int *Index, char *Name, nmapi_phystat * Retifnet)
        
     if (!if_ptr || (saveIndex==0)) { /* we get physical stat only when begining an enumeration */
                                     /*  to limit the cost of walking the interfaces*/
-        count_prev=count;
+        count_prev = count;
         count=Interface_Scan_Get_Count();
         if (count) {
             if (!if_ptr){


### PR DESCRIPTION
On HPUX 11.31  snmpwalk over mibII get timeout if the number of interfaces of the server is large.
This is due to the excessive number of get_phys_stat() called, causing the stats to be get thousand of time for a simple walk

With this fix, get_phys_stat is only get when  SaveIndex is 0 so, starting a new lookup on an interface.