### PR TITLE
Enable systemd socket activation for UDP sockets

### DIFF
--- a/include/net-snmp/library/snmp_transport.h
+++ b/include/net-snmp/library/snmp_transport.h
@@ -115,6 +115,7 @@ typedef struct netsnmp_tmStateReference_s {
 } netsnmp_tmStateReference;
 
 #define NETSNMP_TSPEC_LOCAL                     0x01 /* 1=server, 0=client */
+#define NETSNMP_TSPEC_PREBOUND                  0x02 /* 1=bound by systemd, 0=needs bind in the library */
 
 struct netsnmp_container_s; /* forward decl */
 typedef struct netsnmp_tdomain_spec_s {

--- a/snmplib/transports/snmpUDPIPv4BaseDomain.c
+++ b/snmplib/transports/snmpUDPIPv4BaseDomain.c
@@ -202,6 +202,11 @@ netsnmp_udpipv4base_transport_bind(netsnmp_transport *t,
                     t->sock, str));
         free(str);
     }
+    if (flags & NETSNMP_TSPEC_PREBOUND) {
+        DEBUGMSGTL(("netsnmp_udpbase", "socket %d is prebound, nothing to do\n",
+                    t->sock));
+        return 0;
+    }
     rc = netsnmp_bindtodevice(t->sock, ep->iface);
     if (rc != 0) {
         DEBUGMSGTL(("netsnmp_udpbase", "failed to bind to iface %s: %s\n",
@@ -276,6 +281,8 @@ netsnmp_udpipv4base_transport_with_source(const struct netsnmp_ep *ep,
          */
         t->sock = netsnmp_sd_find_inet_socket(PF_INET, SOCK_DGRAM, -1,
                                               ntohs(ep->a.sin.sin_port));
+        if (t->sock >= 0)
+            flags |= NETSNMP_TSPEC_PREBOUND;
 #endif
     }
     else

--- a/snmplib/transports/snmpUDPIPv6Domain.c
+++ b/snmplib/transports/snmpUDPIPv6Domain.c
@@ -296,9 +296,14 @@ netsnmp_udp6_transport_bind(netsnmp_transport *t,
     DEBUGIF("netsnmp_udp6") {
         char *str;
         str = netsnmp_udp6_fmtaddr(NULL, addr, sizeof(*addr));
-        DEBUGMSGTL(("netsnmp_udpbase", "binding socket: %d to %s\n",
+        DEBUGMSGTL(("netsnmp_udp6", "binding socket: %d to %s\n",
                     t->sock, str));
         free(str);
+    }
+    if (flags & NETSNMP_TSPEC_PREBOUND) {
+        DEBUGMSGTL(("netsnmp_udp6", "socket %d is prebound, nothing to do\n",
+                    t->sock));
+        return 0;
     }
     rc = netsnmp_bindtodevice(t->sock, ep->iface);
     if (rc != 0) {
@@ -415,6 +420,8 @@ netsnmp_udp6_transport_with_source(const struct netsnmp_ep *ep,
          */
         t->sock = netsnmp_sd_find_inet_socket(PF_INET6, SOCK_DGRAM, -1,
                                               ntohs(ep->a.sin6.sin6_port));
+        if (t->sock >= 0)
+            flags |= NETSNMP_TSPEC_PREBOUND;
 #endif
     }
     else


### PR DESCRIPTION
For example if snmptrapd is UDP socket-activated, it still tries to bind the
socket passed in by systemd.  This is not permitted (the default port is "low",
thus privileged) and also invalid, because the port is already taken by systemd.

Since the code handling UDP is structured differently than TCP, that
method isn't directly applicable, but I tried to copy the idea as far as
possible. Other solutions are certainly possible if preferred.