### PR TITLE
Do not increment EngineBoots on config reload

### DIFF
--- a/snmplib/snmpv3.c
+++ b/snmplib/snmpv3.c
@@ -994,7 +994,7 @@ init_snmpv3(const char *type)
                                     engineIDType_conf, NULL, "num");
     register_prenetsnmp_mib_handler(type, "engineIDNic", engineIDNic_conf,
                                     NULL, "string");
-    register_config_handler(type, "engineBoots", engineBoots_conf, NULL,
+    register_prenetsnmp_mib_handler(type, "engineBoots", engineBoots_conf, NULL,
                             NULL);
 
     /*


### PR DESCRIPTION
This is a pull request for Issue #220 to avoid incrementing the EngineBoots when the config is reloaded. The following use cases were tested
1- Restart: Make sure the engineBoots is incremented.
2- Config reload: Make sure the engineBoots is not incremented.

This is for V5-8-patches since we are still using this version. Maybe it is also needed in 5-9 as well. 