### PR TITLE
snmpd: avoid container double free in error cases

### DIFF
--- a/agent/mibgroup/if-mib/data_access/interface_linux.c
+++ b/agent/mibgroup/if-mib/data_access/interface_linux.c
@@ -757,8 +757,6 @@ netsnmp_arch_interface_container_load(netsnmp_container* container,
 #ifdef NETSNMP_ENABLE_IPV6
             netsnmp_access_ipaddress_container_free(addr_container, 0);
 #endif
-            netsnmp_access_interface_container_free(container,
-                                                    NETSNMP_ACCESS_INTERFACE_FREE_NOFLAGS);
             fclose(devin);
             close(fd);
             free(ifc.ifc_buf);

--- a/agent/mibgroup/if-mib/data_access/interface_openbsd.c
+++ b/agent/mibgroup/if-mib/data_access/interface_openbsd.c
@@ -143,8 +143,6 @@ netsnmp_arch_interface_container_load(netsnmp_container* container,
 
         entry = netsnmp_access_interface_entry_create(if_name, ifp->ifm_index);
         if(NULL == entry) {
-            netsnmp_access_interface_container_free(container,
-                                                    NETSNMP_ACCESS_INTERFACE_FREE_NOFLAGS);
             free(if_list);
             return -3;
         }

--- a/agent/mibgroup/if-mib/data_access/interface_solaris2.c
+++ b/agent/mibgroup/if-mib/data_access/interface_solaris2.c
@@ -211,8 +211,6 @@ netsnmp_arch_interface_container_load(netsnmp_container* container,
     if (error) {
         DEBUGMSGTL(("access:interface:container:arch", 
                     "error %d, free container\n", error));
-        netsnmp_access_interface_container_free(container,
-            NETSNMP_ACCESS_INTERFACE_FREE_NOFLAGS);
         return -2;
     }
 

--- a/agent/mibgroup/if-mib/data_access/interface_sysctl.c
+++ b/agent/mibgroup/if-mib/data_access/interface_sysctl.c
@@ -546,8 +546,6 @@ netsnmp_arch_interface_container_load(netsnmp_container* container,
         entry = netsnmp_access_interface_entry_create(if_name, ifp->ifm_index);
         free(if_name);
         if(NULL == entry) {
-            netsnmp_access_interface_container_free(container,
-                                                    NETSNMP_ACCESS_INTERFACE_FREE_NOFLAGS);
             free(if_list);
             return -3;
         }


### PR DESCRIPTION
container should be freed by caller function netsnmp_access_interface_container_load().