### PR TITLE
Read intermediate certificates from PEM files

### DIFF
--- a/include/net-snmp/library/cert_util.h
+++ b/include/net-snmp/library/cert_util.h
@@ -29,7 +29,7 @@ extern "C" {
     typedef struct netsnmp_cert_common_s {
         char           *dir;
         char           *filename;
-        
+
         u_char          type;
         u_char          allowed_uses;
         u_char          _pad[2]; /* for future use */
@@ -56,6 +56,8 @@ extern "C" {
 
         u_char          hash_type;
         u_char          _pad[3]; /* for future use */
+
+        int             offset;
     } netsnmp_cert;
 
 /** types */

--- a/include/net-snmp/library/dir_utils.h
+++ b/include/net-snmp/library/dir_utils.h
@@ -53,9 +53,10 @@ extern "C" {
 #define NETSNMP_DIR_NSFILE                            0x0010
 /** load stats in netsnmp_file */
 #define NETSNMP_DIR_NSFILE_STATS                      0x0020
+/** allow files to be indexed more than once */
+#define NETSNMP_DIR_ALLOW_DUPLICATES                  0x0040
 
-    
-        
+
 #ifdef __cplusplus
 }
 #endif

--- a/snmplib/cert_util.c
+++ b/snmplib/cert_util.c
@@ -88,7 +88,7 @@ netsnmp_feature_child_of(tls_fingerprint_build, cert_util_all);
  * bump this value whenever cert index format changes, so indexes
  * will be regenerated with new format.
  */
-#define CERT_INDEX_FORMAT  1
+#define CERT_INDEX_FORMAT  2
 
 static netsnmp_container *_certs = NULL;
 static netsnmp_container *_keys = NULL;
@@ -114,6 +114,8 @@ static int  _cert_fn_ncompare(netsnmp_cert_common *lhs,
                               netsnmp_cert_common *rhs);
 static void _find_partner(netsnmp_cert *cert, netsnmp_key *key);
 static netsnmp_cert *_find_issuer(netsnmp_cert *cert);
+static netsnmp_void_array *_cert_reduce_subset_first(netsnmp_void_array *matching);
+static netsnmp_void_array *_cert_reduce_subset_what(netsnmp_void_array *matching, int what);
 static netsnmp_void_array *_cert_find_subset_fn(const char *filename,
                                                 const char *directory);
 static netsnmp_void_array *_cert_find_subset_sn(const char *subject);
@@ -333,6 +335,8 @@ _get_cert_container(const char *use)
 {
     netsnmp_container *c;
 
+    int rc;
+
     c = netsnmp_container_find("certs:binary_array");
     if (NULL == c) {
         snmp_log(LOG_ERR, "could not create container for %s\n", use);
@@ -342,6 +346,8 @@ _get_cert_container(const char *use)
     c->free_item = (netsnmp_container_obj_func*)_cert_free;
     c->compare = (netsnmp_container_compare*)_cert_compare;
 
+    CONTAINER_SET_OPTIONS(c, CONTAINER_KEY_ALLOW_DUPLICATES, rc);
+
     return c;
 }
 
@@ -349,6 +355,8 @@ static void
 _setup_containers(void)
 {
     netsnmp_container *additional_keys;
+
+    int rc;
 
     _certs = _get_cert_container("netsnmp certificates");
     if (NULL == _certs)
@@ -364,6 +372,7 @@ _setup_containers(void)
     additional_keys->container_name = strdup("certs_cn");
     additional_keys->free_item = NULL;
     additional_keys->compare = (netsnmp_container_compare*)_cert_cn_compare;
+    CONTAINER_SET_OPTIONS(additional_keys, CONTAINER_KEY_ALLOW_DUPLICATES, rc);
     netsnmp_container_add_index(_certs, additional_keys);
 
     /** additional keys: subject name */
@@ -377,6 +386,7 @@ _setup_containers(void)
     additional_keys->free_item = NULL;
     additional_keys->compare = (netsnmp_container_compare*)_cert_sn_compare;
     additional_keys->ncompare = (netsnmp_container_compare*)_cert_sn_ncompare;
+    CONTAINER_SET_OPTIONS(additional_keys, CONTAINER_KEY_ALLOW_DUPLICATES, rc);
     netsnmp_container_add_index(_certs, additional_keys);
 
     /** additional keys: file name */
@@ -390,6 +400,7 @@ _setup_containers(void)
     additional_keys->free_item = NULL;
     additional_keys->compare = (netsnmp_container_compare*)_cert_fn_compare;
     additional_keys->ncompare = (netsnmp_container_compare*)_cert_fn_ncompare;
+    CONTAINER_SET_OPTIONS(additional_keys, CONTAINER_KEY_ALLOW_DUPLICATES, rc);
     netsnmp_container_add_index(_certs, additional_keys);
 
     _keys = netsnmp_container_find("cert_keys:binary_array");
@@ -412,7 +423,7 @@ netsnmp_cert_map_container(void)
 }
 
 static netsnmp_cert *
-_new_cert(const char *dirname, const char *filename, int certType,
+_new_cert(const char *dirname, const char *filename, int certType, int offset,
           int hashType, const char *fingerprint, const char *common_name,
           const char *subject)
 {
@@ -434,8 +445,10 @@ _new_cert(const char *dirname, const char *filename, int certType,
 
     cert->info.dir = strdup(dirname);
     cert->info.filename = strdup(filename);
-    cert->info.allowed_uses = NS_CERT_REMOTE_PEER;
+    /* only the first certificate is allowed to be a remote peer */
+    cert->info.allowed_uses = offset ? 0 : NS_CERT_REMOTE_PEER;
     cert->info.type = certType;
+    cert->offset = offset;
     if (fingerprint) {
         cert->hash_type = hashType;
         cert->fingerprint = strdup(fingerprint);
@@ -872,31 +885,13 @@ _certindex_new( const char *dirname )
  * certificate utility functions
  *
  */
-static X509 *
-netsnmp_ocert_get(netsnmp_cert *cert)
+static BIO *
+netsnmp_open_bio(const char *dir, const char *filename)
 {
     BIO            *certbio;
-    X509           *ocert = NULL;
-    EVP_PKEY       *okey = NULL;
     char            file[SNMP_MAXPATH];
-    int             is_ca;
 
-    if (NULL == cert)
-        return NULL;
-
-    if (cert->ocert)
-        return cert->ocert;
-
-    if (NS_CERT_TYPE_UNKNOWN == cert->info.type) {
-        cert->info.type = _type_from_filename(cert->info.filename);
-        if (NS_CERT_TYPE_UNKNOWN == cert->info.type) {
-            snmp_log(LOG_ERR, "unknown certificate type %d for %s\n",
-                     cert->info.type, cert->info.filename);
-            return NULL;
-        }
-    }
-
-    DEBUGMSGT(("9:cert:read", "Checking file %s\n", cert->info.filename));
+    DEBUGMSGT(("9:cert:read", "Checking file %s\n", filename));
 
     certbio = BIO_new(BIO_s_file());
     if (NULL == certbio) {
@@ -904,90 +899,23 @@ netsnmp_ocert_get(netsnmp_cert *cert)
         return NULL;
     }
 
-    snprintf(file, sizeof(file),"%s/%s", cert->info.dir, cert->info.filename);
+    snprintf(file, sizeof(file),"%s/%s", dir, filename);
     if (BIO_read_filename(certbio, file) <=0) {
-        snmp_log(LOG_ERR, "error reading certificate %s into BIO\n", file);
+        snmp_log(LOG_ERR, "error reading certificate/key %s into BIO\n", file);
         BIO_vfree(certbio);
         return NULL;
     }
 
-    if (NS_CERT_TYPE_UNKNOWN == cert->info.type) {
-        char *pos = strrchr(cert->info.filename, '.');
-        if (NULL == pos)
-            return NULL;
-        cert->info.type = _cert_ext_type(++pos);
-        netsnmp_assert(cert->info.type != NS_CERT_TYPE_UNKNOWN);
-    }
+    return certbio;
+}
 
-    switch (cert->info.type) {
-
-        case NS_CERT_TYPE_DER:
-            ocert = d2i_X509_bio(certbio,NULL); /* DER/ASN1 */
-            if (NULL != ocert)
-                break;
-            (void)BIO_reset(certbio);
-            /* Check for PEM if DER didn't work */
-            /* FALLTHROUGH */
-
-        case NS_CERT_TYPE_PEM:
-            ocert = PEM_read_bio_X509_AUX(certbio, NULL, NULL, NULL);
-            if (NULL == ocert)
-                break;
-            if (NS_CERT_TYPE_DER == cert->info.type) {
-                DEBUGMSGT(("9:cert:read", "Changing type from DER to PEM\n"));
-                cert->info.type = NS_CERT_TYPE_PEM;
-            }
-            /** check for private key too */
-            if (NULL == cert->key) {
-                (void)BIO_reset(certbio);
-                okey =  PEM_read_bio_PrivateKey(certbio, NULL, NULL, NULL);
-                if (NULL != okey) {
-                    netsnmp_key  *key;
-                    DEBUGMSGT(("cert:read:key", "found key with cert in %s\n",
-                               cert->info.filename));
-                    key = _new_key(cert->info.dir, cert->info.filename);
-                    if (NULL != key) {
-                        key->okey = okey;
-                        if (-1 == CONTAINER_INSERT(_keys, key)) {
-                            DEBUGMSGT(("cert:read:key:add",
-                                       "error inserting key into container\n"));
-                            netsnmp_key_free(key);
-                            key = NULL;
-                        }
-                        else {
-                            DEBUGMSGT(("cert:read:partner", "%s match found!\n",
-                                       cert->info.filename));
-                            key->cert = cert;
-                            cert->key = key;
-                            cert->info.allowed_uses |= NS_CERT_IDENTITY;
-                        }
-                    }
-                } /* null return from read */
-            } /* null key */
-            break;
-#ifdef CERT_PKCS12_SUPPORT_MAYBE_LATER
-        case NS_CERT_TYPE_PKCS12:
-            (void)BIO_reset(certbio);
-            PKCS12 *p12 = d2i_PKCS12_bio(certbio, NULL);
-            if ( (NULL != p12) && (PKCS12_verify_mac(p12, "", 0) ||
-                                   PKCS12_verify_mac(p12, NULL, 0)))
-                PKCS12_parse(p12, "", NULL, &cert, NULL);
-            break;
-#endif
-        default:
-            snmp_log(LOG_ERR, "unknown certificate type %d for %s\n",
-                     cert->info.type, cert->info.filename);
-    }
-
-    BIO_vfree(certbio);
-
-    if (NULL == ocert) {
-        snmp_log(LOG_ERR, "error parsing certificate file %s\n",
-                 cert->info.filename);
-        return NULL;
-    }
+static void
+netsnmp_ocert_parse(netsnmp_cert *cert, X509 *ocert)
+{
+    int             is_ca;
 
     cert->ocert = ocert;
+
     /*
      * X509_check_ca return codes:
      * 0 not a CA
@@ -1015,18 +943,118 @@ netsnmp_ocert_get(netsnmp_cert *cert)
         }
         DEBUGMSGT(("9:cert:add:issuer", "CA issuer: %s\n", cert->issuer));
     }
-    
+
     if (NULL == cert->fingerprint) {
         cert->hash_type = netsnmp_openssl_cert_get_hash_type(ocert);
         cert->fingerprint =
             netsnmp_openssl_cert_get_fingerprint(ocert, cert->hash_type);
     }
-    
+
     if (NULL == cert->common_name) {
         cert->common_name =netsnmp_openssl_cert_get_commonName(ocert, NULL,
                                                                NULL);
         DEBUGMSGT(("9:cert:add:name","%s\n", cert->common_name));
     }
+
+}
+
+static X509 *
+netsnmp_ocert_get(netsnmp_cert *cert)
+{
+    BIO            *certbio;
+    X509           *ocert = NULL;
+    X509           *ncert = NULL;
+    EVP_PKEY       *okey = NULL;
+
+    if (NULL == cert)
+        return NULL;
+
+    if (cert->ocert)
+        return cert->ocert;
+
+    if (NS_CERT_TYPE_UNKNOWN == cert->info.type) {
+        cert->info.type = _type_from_filename(cert->info.filename);
+        if (NS_CERT_TYPE_UNKNOWN == cert->info.type) {
+            snmp_log(LOG_ERR, "unknown certificate type %d for %s\n",
+                     cert->info.type, cert->info.filename);
+            return NULL;
+        }
+    }
+
+    certbio = netsnmp_open_bio(cert->info.dir, cert->info.filename);
+    if (!certbio) {
+        return NULL;
+    }
+
+    switch (cert->info.type) {
+
+        case NS_CERT_TYPE_DER:
+            (void)BIO_seek(certbio, cert->offset);
+            ocert = d2i_X509_bio(certbio,NULL); /* DER/ASN1 */
+            if (NULL != ocert)
+                break;
+            /* Check for PEM if DER didn't work */
+            /* FALLTHROUGH */
+
+        case NS_CERT_TYPE_PEM:
+            (void)BIO_seek(certbio, cert->offset);
+            ocert = ncert = PEM_read_bio_X509_AUX(certbio, NULL, NULL, NULL);
+            if (NULL == ocert)
+                break;
+            if (NS_CERT_TYPE_DER == cert->info.type) {
+                DEBUGMSGT(("9:cert:read", "Changing type from DER to PEM\n"));
+                cert->info.type = NS_CERT_TYPE_PEM;
+            }
+            /** check for private key too, but only if we're the first certificate */
+            if (0 == cert->offset && NULL == cert->key) {
+                okey = PEM_read_bio_PrivateKey(certbio, NULL, NULL, NULL);
+                if (NULL != okey) {
+                    netsnmp_key  *key;
+                    DEBUGMSGT(("cert:read:key", "found key with cert in %s\n",
+                               cert->info.filename));
+                    key = _new_key(cert->info.dir, cert->info.filename);
+                    if (NULL != key) {
+                        key->okey = okey;
+                        if (-1 == CONTAINER_INSERT(_keys, key)) {
+                            DEBUGMSGT(("cert:read:key:add",
+                                       "error inserting key into container\n"));
+                            netsnmp_key_free(key);
+                            key = NULL;
+                        }
+                        else {
+                            DEBUGMSGT(("cert:read:partner", "%s match found!\n",
+                                       cert->info.filename));
+                            key->cert = cert;
+                            cert->key = key;
+                            cert->info.allowed_uses |= NS_CERT_IDENTITY;
+                        }
+                    }
+                } /* null return from read */
+            } /* null key */
+            break;
+#ifdef CERT_PKCS12_SUPPORT_MAYBE_LATER
+        case NS_CERT_TYPE_PKCS12:
+            (void)BIO_seek(certbio, cert->offset);
+            PKCS12 *p12 = d2i_PKCS12_bio(certbio, NULL);
+            if ( (NULL != p12) && (PKCS12_verify_mac(p12, "", 0) ||
+                                   PKCS12_verify_mac(p12, NULL, 0)))
+                PKCS12_parse(p12, "", NULL, &cert, NULL);
+            break;
+#endif
+        default:
+            snmp_log(LOG_ERR, "unknown certificate type %d for %s\n",
+                     cert->info.type, cert->info.filename);
+    }
+
+    BIO_vfree(certbio);
+
+    if (NULL == ocert) {
+        snmp_log(LOG_ERR, "error parsing certificate file %s\n",
+                 cert->info.filename);
+        return NULL;
+    }
+
+    netsnmp_ocert_parse(cert, ocert);
 
     return ocert;
 }
@@ -1036,7 +1064,6 @@ netsnmp_okey_get(netsnmp_key  *key)
 {
     BIO            *keybio;
     EVP_PKEY       *okey;
-    char            file[SNMP_MAXPATH];
 
     if (NULL == key)
         return NULL;
@@ -1044,19 +1071,8 @@ netsnmp_okey_get(netsnmp_key  *key)
     if (key->okey)
         return key->okey;
 
-    snprintf(file, sizeof(file),"%s/%s", key->info.dir, key->info.filename);
-    DEBUGMSGT(("cert:key:read", "Checking file %s\n", key->info.filename));
-
-    keybio = BIO_new(BIO_s_file());
-    if (NULL == keybio) {
-        snmp_log(LOG_ERR, "error creating BIO\n");
-        return NULL;
-    }
-
-    if (BIO_read_filename(keybio, file) <=0) {
-        snmp_log(LOG_ERR, "error reading certificate %s into BIO\n",
-                 key->info.filename);
-        BIO_vfree(keybio);
+    keybio = netsnmp_open_bio(key->info.dir, key->info.filename);
+    if (!keybio) {
         return NULL;
     }
 
@@ -1142,7 +1158,7 @@ netsnmp_cert_load_x509(netsnmp_cert *cert)
             cert->issuer_cert =  _find_issuer(cert);
             if (NULL == cert->issuer_cert) {
                 DEBUGMSGT(("cert:load:warn",
-                           "couldn't load CA chain for cert %s\n",
+                           "couldn't load full CA chain for cert %s\n",
                            cert->info.filename));
                 rc = CERT_LOAD_PARTIAL;
                 break;
@@ -1151,7 +1167,7 @@ netsnmp_cert_load_x509(netsnmp_cert *cert)
         /** get issuer ocert */
         if ((NULL == cert->issuer_cert->ocert) &&
             (netsnmp_ocert_get(cert->issuer_cert) == NULL)) {
-            DEBUGMSGT(("cert:load:warn", "couldn't load cert chain for %s\n",
+            DEBUGMSGT(("cert:load:warn", "couldn't load full cert chain for %s\n",
                        cert->info.filename));
             rc = CERT_LOAD_PARTIAL;
             break;
@@ -1172,7 +1188,7 @@ _find_partner(netsnmp_cert *cert, netsnmp_key *key)
         return;
     }
 
-    if(key) {
+    if (key) {
         if (key->cert) {
             DEBUGMSGT(("cert:partner", "key already has partner\n"));
             return;
@@ -1185,7 +1201,8 @@ _find_partner(netsnmp_cert *cert, netsnmp_key *key)
             return;
         *pos = 0;
 
-        matching = _cert_find_subset_fn( filename, key->info.dir );
+        matching = _cert_reduce_subset_first(_cert_find_subset_fn( filename,
+                                             key->info.dir ));
         if (!matching)
             return;
         if (1 == matching->size) {
@@ -1205,7 +1222,7 @@ _find_partner(netsnmp_cert *cert, netsnmp_key *key)
             DEBUGMSGT(("cert:partner", "%s matches multiple certs\n",
                           key->info.filename));
     }
-    else if(cert) {
+    else if (cert) {
         if (cert->key) {
             DEBUGMSGT(("cert:partner", "cert already has partner\n"));
             return;
@@ -1243,64 +1260,47 @@ _find_partner(netsnmp_cert *cert, netsnmp_key *key)
     }
 }
 
-static int
-_add_certfile(const char* dirname, const char* filename, FILE *index)
+static netsnmp_key *
+_add_key(EVP_PKEY *okey, const char* dirname, const char* filename, FILE *index)
 {
-    X509         *ocert;
-    EVP_PKEY     *okey;
-    netsnmp_cert *cert = NULL;
-    netsnmp_key  *key = NULL;
-    char          certfile[SNMP_MAXPATH];
-    int           type;
+    netsnmp_key  *key;
 
-    if (((const void*)NULL == dirname) || (NULL == filename))
-        return -1;
-
-    type = _type_from_filename(filename);
-    netsnmp_assert(type != NS_CERT_TYPE_UNKNOWN);
-
-    snprintf(certfile, sizeof(certfile),"%s/%s", dirname, filename);
-
-    DEBUGMSGT(("9:cert:file:add", "Checking file: %s (type %d)\n", filename,
-               type));
-
-    if (NS_CERT_TYPE_KEY == type) {
-        key = _new_key(dirname, filename);
-        if (NULL == key)
-            return -1;
-        okey = netsnmp_okey_get(key);
-        if (NULL == okey) {
-            netsnmp_key_free(key);
-            return -1;
-        }
-        key->okey = okey;
-        if (-1 == CONTAINER_INSERT(_keys, key)) {
-            DEBUGMSGT(("cert:key:file:add:err",
-                       "error inserting key into container\n"));
-            netsnmp_key_free(key);
-            key = NULL;
-        }
+    key = _new_key(dirname, filename);
+    if (NULL == key) {
+        return NULL;
     }
-    else {
-        cert = _new_cert(dirname, filename, type, -1, NULL, NULL, NULL);
-        if (NULL == cert)
-            return -1;
-        ocert = netsnmp_ocert_get(cert);
-        if (NULL == ocert) {
-            netsnmp_cert_free(cert);
-            return -1;
-        }
-        cert->ocert = ocert;
-        if (-1 == CONTAINER_INSERT(_certs, cert)) {
-            DEBUGMSGT(("cert:file:add:err",
-                       "error inserting cert into container\n"));
-            netsnmp_cert_free(cert);
-            cert = NULL;
-        }
+
+    key->okey = okey;
+
+    if (-1 == CONTAINER_INSERT(_keys, key)) {
+        DEBUGMSGT(("cert:key:file:add:err",
+                   "error inserting key into container\n"));
+        netsnmp_key_free(key);
+        key = NULL;
     }
-    if ((NULL == cert) && (NULL == key)) {
-        DEBUGMSGT(("cert:file:add:failure", "for %s\n", certfile));
-        return -1;
+    if (index) {
+        fprintf(index, "k:%s\n", filename);
+    }
+
+    return key;
+}
+
+static netsnmp_cert *
+_add_cert(X509 *ocert, const char* dirname, const char* filename, int type, int offset, FILE *index)
+{
+    netsnmp_cert *cert;
+
+    cert = _new_cert(dirname, filename, type, offset, -1, NULL, NULL, NULL);
+    if (NULL == cert)
+        return NULL;
+
+    netsnmp_ocert_parse(cert, ocert);
+
+    if (-1 == CONTAINER_INSERT(_certs, cert)) {
+        DEBUGMSGT(("cert:file:add:err",
+                   "error inserting cert into container\n"));
+        netsnmp_cert_free(cert);
+        return NULL;
     }
 
     if (index) {
@@ -1308,11 +1308,134 @@ _add_certfile(const char* dirname, const char* filename, FILE *index)
         /** fingerprint max = 64*3=192 for sha512 */
         /** common name / CN  = 64 */
         if (cert)
-            fprintf(index, "c:%s %d %d %s '%s' '%s'\n", filename,
-                    cert->info.type, cert->hash_type, cert->fingerprint,
+            fprintf(index, "c:%s %d %d %d %s '%s' '%s'\n", filename,
+                    cert->info.type, cert->offset, cert->hash_type, cert->fingerprint,
                     cert->common_name, cert->subject);
-        else if (key)
-            fprintf(index, "k:%s\n", filename);
+    }
+
+    return cert;
+}
+
+static int
+_add_certfile(const char* dirname, const char* filename, FILE *index)
+{
+    BIO          *certbio;
+    X509         *ocert = NULL;
+    X509         *ncert;
+    EVP_PKEY     *okey = NULL;
+    netsnmp_cert *cert = NULL;
+    netsnmp_key  *key = NULL;
+    char          certfile[SNMP_MAXPATH];
+    int           type;
+    int           offset = 0;
+
+    if (((const void*)NULL == dirname) || (NULL == filename))
+        return -1;
+
+    type = _type_from_filename(filename);
+    if (type == NS_CERT_TYPE_UNKNOWN) {
+        snmp_log(LOG_ERR, "certificate file '%s' type not recognised, ignoring\n", filename);
+        return -1;
+    }
+
+    certbio = netsnmp_open_bio(dirname, filename);
+    if (!certbio) {
+        return -1;
+    }
+
+    switch (type) {
+
+       case NS_CERT_TYPE_KEY: 
+
+           okey = PEM_read_bio_PrivateKey(certbio, NULL, NULL, NULL);
+           if (NULL == okey)
+               snmp_log(LOG_ERR, "error parsing key file %s\n",
+                     key->info.filename);
+           else {
+               key = _add_key(okey, dirname, filename, index);
+               if (NULL == key) {
+                   EVP_PKEY_free(okey);
+                      okey = NULL;
+               }
+           }
+           break;
+
+        case NS_CERT_TYPE_DER:
+
+            ocert = d2i_X509_bio(certbio, NULL); /* DER/ASN1 */
+            if (NULL != ocert) {
+                if (!_add_cert(ocert, dirname, filename, type, 0, index)) {
+                    X509_free(ocert);
+                    ocert = NULL;
+                }
+                break;
+            }
+            (void)BIO_reset(certbio);
+            /* Check for PEM if DER didn't work */
+            /* FALLTHROUGH */
+
+        case NS_CERT_TYPE_PEM:
+
+            if (NS_CERT_TYPE_DER == type) {
+                DEBUGMSGT(("9:cert:read", "Changing type from DER to PEM\n"));
+                type = NS_CERT_TYPE_PEM;
+            }
+            ocert = ncert = PEM_read_bio_X509_AUX(certbio, NULL, NULL, NULL);
+            if (NULL != ocert) {
+                cert = _add_cert(ncert, dirname, filename, type, offset, index);
+                if (NULL == cert) {
+                    X509_free(ocert);
+                    ocert = ncert = NULL;
+                }
+            }
+            while (NULL != ncert) {
+                offset = BIO_tell(certbio);
+                ncert = PEM_read_bio_X509_AUX(certbio, NULL, NULL, NULL);
+                if (ncert) {
+                    if (NULL == _add_cert(ncert, dirname, filename, type, offset, index)) {
+                        X509_free(ncert);
+                        ncert = NULL;
+                    }
+                }
+            };
+
+            BIO_seek(certbio, offset);
+
+            /** check for private key too */
+            okey = PEM_read_bio_PrivateKey(certbio, NULL, NULL, NULL);
+
+            if (NULL != okey) {
+                DEBUGMSGT(("cert:read:key", "found key with cert in %s\n",
+                           cert->info.filename));
+                key = _add_key(okey, dirname, filename, NULL);
+                if (NULL != key) {
+                    DEBUGMSGT(("cert:read:partner", "%s match found!\n",
+                               cert->info.filename));
+                    key->cert = cert;
+                    cert->key = key;
+                    cert->info.allowed_uses |= NS_CERT_IDENTITY;
+                }
+                else {
+                    EVP_PKEY_free(okey);
+                    okey = NULL;
+                }
+            }
+
+            break;
+
+#ifdef CERT_PKCS12_SUPPORT_MAYBE_LATER
+        case NS_CERT_TYPE_PKCS12:
+#endif
+
+        default:
+            break;
+    }
+
+    BIO_vfree(certbio);
+
+    if ((NULL == ocert) && (NULL == okey)) {
+        snmp_log(LOG_ERR, "certificate file '%s' contained neither certificate nor key, ignoring\n", certfile);
+        return -1;
     }
 
     return 0;
@@ -1326,7 +1449,8 @@ _cert_read_index(const char *dirname, struct stat *dirstat)
     struct stat     idx_stat;
     char            tmpstr[SNMP_MAXPATH + 5], filename[NAME_MAX];
     char            fingerprint[EVP_MAX_MD_SIZE*3], common_name[64+1], type_str[15];
-    char            subject[SNMP_MAXBUF_SMALL], hash_str[15];
+    char            subject[SNMP_MAXBUF_SMALL], hash_str[15], offset_str[15];
+    ssize_t         offset;
     int             count = 0, type, hash, version;
     netsnmp_cert    *cert;
     netsnmp_key     *key;
@@ -1369,7 +1493,8 @@ _cert_read_index(const char *dirname, struct stat *dirstat)
         netsnmp_directory_container_read_some(NULL, dirname,
                                               _time_filter, &idx_stat,
                                               NETSNMP_DIR_NSFILE |
-                                              NETSNMP_DIR_NSFILE_STATS);
+                                              NETSNMP_DIR_NSFILE_STATS |
+                                              NETSNMP_DIR_ALLOW_DUPLICATES);
     if (newer) {
         DEBUGMSGT(("cert:index:parse", "Index outdated; files modified\n"));
         CONTAINER_FREE_ALL(newer, NULL);
@@ -1413,6 +1538,7 @@ _cert_read_index(const char *dirname, struct stat *dirstat)
             pos = &tmpstr[2];
             if ((NULL == (pos=copy_nword(pos, filename, sizeof(filename)))) ||
                 (NULL == (pos=copy_nword(pos, type_str, sizeof(type_str)))) ||
+                (NULL == (pos=copy_nword(pos, offset_str, sizeof(offset_str)))) ||
                 (NULL == (pos=copy_nword(pos, hash_str, sizeof(hash_str)))) ||
                 (NULL == (pos=copy_nword(pos, fingerprint,
                                          sizeof(fingerprint)))) ||
@@ -1425,8 +1551,9 @@ _cert_read_index(const char *dirname, struct stat *dirstat)
                 break;
             }
             type = atoi(type_str);
+            offset = atoi(offset_str);
             hash = atoi(hash_str);
-            cert = _new_cert(dirname, filename, type, hash, fingerprint,
+            cert = _new_cert(dirname, filename, type, offset, hash, fingerprint,
                              common_name, subject);
             if (cert && 0 == CONTAINER_INSERT(found, cert))
                 ++count;
@@ -1531,7 +1658,8 @@ _add_certdir(const char *dirname)
         netsnmp_directory_container_read_some(NULL, dirname,
                                               _cert_cert_filter, NULL,
                                               NETSNMP_DIR_RELATIVE_PATH |
-                                              NETSNMP_DIR_EMPTY_OK );
+                                              NETSNMP_DIR_EMPTY_OK |
+                                              NETSNMP_DIR_ALLOW_DUPLICATES);
     if (NULL == cert_container) {
         DEBUGMSGT(("cert:index:dir",
                     "error creating container for cert files\n"));
@@ -1619,7 +1747,7 @@ _cert_print(netsnmp_cert *c, void *context)
     if (NULL == c)
         return;
 
-    DEBUGMSGT(("cert:dump", "cert %s in %s\n", c->info.filename, c->info.dir));
+    DEBUGMSGT(("cert:dump", "cert %s in %s at offset %d\n", c->info.filename, c->info.dir, c->offset));
     DEBUGMSGT(("cert:dump", "   type %d flags 0x%x (%s)\n",
              c->info.type, c->info.allowed_uses,
               _mode_str(c->info.allowed_uses)));
@@ -1823,7 +1951,8 @@ netsnmp_cert_find(int what, int where, void *hint)
         netsnmp_void_array *matching;
 
         DEBUGMSGT(("cert:find:params", " hint = %s\n", (char *)hint));
-        matching = _cert_find_subset_fn( filename, NULL );
+        matching = _cert_reduce_subset_what(_cert_find_subset_fn(
+                                            filename, NULL ), what);
         if (!matching)
             return NULL;
         if (1 == matching->size)
@@ -2264,6 +2393,124 @@ _reduce_subset_dir(netsnmp_void_array *matching, const char *directory)
                    matching->size, newsize));
         matching->size = newsize;
     }
+}
+
+/*
+ * reduce subset by eliminating any certificates that are not the
+ * first certficate in a file. This allows us to ignore certificate
+ * chains when testing for specific certificates, and to match keys
+ * to the first certificate only.
+ */
+static netsnmp_void_array *
+_cert_reduce_subset_first(netsnmp_void_array *matching)
+{
+    netsnmp_cert *cc;
+    int i = 0, j, newsize;
+
+    if ((NULL == matching))
+        return matching;
+
+    newsize = matching->size;
+
+    for( ; i < matching->size; ) {
+        /*
+         * if we've shifted matches down we'll hit a NULL entry before
+         * we hit the end of the array.
+         */
+        if (NULL == matching->array[i])
+            break;
+        /*
+         * skip over valid matches. The first entry has an offset of zero.
+         */
+        cc = (netsnmp_cert*)matching->array[i];
+        if (0 == cc->offset) {
+            ++i;
+            continue;
+        }
+        /*
+         * shrink array by shifting everything down a spot. Might not be
+         * the most efficient soloution, but this is just happening at
+         * startup and hopefully most certs won't have common prefixes.
+         */
+        --newsize;
+        for ( j=i; j < newsize; ++j )
+            matching->array[j] = matching->array[j+1];
+        matching->array[j] = NULL;
+        /** no ++i; just shifted down, need to look at same position again */
+    }
+    /*
+     * if we shifted, set the new size
+     */
+    if (newsize != matching->size) {
+        DEBUGMSGT(("9:cert:subset:first", "shrank from %" NETSNMP_PRIz "d to %d\n",
+                   matching->size, newsize));
+        matching->size = newsize;
+    }
+
+    if (0 == matching->size) {
+        free(matching->array);
+        SNMP_FREE(matching);
+    }
+
+    return matching;
+}
+
+/*
+ * reduce subset by eliminating any certificates that do not match
+ * purpose specified.
+ */
+static netsnmp_void_array *
+_cert_reduce_subset_what(netsnmp_void_array *matching, int what)
+{
+    netsnmp_cert_common *cc;
+    int i = 0, j, newsize;
+
+    if ((NULL == matching))
+        return matching;
+
+    newsize = matching->size;
+
+    for( ; i < matching->size; ) {
+        /*
+         * if we've shifted matches down we'll hit a NULL entry before
+         * we hit the end of the array.
+         */
+        if (NULL == matching->array[i])
+            break;
+        /*
+         * skip over valid matches. The first entry has an offset of zero.
+         */
+        cc = (netsnmp_cert_common *)matching->array[i];
+        if ((cc->allowed_uses & what)) {
+            ++i;
+            continue;
+        }
+        /*
+         * shrink array by shifting everything down a spot. Might not be
+         * the most efficient soloution, but this is just happening at
+         * startup and hopefully most certs won't have common prefixes.
+         */
+        --newsize;
+        for ( j=i; j < newsize; ++j )
+            matching->array[j] = matching->array[j+1];
+        matching->array[j] = NULL;
+        /** no ++i; just shifted down, need to look at same position again */
+    }
+    /*
+     * if we shifted, set the new size
+     */
+    if (newsize != matching->size) {
+        DEBUGMSGT(("9:cert:subset:what", "shrank from %" NETSNMP_PRIz "d to %d\n",
+                   matching->size, newsize));
+        matching->size = newsize;
+    }
+
+    if (0 == matching->size) {
+        free(matching->array);
+        SNMP_FREE(matching);
+    }
+
+    return matching;
 }
 
 static netsnmp_void_array *

--- a/snmplib/dir_utils.c
+++ b/snmplib/dir_utils.c
@@ -103,6 +103,9 @@ netsnmp_directory_container_read_some(netsnmp_container *user_container,
         /** default to unsorted */
         if (! (flags & NETSNMP_DIR_SORTED))
             CONTAINER_SET_OPTIONS(container, CONTAINER_KEY_UNSORTED, rc);
+        /** default to duplicates not allowed */
+        if (! (flags & NETSNMP_DIR_ALLOW_DUPLICATES))
+           CONTAINER_SET_OPTIONS(container, CONTAINER_KEY_ALLOW_DUPLICATES, rc);
     }
 
     dir = opendir(dirname);


### PR DESCRIPTION
This patch lifts the restriction that a PEM file can only contain
one certificate. This brings net-snmp in line with the behaviour
of other applications that use PEM files.

Multiple certificates are read from each file, and the offset of
each certificate is added to the index for efficient retrieval.

The first certificate in the chain is eligible to be either an
identity certificate or a remote certificate. Intermediate
certificates are ignored for this purpose, maintaining existing
behaviour with respect to peerCert and remoteCert.

Trusted CA certificates are still required to be listed one per
file, this restriction will be lifted in a separate patch.

Fixes https://github.com/net-snmp/net-snmp/issues/245