### PR TITLE
snmpnetstat: don't use sigpause and sigblock

### DIFF
--- a/apps/snmpnetstat/if.c
+++ b/apps/snmpnetstat/if.c
@@ -907,12 +907,13 @@ timerPause(void)
         sigpause(SIGALRM);
     }
 #else
-    int             oldmask;
-    oldmask = sigblock(sigmask(SIGALRM));
+    sigset_t mask;
+    sigemptyset(&mask);
+    sigaddset(&mask, SIGALRM);
+    sigprocmask(SIG_BLOCK, &mask, 0);
     if (!signalled) {
-        sigpause(0);
+        sigsuspend(&mask);
     }
-    sigsetmask(oldmask);
 #endif
 }
 


### PR DESCRIPTION
sigblock/pause is deprecated. Replaced with newer APIs.