### PR TITLE
sensors: Add support for humidity sensor

### DIFF
--- a/agent/mibgroup/hardware/sensors/lmsensors_v3.c
+++ b/agent/mibgroup/hardware/sensors/lmsensors_v3.c
@@ -54,6 +54,9 @@ netsnmp_sensor_arch_load(netsnmp_cache *cache, void *vp) {
                 case SENSORS_SUBFEATURE_VID:
                     type = NETSNMP_SENSOR_TYPE_VOLTAGE_DC;
                     break;
+                case SENSORS_SUBFEATURE_HUMIDITY_INPUT:
+                    type = NETSNMP_SENSOR_TYPE_HUMIDITY;
+                    break;
                 default:
                     /* Skip everything other than these basic sensor features - ??? */
                     DEBUGMSGTL(("sensors:arch:detail", "  Skip type %x\n", data2->type));


### PR DESCRIPTION
LM-SENSORS-MIB supports only 4 standard sensors but provides MISC table
for other sensors, we can use that table to log the humidity sensor
reading.

Tested using my local unit and works fine.