### PR TITLE
pingCtlTable: Move two more global variable definitions from .h to .c

### DIFF
--- a/agent/mibgroup/disman/ping/pingCtlTable.c
+++ b/agent/mibgroup/disman/ping/pingCtlTable.c
@@ -74,6 +74,10 @@ static struct proto {
     int             icmpproto;  /* IPPROTO_xxx value for ICMP */
 } *pr;
 
+static volatile int    exiting;
+static volatile int    status_snapshot;
+
+
 /*
  *pingCtlTable_variables_oid:
  *                                                      

--- a/agent/mibgroup/disman/ping/pingCtlTable.h
+++ b/agent/mibgroup/disman/ping/pingCtlTable.h
@@ -327,8 +327,6 @@ unsigned long   round_double(double);
 
 #define	MAX_DUP_CHK	0x10000
 
-volatile int    exiting;
-volatile int    status_snapshot;
 
 #ifndef MSG_CONFIRM
 #define MSG_CONFIRM 0


### PR DESCRIPTION
Fix a Problem with GCC 10