### PR TITLE
snmpd: support MemAvailable on Linux

### DIFF
--- a/agent/mibgroup/ucd-snmp/memory.c
+++ b/agent/mibgroup/ucd-snmp/memory.c
@@ -111,6 +111,13 @@ handle_memory(netsnmp_mib_handler *handler,
             val  =  mem_info->free;     /* memfree */
             val *= (mem_info->units/1024);
             break;
+        case MEMORY_SYS_AVAIL:
+            mem_info = netsnmp_memory_get_byIdx( NETSNMP_MEM_TYPE_AVAILMEM, 0);
+            if (!mem_info)
+                goto NOSUCH;
+            val = mem_info->size;       /* memavail */
+            val *= (mem_info->units/1024);
+            break;
         case MEMORY_STXT_TOTAL:
             mem_info = netsnmp_memory_get_byIdx( NETSNMP_MEM_TYPE_STEXT, 0 );
             if (!mem_info)

--- a/agent/mibgroup/ucd-snmp/memory.h
+++ b/agent/mibgroup/ucd-snmp/memory.h
@@ -41,6 +41,7 @@ Netsnmp_Node_Handler handle_memory;
 #define MEMORY_SHARED_X     24
 #define MEMORY_BUFFER_X     25
 #define MEMORY_CACHED_X     26
+#define MEMORY_SYS_AVAIL    27
 #define MEMORY_SWAP_ERROR  100
 #define MEMORY_SWAP_ERRMSG 101
 #endif                          /* MEMORY_H */

--- a/include/net-snmp/agent/hardware/memory.h
+++ b/include/net-snmp/agent/hardware/memory.h
@@ -10,6 +10,7 @@ typedef struct netsnmp_memory_info_s netsnmp_memory_info;
 #define NETSNMP_MEM_TYPE_SHARED   8
 #define NETSNMP_MEM_TYPE_SHARED2  9
 #define NETSNMP_MEM_TYPE_SWAP    10
+#define NETSNMP_MEM_TYPE_AVAIMEM 11
     /* Leave space for individual swap devices */
 #define NETSNMP_MEM_TYPE_MAX     30
 

--- a/mibs/UCD-SNMP-MIB.txt
+++ b/mibs/UCD-SNMP-MIB.txt
@@ -746,6 +746,22 @@ memCachedX OBJECT-TYPE
          memory as specifically reserved for this purpose."
     ::= { memory 26 }
 
+memSysAvail OBJECT-TYPE
+    SYNTAX	CounterBasedGauge64
+    UNITS       "kB"
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+        "The total amount of available memory, which is an estimate
+         of how much memory is available for starting new applications,
+         without swapping.
+
+         This object will not be implemented on hosts where the
+         underlying operating system does not explicitly identify
+         memory as specifically reserved for this purpose."
+    ::= { memory 27 }
+
+
 memSwapError OBJECT-TYPE
     SYNTAX	UCDErrorFlag
     MAX-ACCESS	read-only


### PR DESCRIPTION
This is my first time walking into this code base, so I don't know what I'm doing.

But the idea is to add support of reporting MemAvailable on Linux

```
-> % free -h
              total        used        free      shared  buff/cache   **available**
Mem:          3.8Gi       437Mi       2.5Gi       5.0Mi       936Mi       3.2Gi
Swap:         4.0Gi          0B       4.0Gi
```

please guide if I'm doing this correctly and/or anything that is not covered