### PR TITLE
Fix compilation with feature NETSNMP_FEATURE_REMOVE_LOGGING_STDIO

### DIFF
--- a/include/net-snmp/library/snmp_logging.h
+++ b/include/net-snmp/library/snmp_logging.h
@@ -83,8 +83,9 @@ extern          "C" {
     char *snmp_log_syslogname(const char *syslogname);
     typedef struct netsnmp_log_handler_s netsnmp_log_handler; 
     typedef int (NetsnmpLogHandler)(netsnmp_log_handler*, int, const char *);
-
+#ifndef NETSNMP_FEATURE_REMOVE_LOGGING_STDIO
     NetsnmpLogHandler log_handler_stdouterr;
+#endif /* NETSNMP_FEATURE_REMOVE_LOGGING_STDIO */
     NetsnmpLogHandler log_handler_file;
     NetsnmpLogHandler log_handler_syslog;
     NetsnmpLogHandler log_handler_callback;

--- a/snmplib/snmp_logging.c
+++ b/snmplib/snmp_logging.c
@@ -996,11 +996,11 @@ netsnmp_register_loghandler( int type, int priority )
 
     logh->type     = type;
     switch ( type ) {
+#ifndef NETSNMP_FEATURE_REMOVE_LOGGING_STDIO
     case NETSNMP_LOGHANDLER_STDOUT:
         logh->imagic  = 1;
         logh->handler = log_handler_stdouterr;
         break;
-#ifndef NETSNMP_FEATURE_REMOVE_LOGGING_STDIO
     case NETSNMP_LOGHANDLER_STDERR:
         logh->handler = log_handler_stdouterr;
         break;


### PR DESCRIPTION
Fix compilation when feature NETSNMP_FEATURE_REMOVE_LOGGING_STDIO is used. Currently when this feature is set in include/net-snmp/net-snmp-config.h, according to INSTALL instructions, the program won't build. This fixes this problem.