### PR TITLE
Parse MIBs: Raise limit for external imports

### DIFF
--- a/snmplib/parse.c
+++ b/snmplib/parse.c
@@ -28,7 +28,7 @@ ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS
 SOFTWARE.
 ******************************************************************/
 /*
- * Copyright © 2003 Sun Microsystems, Inc. All rights reserved.
+ * Copyright Â© 2003 Sun Microsystems, Inc. All rights reserved.
  * Use is subject to license terms specified in the COPYING file
  * distributed with the Net-SNMP package.
  */
@@ -3620,7 +3620,7 @@ parse_imports(FILE * fp)
     register int    type;
     char            token[MAXTOKEN];
     char            modbuf[256];
-#define MAX_IMPORTS	256
+#define MAX_IMPORTS	512
     struct module_import import_list[MAX_IMPORTS];
     int             this_module;
     struct module  *mp;


### PR DESCRIPTION
Today, I stepped into an well-known old issue (https://sourceforge.net/p/net-snmp/mailman/message/16927159/) using a bunch of MIBs from CISCO.