### PR TITLE
ci: added static code analysis with Codechecker

### DIFF
--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -1,0 +1,45 @@
+name: Build and test
+
+on: [workflow_dispatch]
+#on:
+#  push:
+#    branches: [ master ]
+
+jobs:
+  build_and_test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: install required packages
+      run: sudo apt-get install libatm-dev libperl-dev libpopt-dev libsensors4-dev libssh2-1-dev libxml2-dev uuid-dev libkrb5-dev python3-setuptools
+
+    - name: configure
+      run: ./configure --enable-developer --enable-ipv6 --prefix=/usr/local/net-snmp-master --with-cflags= --with-defaults --enable-new-features --with-perl-modules --with-default-snmp-version=2 --with-systemd --enable-blumenthal-aes --with-python-modules '--with-transports=AAL5PVC IPX STD UDPshared DTLSUDP TLSTCP' '--with-security-modules=usm tsm ksm' '--with-mib-modules=examples/data_set examples/delayed_instance examples/example examples/notification examples/scalar_int examples/ucdDemoPublic examples/watched smux deliver/deliverByNotify disman/event disman/mteEventNotificationTable disman/mteEventTable disman/mteObjectsTable disman/mteTriggerBooleanTable disman/mteTriggerDeltaTable disman/mteTriggerExistenceTable disman/mteTriggerTable disman/mteTriggerThresholdTable disman/nslookup-mib disman/ping-mib disman/schedule disman/traceroute-mib etherlike-mib examples/netSnmpHostsTable hardware/cpu hardware/fsys hardware/memory host ip-forward-mib ip-mib/inetNetToMediaTable ip-mib/ipDefaultRouterTable ip-mib/ipv4InterfaceTable ip-mib/ipv6InterfaceTable ip-mib/ipv6ScopeZoneIndexTable mibII/ipAddr mibII/mta_sendmail misc/ipfwacc sctp-mib snmp-notification-mib tcp-mib testhandler tunnel ucd-snmp/diskio hardware/sensors ucd-snmp/lmsensorsMib ucd-snmp/extensible udp-mib rmon-mib snmp-usm-dh-objects-mib tlstm-mib tsm-mib'
+
+    - name: build
+      run: make
+
+    - name: test default
+      run: cd testing; ./RUNFULLTESTS -g default
+
+    - name: test perl
+      run: cd testing; ./RUNFULLTESTS -g perl
+
+    - name: test read-only
+      continue-on-error: true
+      run: cd testing; ./RUNFULLTESTS -g read-only
+
+    - name: test snmv3
+      run: cd testing; ./RUNFULLTESTS -g snmpv3
+
+    - name: test tls
+      continue-on-error: true
+      run: cd testing; ./RUNFULLTESTS -g tls
+
+    - name: test transports
+      run: cd testing; ./RUNFULLTESTS -g transports
+
+    - name: test unit-tests
+      run: cd testing; ./RUNFULLTESTS -g unit-tests

--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -16,7 +16,7 @@ jobs:
       run: sudo apt-get install libatm-dev libperl-dev libpopt-dev libsensors4-dev libssh2-1-dev libxml2-dev uuid-dev libkrb5-dev python3-setuptools
 
     - name: configure
-      run: ./configure --enable-developer --enable-ipv6 --prefix=/usr/local/net-snmp-master --with-cflags= --with-defaults --enable-new-features --with-perl-modules --with-default-snmp-version=2 --with-systemd --enable-blumenthal-aes --with-python-modules '--with-transports=AAL5PVC IPX STD UDPshared DTLSUDP TLSTCP' '--with-security-modules=usm tsm ksm' '--with-mib-modules=examples/data_set examples/delayed_instance examples/example examples/notification examples/scalar_int examples/ucdDemoPublic examples/watched smux deliver/deliverByNotify disman/event disman/mteEventNotificationTable disman/mteEventTable disman/mteObjectsTable disman/mteTriggerBooleanTable disman/mteTriggerDeltaTable disman/mteTriggerExistenceTable disman/mteTriggerTable disman/mteTriggerThresholdTable disman/nslookup-mib disman/ping-mib disman/schedule disman/traceroute-mib etherlike-mib examples/netSnmpHostsTable hardware/cpu hardware/fsys hardware/memory host ip-forward-mib ip-mib/inetNetToMediaTable ip-mib/ipDefaultRouterTable ip-mib/ipv4InterfaceTable ip-mib/ipv6InterfaceTable ip-mib/ipv6ScopeZoneIndexTable mibII/ipAddr mibII/mta_sendmail misc/ipfwacc sctp-mib snmp-notification-mib tcp-mib testhandler tunnel ucd-snmp/diskio hardware/sensors ucd-snmp/lmsensorsMib ucd-snmp/extensible udp-mib rmon-mib snmp-usm-dh-objects-mib tlstm-mib tsm-mib'
+      run: MODE=regular; ci/net-snmp-configure ${GITHUB_REF##*/}
 
     - name: build
       run: make

--- a/.github/workflows/codechecker.yml
+++ b/.github/workflows/codechecker.yml
@@ -46,9 +46,7 @@ jobs:
         CodeChecker version
 
     - name: configure
-      run: |
-        ./configure --enable-developer --enable-ipv6 --prefix=/usr/local/net-snmp-master --with-cflags= --with-defaults --enable-new-features --with-perl-modules --with-default-snmp-version=2 --with-systemd --enable-blumenthal-aes --with-python-modules '--with-transports=AAL5PVC IPX STD UDPshared DTLSUDP TLSTCP' '--with-security-modules=usm tsm ksm' '--with-mib-modules=examples/data_set examples/delayed_instance examples/example examples/notification examples/scalar_int examples/ucdDemoPublic examples/watched smux deliver/deliverByNotify disman/event disman/mteEventNotificationTable disman/mteEventTable disman/mteObjectsTable disman/mteTriggerBooleanTable disman/mteTriggerDeltaTable disman/mteTriggerExistenceTable disman/mteTriggerTable disman/mteTriggerThresholdTable disman/nslookup-mib disman/ping-mib disman/schedule disman/traceroute-mib etherlike-mib examples/netSnmpHostsTable hardware/cpu hardware/fsys hardware/memory host ip-forward-mib ip-mib/inetNetToMediaTable ip-mib/ipDefaultRouterTable ip-mib/ipv4InterfaceTable ip-mib/ipv6InterfaceTable ip-mib/ipv6ScopeZoneIndexTable mibII/ipAddr mibII/mta_sendmail misc/ipfwacc sctp-mib snmp-notification-mib tcp-mib testhandler tunnel ucd-snmp/diskio hardware/sensors ucd-snmp/lmsensorsMib ucd-snmp/extensible udp-mib rmon-mib snmp-usm-dh-objects-mib tlstm-mib tsm-mib'
-        git status
+      run: MODE=regular; ci/net-snmp-configure ${GITHUB_REF##*/}
 
     - name: Codechecker log
       run: |

--- a/.github/workflows/codechecker.yml
+++ b/.github/workflows/codechecker.yml
@@ -1,0 +1,79 @@
+name: CodeChecker
+
+on: [workflow_dispatch]
+#on:
+#  push:
+#    branches: [ master ]
+
+jobs:
+  codechecker:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: install required packages
+      run: sudo apt-get install libatm-dev libperl-dev libpopt-dev libsensors4-dev libssh2-1-dev libxml2-dev uuid-dev libkrb5-dev python3-setuptools
+
+    - name: install clang v12
+      run: |
+        wget https://apt.llvm.org/llvm.sh
+        chmod +x llvm.sh
+        sudo ./llvm.sh 12
+        sudo apt-get install clang clang-tidy
+
+    - name: install packages required by CodeChecker
+      run: |
+        sudo apt-get install doxygen gcc-multilib python-virtualenv
+
+    - name: install nodejs version 12.x
+      run: |
+        curl -sL https://deb.nodesource.com/setup_12.x | sudo bash -
+        sudo apt-get install nodejs
+
+    - name: install CodeChecker v6.14
+      run: |
+        git clone https://github.com/Ericsson/CodeChecker.git /opt/codechecker
+        git -C /opt/codechecker/ checkout -b b6.14.0 v6.14.0
+        make -C /opt/codechecker venv
+        . /opt/codechecker/venv/bin/activate
+        make -C /opt/codechecker package
+
+    - name: CodeChecker version
+      run: |
+        source /opt/codechecker/venv/bin/activate
+        export PATH=/opt/codechecker/build/CodeChecker/bin:$PATH;
+        CodeChecker version
+
+    - name: configure
+      run: |
+        ./configure --enable-developer --enable-ipv6 --prefix=/usr/local/net-snmp-master --with-cflags= --with-defaults --enable-new-features --with-perl-modules --with-default-snmp-version=2 --with-systemd --enable-blumenthal-aes --with-python-modules '--with-transports=AAL5PVC IPX STD UDPshared DTLSUDP TLSTCP' '--with-security-modules=usm tsm ksm' '--with-mib-modules=examples/data_set examples/delayed_instance examples/example examples/notification examples/scalar_int examples/ucdDemoPublic examples/watched smux deliver/deliverByNotify disman/event disman/mteEventNotificationTable disman/mteEventTable disman/mteObjectsTable disman/mteTriggerBooleanTable disman/mteTriggerDeltaTable disman/mteTriggerExistenceTable disman/mteTriggerTable disman/mteTriggerThresholdTable disman/nslookup-mib disman/ping-mib disman/schedule disman/traceroute-mib etherlike-mib examples/netSnmpHostsTable hardware/cpu hardware/fsys hardware/memory host ip-forward-mib ip-mib/inetNetToMediaTable ip-mib/ipDefaultRouterTable ip-mib/ipv4InterfaceTable ip-mib/ipv6InterfaceTable ip-mib/ipv6ScopeZoneIndexTable mibII/ipAddr mibII/mta_sendmail misc/ipfwacc sctp-mib snmp-notification-mib tcp-mib testhandler tunnel ucd-snmp/diskio hardware/sensors ucd-snmp/lmsensorsMib ucd-snmp/extensible udp-mib rmon-mib snmp-usm-dh-objects-mib tlstm-mib tsm-mib'
+        git status
+
+    - name: Codechecker log
+      run: |
+        source /opt/codechecker/venv/bin/activate
+        export PATH=/opt/codechecker/build/CodeChecker/bin:$PATH
+        CodeChecker log -o codechecker-log.json -b "make"
+
+    - name: Codechecker analyze
+      run: |
+        source /opt/codechecker/venv/bin/activate
+        export PATH=/opt/codechecker/build/CodeChecker/bin:$PATH
+        echo "-*/conftest.c"    > codechecker.skipfile
+        echo "-*/conftest.cpp" >> codechecker.skipfile
+        echo "-*/tmp.*.c"      >> codechecker.skipfile
+        CodeChecker analyze -j $(nproc) --clean --skip codechecker.skipfile -o ./results  --report-hash context-free-v2 codechecker-log.json
+        #CodeChecker analyze -j $(nproc) --clean --skip codechecker.skipfile --ctu -e sensitive -o ./results  --report-hash context-free-v2 codechecker-log.json
+
+    - name: CodeChecker parse
+      run: |
+        source /opt/codechecker/venv/bin/activate;
+        export PATH=/opt/codechecker/build/CodeChecker/bin:$PATH
+        CodeChecker parse -e html ./results -o ./reports_html
+
+    - name: Archive CodeChecker results
+      uses: actions/upload-artifact@v2
+      with:
+        name: CodeChecker reports
+        path: reports_html


### PR DESCRIPTION
CodeChecker is a static analysis infrastructure built on the LLVM/Clang Static Analyzer toolchain.
Using Github action to build net-snmp with SCA.
The Github action Codechecker workflow is started manually.
The result is stored in an artifact with HTML files that can be downloaded
and analyzed.

Reference:
- https://github.com/Ericsson/codechecker

Signed-off-by: Anders Wallin <wallinux@gmail.com>