### PR TITLE
HOST-MIB, hr_filesys: fix compile error

### DIFF
--- a/agent/mibgroup/host/hr_filesys.c
+++ b/agent/mibgroup/host/hr_filesys.c
@@ -718,7 +718,7 @@ static const char *HRFS_ignores[] = {
 int
 Get_Next_HR_FileSys(void)
 {
-next:
+next: ;
 #if HAVE_GETFSSTAT
     if (HRFS_index >= fscount)
         return -1;


### PR DESCRIPTION
On non-AIX systems without getfsstat, a variable is being declared right
after a label. This is a violation of the C language standard, and
causes the following compile error:

host/hr_filesys.c: In function 'Get_Next_HR_FileSys':
host/hr_filesys.c:752:5: error: a label can only be part of a statement and a declaration is not a statement
     const char    **cpp;
          ^~~~~

Fix the problem by adding an empty statement after the label.

Fixes: 22e1371bb1fd ("HOST-MIB, hr_filesys: Convert recursion into iteration")

Signed-off-by: Stijn Tintel <stijn@linux-ipv6.be>