### PR TITLE
Fix the crash of snmpd when snmptrapd terminates the TCP connection.

### DIFF
--- a/agent/agent_trap.c
+++ b/agent/agent_trap.c
@@ -183,9 +183,9 @@ _dump_trap_stats(netsnmp_session *sess)
 #endif /* NETSNMP_NO_TRAP_STATS */
 
 int
-netsnmp_add_notification_session(netsnmp_session * ss, int pdutype,
-                                 int confirm, int version, const char *name,
-                                 const char *tag, const char* profile)
+netsnmp_add_closable_notification_session(netsnmp_session *ss, int close_sess, int pdutype,
+                                          int confirm, int version, const char *name,
+                                          const char *tag, const char* profile)
 {
     if (NETSNMP_RUNTIME_PROTOCOL_SKIP(version)) {
         DEBUGMSGTL(("trap", "skipping trap sink (version 0x%02x disabled)\n",
@@ -201,6 +201,7 @@ netsnmp_add_notification_session(netsnmp_session * ss, int pdutype,
         struct agent_add_trap_args args;
         DEBUGMSGTL(("trap", "adding callback trap sink (%p)\n", ss));
         args.ss = ss;
+        args.close_sess = close_sess;
         args.confirm = confirm;
         args.nameData = name;
         args.nameLen = (NULL == name) ? 0 : strlen(name);
@@ -234,6 +235,19 @@ netsnmp_add_notification_session(netsnmp_session * ss, int pdutype,
     return 1;
 }
 
+/* This is a wrapper to netsnmp_add_closable_notification_session
+   for backward compatibility
+ */
+int
+netsnmp_add_notification_session(netsnmp_session *ss, int pdutype,
+                                 int confirm, int version, const char *name,
+                                 const char *tag, const char* profile)
+{
+    return netsnmp_add_closable_notification_session(ss, 1, pdutype, confirm,
+                                                     version, name,
+                                                     tag, profile);
+}
+
 /*
  * xxx needs update to support embedded NUL.
  * xxx should probably also be using and unregister callback, similar to
@@ -261,11 +275,35 @@ netsnmp_unregister_notification(const char *name, u_char len)
 }
 
 int
+handle_disconnect_packet(int operation, netsnmp_session *session, int reqid,
+                            netsnmp_pdu *pdu, void *magic)
+{
+    if (NETSNMP_CALLBACK_OP_DISCONNECT == operation) {
+        netsnmp_transport *t = snmp_sess_transport(snmp_sess_pointer(session));
+        char *addr_string = NULL;
+
+        if (t && (addr_string = netsnmp_transport_peer_string(t, t->remote, t->remote_length))) {
+            snmp_log(LOG_WARNING,
+                        "send_trap: session closed by snmptrap (%s)\n", addr_string);
+            free(addr_string);
+        } else {
+            snmp_log(LOG_WARNING,
+                        "send_trap: session %8p closed by snmptrap\n", session);
+        }
+        snmp_log(LOG_WARNING,
+                    "send_trap: re-opening of TCP connection is not supported.\n");
+
+        netsnmp_unregister_notification(session->paramName, strlen(session->paramName));
+    }
+    return 1;
+}
+
+int
 add_trap_session(netsnmp_session * ss, int pdutype, int confirm,
                          int version)
 {
-    return netsnmp_add_notification_session(ss, pdutype, confirm, version,
-                                            NULL, NULL, NULL);
+    return netsnmp_add_closable_notification_session(ss, 0, pdutype, confirm, version,
+                                                     NULL, NULL, NULL);
 }
 
 #ifndef NETSNMP_FEATURE_REMOVE_REMOVE_TRAP_SESSION
@@ -326,6 +364,7 @@ netsnmp_create_v1v2_notification_session(const char *sink, const char* sinkport,
     }
 
     snmp_sess_init(&session);
+    session.callback = handle_disconnect_packet;
     session.version = version;
     if (com) {
         session.community = (u_char *) NETSNMP_REMOVE_CONST(char *, com);
@@ -378,9 +417,11 @@ netsnmp_create_v1v2_notification_session(const char *sink, const char* sinkport,
         return NULL;
     }
 
-    rc = netsnmp_add_notification_session(sesp, pdutype,
-                                          (pdutype == SNMP_MSG_INFORM),
-                                          version, name, tag, profile);
+    rc = netsnmp_add_closable_notification_session(sesp,
+                                                   !(t->flags & NETSNMP_TRANSPORT_FLAG_STREAM),
+                                                   pdutype,
+                                                   (pdutype == SNMP_MSG_INFORM),
+                                                   version, name, tag, profile);
     if (0 == rc)
         return NULL;
 
@@ -1564,6 +1605,8 @@ netsnmp_create_v3user_notification_session(const char *dest, const char *user,
 
     snmp_sess_init(&session);
 
+    session.callback = handle_disconnect_packet;
+
     session.version = SNMP_VERSION_3;
 
     session.peername = NETSNMP_REMOVE_CONST(char*,dest);
@@ -1648,10 +1691,12 @@ netsnmp_create_v3user_notification_session(const char *dest, const char *user,
         goto bail;
     }
 
-    if (netsnmp_add_notification_session(ss, pdutype,
-                                         (pdutype == SNMP_MSG_INFORM),
-                                         ss->version, notif_name, notif_tag,
-                                         notif_profile) != 1) {
+    if (netsnmp_add_closable_notification_session(ss,
+                                                  !(transport->flags & NETSNMP_TRANSPORT_FLAG_STREAM),
+                                                  pdutype,
+                                                  (pdutype == SNMP_MSG_INFORM),
+                                                  ss->version, notif_name, notif_tag,
+                                                  notif_profile) != 1) {
         DEBUGMSGTL(("trap:v3user_notif_sess", "add notification failed\n"));
         snmp_close(ss);
         ss = NULL;
@@ -1754,6 +1799,7 @@ snmpd_parse_config_trapsess(const char *word, char *cptr)
             free(argv[argn - 1]);
         goto cleanup;
     }
+    session.callback = handle_disconnect_packet;
     ss = snmp_add(&session, transport, NULL, NULL);
     for (; argn > 0; argn--)
         free(argv[argn - 1]);
@@ -1785,9 +1831,11 @@ snmpd_parse_config_trapsess(const char *word, char *cptr)
                                 NETSNMP_DS_LIB_DISABLE_V1))
         traptype = SNMP_MSG_TRAP;
 #endif
-    netsnmp_add_notification_session(ss, traptype,
-                                     (traptype == SNMP_MSG_INFORM),
-                                     ss->version, name, tag, profile);
+    netsnmp_add_closable_notification_session(ss,
+                                              !(transport->flags & NETSNMP_TRANSPORT_FLAG_STREAM),
+                                              traptype,
+                                              (traptype == SNMP_MSG_INFORM),
+                                              ss->version, name, tag, profile);
 
   cleanup:
     if (session.securityEngineIDLen > 0)

--- a/agent/mibgroup/notification/snmpNotifyTable_data.c
+++ b/agent/mibgroup/notification/snmpNotifyTable_data.c
@@ -274,7 +274,7 @@ notifyTable_register_notifications(int major, int minor,
     struct targetAddrTable_struct *ptr = NULL;
     struct targetParamTable_struct *pptr = NULL;
     struct snmpNotifyTable_data *nptr = NULL;
-    int             confirm, i;
+    int             confirm, close_sess, i;
     char            buf[SNMP_MAXBUF_SMALL];
     netsnmp_transport *t = NULL;
     struct agent_add_trap_args *args =
@@ -289,6 +289,7 @@ notifyTable_register_notifications(int major, int minor,
     args->rc = SNMPERR_GENERR;
     confirm = args->confirm;
     ss = args->ss;
+    close_sess = args->close_sess;
     name = args->nameData;
     nameLen = args->nameLen;
     tag = args->tagData;
@@ -360,6 +361,7 @@ notifyTable_register_notifications(int major, int minor,
     ptr->storageType = ST_READONLY;
     ptr->rowStatus = RS_ACTIVE;
     ptr->sess = ss;
+    ptr->close_sess = close_sess;
     DEBUGMSGTL(("trapsess", "adding %s to trap table\n", ptr->nameData));
     snmpTargetAddrTable_add(ptr);
 

--- a/agent/mibgroup/target/snmpTargetAddrEntry_data.c
+++ b/agent/mibgroup/target/snmpTargetAddrEntry_data.c
@@ -78,6 +78,8 @@ snmpTargetAddrTable_create(void)
 
         newEntry->storageType = SNMP_STORAGE_NONVOLATILE;
         newEntry->rowStatus = SNMP_ROW_NONEXISTENT;
+
+        newEntry->close_sess = 1;
     }
 
     return newEntry;
@@ -94,7 +96,7 @@ snmpTargetAddrTable_dispose(struct targetAddrTable_struct *reaped)
     if (NULL == reaped)
         return;
 
-    if (reaped->sess)
+    if (reaped->sess && reaped->close_sess)
         snmp_close(reaped->sess);
     else
         SNMP_FREE(reaped->tAddress);

--- a/agent/mibgroup/target/snmpTargetAddrEntry_data.h
+++ b/agent/mibgroup/target/snmpTargetAddrEntry_data.h
@@ -56,6 +56,7 @@
          int             rowStatus;
          struct targetAddrTable_struct *next;
          netsnmp_session *sess; /* a snmp session to the target host */
+         int             close_sess;
          time_t          sessionCreationTime;
      };
 

--- a/include/net-snmp/agent/agent_trap.h
+++ b/include/net-snmp/agent/agent_trap.h
@@ -13,6 +13,7 @@ extern          "C" {
 
 struct agent_add_trap_args {
     netsnmp_session *ss;
+    int             close_sess;
     int             confirm;
     const char      *nameData; /* notification target addr name */
     int             nameLen;
@@ -77,9 +78,15 @@ netsnmp_session *netsnmp_create_v3user_notification_session(const char *dst,
                                                             const char *name,
                                                             const char *tag,
                                                             const char *prof);
+/* This is a wrapper to netsnmp_add_closable_notification_session
+   for backward compatibility
+ */
 int             netsnmp_add_notification_session(netsnmp_session *, int, int,
                                                  int, const char*, const char*,
                                                  const char*);
+int             netsnmp_add_closable_notification_session(netsnmp_session *, int, int,
+                                                          int, int, const char*,
+                                                          const char*, const char*);
 void            netsnmp_unregister_notification(const char *, u_char);
 
 int             netsnmp_build_trap_oid(netsnmp_pdu *pdu, oid *, size_t *);


### PR DESCRIPTION
See also: https://github.com/net-snmp/net-snmp/issues/187

Re-opening of TCP connection with snmptrapd is still not supported.