### PR TITLE
Prevent parsing IP address twice (#199)

### DIFF
--- a/snmplib/transports/snmpUDPDomain.c
+++ b/snmplib/transports/snmpUDPDomain.c
@@ -387,7 +387,7 @@ netsnmp_udp_parse_security(const char *token, char *param)
             /* Nope, wasn't a dotted quad.  Must be a hostname. */
             int ret = netsnmp_gethostbyname_v4(sourcep, &network.s_addr);
             if (ret < 0) {
-                config_perror("cannot resolve source hostname");
+                config_perror("cannot resolve IPv4 source hostname");
                 return;
             }
         }

--- a/snmplib/transports/snmpUDPIPv6Domain.c
+++ b/snmplib/transports/snmpUDPIPv6Domain.c
@@ -736,7 +736,15 @@ netsnmp_udp6_parse_security(const char *token, char *param)
                 memset(&pton_addr.sin6_addr.s6_addr, '\0',
                        sizeof(struct in6_addr));
             } else if (inet_pton(AF_INET6, sourcep, &pton_addr.sin6_addr) != 1) {
-                /* Nope, wasn't a numeric address. Must be a hostname. */
+                /* Nope, wasn't a numeric IPv6 address. Must be IPv4 or a hostname. */
+
+                /* Try interpreting as dotted quad - IPv4 */
+                struct in_addr network;
+                if (inet_pton(AF_INET, sourcep, &network) > 0){
+                    /* Yes, it's IPv4 - so it's already parsed and we can return. */
+                    DEBUGMSGTL(("com2sec6", "IPv4 detected for IPv6 parser. Skipping.\n"));
+                    return;
+                }
 #if HAVE_GETADDRINFO
                 int             gai_error;
 


### PR DESCRIPTION
This fixes issue, that is caused by parsing IP address twice. First as IPv4 and as IPv6 at second, even though the address was
properly parsed as a valid IPv4 address. See issue #199 for more details