### PR TITLE
Fix warnings generated by configure scripts

### DIFF
--- a/configure.d/config_os_functions
+++ b/configure.d/config_os_functions
@@ -212,12 +212,12 @@ AC_CACHE_VAL(
 #ifdef HAVE_SYS_FS_TYPES_H
 #include <sys/fs_types.h>
 #endif
-main ()
+int main ()
 {
 struct fs_data fsd;
 /* Ultrix's statfs returns 1 for success,
    0 for not mounted, -1 for failure.  */
-exit (statfs (".", &fsd) != 1);
+return statfs (".", &fsd) != 1;
 }]])],
     [fu_cv_sys_stat_fs_data=yes],
     [fu_cv_sys_stat_fs_data=no],

--- a/configure.d/config_os_misc4
+++ b/configure.d/config_os_misc4
@@ -334,6 +334,7 @@ AC_CACHE_CHECK([for IP_PKTINFO ],
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
+#include <arpa/inet.h> /* inet_ntoa() */
 ], [
     void *buf;
     int len;
@@ -383,6 +384,7 @@ AC_CACHE_CHECK([for IP_RECVDSTADDR ],
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
+#include <arpa/inet.h> /* inet_ntoa() */
 ], [
     void *buf;
     int len;


### PR DESCRIPTION
Specifically, this is meant to reduce risk of issues with Xcode 12 which has made `-Werror,-Wimplicit-function-declaration` a default.

Normally this doesn't bite "real" code since such a warning would be visible for a long time with most compilers.  However, inside of configure scripts these sorts of warnings just end up in config.log and usually get ignored.  Now that they produce errors it means that configure tests that *should* pass suddenly fail, causing very strange failures later on.

This can be as simple as calling `exit(0);` inside of a test C program without doing `#include <stdlib.h>` first!

I also fixed an implicit-int-return warning since that is another C behavior that was deprecated long ago and future compilers might consider that an error.