### PR TITLE
Fix regex for "-l" discovery in setup.py

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -17,14 +17,14 @@ if intree:
     netsnmp_libs = os.popen(basedir+'/net-snmp-config --libs').read()
     libdir = os.popen(basedir+'/net-snmp-config --build-lib-dirs '+basedir).read()
     incdir = os.popen(basedir+'/net-snmp-config --build-includes '+basedir).read() + " " + os.popen(basedir+'/net-snmp-config --base-cflags '+basedir).read()
-    libs = re.findall(r"-l(\S+)", netsnmp_libs)
-    libdirs = re.findall(r"-L(\S+)", libdir)
-    incdirs = re.findall(r"-I(\S+)", incdir)
+    libs = re.findall(r"(?:^|\s+)-l(\S+)", netsnmp_libs)
+    libdirs = re.findall(r"(?:^|\s+)-L(\S+)", libdir)
+    incdirs = re.findall(r"(?:^|\s+)-I(\S+)", incdir)
 else:
     netsnmp_libs = os.popen('net-snmp-config --libs').read()
-    libdirs = re.findall(r"-L(\S+)", netsnmp_libs)
+    libdirs = re.findall(r"(?:^|\s+)-L(\S+)", netsnmp_libs)
     incdirs = []
-    libs = re.findall(r"-l(\S+)", netsnmp_libs)
+    libs = re.findall(r"(?:^|\s+)-l(\S+)", netsnmp_libs)
 
 setup(
     name="netsnmp-python", version="1.0a1",


### PR DESCRIPTION
This prevents setup.py from discovering wrong library link options (`-l`, `-L`) in the middle of a word, like `"inux-gnu"` from `"-L/usr/lib/x86_64-linux-gnu"`.

For `net-snmp-config` output as follows (real world example from Ubuntu 18.04):
```
-Wl,-Bsymbolic-functions -Wl,-z,relro -Wl,-z,now -L/usr/lib/x86_64-linux-gnu -lnetsnmp -lcrypto -lm
```
the former regex `-l(\S+)` would match to
```python
['inux-gnu', 'netsnmp', 'crypto', 'm']
```
which obviously results in a ld error `cannot find -linux-gnu`.

Now we capture a string only, if `-l` is at the beginning of a string, or if `-l` is preceded by any number of whitespace characters.