### PR TITLE
Issue#147: Net-SNMP not responding when proxy requests times out

### DIFF
--- a/agent/mibgroup/ucd-snmp/proxy.c
+++ b/agent/mibgroup/ucd-snmp/proxy.c
@@ -572,6 +572,17 @@ proxy_got_response(int operation, netsnmp_session * sess, int reqid,
     }
 
     switch (operation) {
+    case NETSNMP_CALLBACK_OP_RESEND:
+         /*
+         * Issue#147: Net-SNMP not responding when proxy requests times out
+         *
+         * When snmp_api issue a resend, the default case was hit and the 
+         * delagated cache was freed.
+         * As a result, the NETSNMP_CALLBACK_OP_TIMED_OUT never came in.
+         */
+        DEBUGMSGTL(("proxy", "pdu has been resent for request = %8p\n", requests));
+        return SNMP_ERR_NOERROR;
+
     case NETSNMP_CALLBACK_OP_TIMED_OUT:
         /*
          * WWWXXX: don't leave requests delayed if operation is


### PR DESCRIPTION
This PR resolves the issue #147.

The test scenario presented in the issue no longer fails with this fix in place.
Without a complete understanding of the actual expected flow, I can not tell if there are any side effects such as leaks or locks in other scenarios.

A short explanation of the fix intent is provided in the code.