### PR TITLE
Include inactive memory with cache under FreeBSD; Fixes #205

### DIFF
--- a/agent/mibgroup/hardware/memory/memory_freebsd.c
+++ b/agent/mibgroup/hardware/memory/memory_freebsd.c
@@ -164,7 +164,7 @@ int netsnmp_mem_arch_load( netsnmp_cache *cache, void *magic ) {
         if (!mem->descr)
              mem->descr = strdup("Cached memory");
         mem->units = pagesize;
-        mem->size  = cache_count;
+        mem->size  = cache_count + inact_count;
         mem->free  = 0;
     }
 


### PR DESCRIPTION
This fixes a memory reporting problem under FreeBSD, which the FreeBSD port has relied on as a patch for many years.