### PR TITLE
remove additional new line character in set-requests to pass_persist scripts

### DIFF
--- a/agent/mibgroup/ucd-snmp/pass_common.c
+++ b/agent/mibgroup/ucd-snmp/pass_common.c
@@ -224,23 +224,23 @@ netsnmp_internal_pass_set_format(char *buf,
         tmp = *((const long *) var_val);
         switch (var_val_type) {
         case ASN_INTEGER:
-            sprintf(buf, "integer %d\n", (int) tmp);
+            sprintf(buf, "integer %d", (int) tmp);
             break;
         case ASN_COUNTER:
-            sprintf(buf, "counter %d\n", (int) tmp);
+            sprintf(buf, "counter %d", (int) tmp);
             break;
         case ASN_GAUGE:
-            sprintf(buf, "gauge %d\n", (int) tmp);
+            sprintf(buf, "gauge %d", (int) tmp);
             break;
         case ASN_TIMETICKS:
-            sprintf(buf, "timeticks %d\n", (int) tmp);
+            sprintf(buf, "timeticks %d", (int) tmp);
             break;
         }
         break;
     case ASN_IPADDRESS:
         utmp = *((const u_long *) var_val);
         utmp = ntohl(utmp);
-        sprintf(buf, "ipaddress %d.%d.%d.%d\n",
+        sprintf(buf, "ipaddress %d.%d.%d.%d",
                 (int) ((utmp & 0xff000000) >> (8 * 3)),
                 (int) ((utmp & 0xff0000) >> (8 * 2)),
                 (int) ((utmp & 0xff00) >> (8)),
@@ -249,17 +249,17 @@ netsnmp_internal_pass_set_format(char *buf,
     case ASN_OCTET_STR:
         memcpy(buf2, var_val, var_val_len);
         if (var_val_len == 0)
-            sprintf(buf, "string \"\"\n");
+            sprintf(buf, "string \"\"");
         else if (netsnmp_internal_bin2asc(buf2, var_val_len) ==
                  (int) var_val_len)
-            snprintf(buf, SNMP_MAXBUF, "string \"%s\"\n", buf2);
+            snprintf(buf, SNMP_MAXBUF, "string \"%s\"", buf2);
         else
-            snprintf(buf, SNMP_MAXBUF, "octet \"%s\"\n", buf2);
+            snprintf(buf, SNMP_MAXBUF, "octet \"%s\"", buf2);
         buf[ SNMP_MAXBUF-1 ] = 0;
         break;
     case ASN_OBJECT_ID:
         sprint_mib_oid(buf2, (const oid *) var_val, var_val_len/sizeof(oid));
-        snprintf(buf, SNMP_MAXBUF, "objectid \"%s\"\n", buf2);
+        snprintf(buf, SNMP_MAXBUF, "objectid \"%s\"", buf2);
         buf[ SNMP_MAXBUF-1 ] = 0;
         break;
     }


### PR DESCRIPTION
According to the MAN page of [snmpd.conf](http://www.net-snmp.org/docs/man/snmpd.conf.html) pass_persist protocol of a set-request consists of exactly three lines:

> For SET requests, PROG will be passed three lines on stdin, the command (set) and the requested OID, followed by the type and value (both on the same line).

In contrast to this specification recent versions of snmpd behave differently:

A set-request to a pass_persist script contains an additional _Newline_ character ("\n"), which leads to a wrong answer (no such name) to the following get-request.

Below is a communication trace between the SNMP agent (snmpd) and an example pass_persist scripts:

    read(0, "PING\n", 8192) = 5
    write(1, "PONG\n", 5) = 5
    read(0, "set\n.1.3.6.1.4.1.xxxx.1.2.3.0\nstring \"Demo Text\"\n\n", 8192) = 76
    […]
    write(1, "DONE\n", 5) = 5
    write(1, "NONE\n", 5) = 5

As one can see in line 3 above, there are two _Newline_ characters after the set-request where only one would be expected. As a result the script answers one additional line ("NONE"). This leads to the mentioned "no such name" error on next get-request of SNMP agent.

The pull request fixes this erroneous behavior and avoids additional _Newline_ characters.