### PR TITLE
Fix inconsistent use of #if vs. #ifdef NETSNMP_CAN_USE_SYSCTL

### DIFF
--- a/agent/mibgroup/host/data_access/swrun_kinfo.c
+++ b/agent/mibgroup/host/data_access/swrun_kinfo.c
@@ -159,7 +159,7 @@
 void
 netsnmp_arch_swrun_init(void)
 {
-#if NETSNMP_CAN_USE_SYSCTL && defined(CTL_KERN) && defined(KERN_MAXPROC)
+#if defined(NETSNMP_CAN_USE_SYSCTL) && defined(CTL_KERN) && defined(KERN_MAXPROC)
     extern int _swrun_max;
     size_t max_size = sizeof(_swrun_max);
     int maxproc_mib[] = { CTL_KERN, KERN_MAXPROC };

--- a/agent/mibgroup/host/hr_system.c
+++ b/agent/mibgroup/host/hr_system.c
@@ -273,7 +273,7 @@ var_hrsys(struct variable * vp,
 #ifdef linux
     FILE           *fp;
 #endif
-#if NETSNMP_CAN_USE_SYSCTL && defined(CTL_KERN) && defined(KERN_MAXPROC)
+#if defined(NETSNMP_CAN_USE_SYSCTL) && defined(CTL_KERN) && defined(KERN_MAXPROC)
     static int      maxproc_mib[] = { CTL_KERN, KERN_MAXPROC };
     size_t          buf_size;
 #endif
@@ -343,7 +343,7 @@ var_hrsys(struct variable * vp,
     case HRSYS_MAXPROCS:
 #if defined(NR_TASKS)
         long_return = NR_TASKS; /* <linux/tasks.h> */
-#elif NETSNMP_CAN_USE_SYSCTL && defined(CTL_KERN) && defined(KERN_MAXPROC)
+#elif defined(NETSNMP_CAN_USE_SYSCTL) && defined(CTL_KERN) && defined(KERN_MAXPROC)
 	{
 	    int nproc = 0;
 

--- a/snmplib/system.c
+++ b/snmplib/system.c
@@ -642,7 +642,7 @@ get_boottime(void)
 #if defined(hpux10) || defined(hpux11)
     pstat_getstatic(&pst_buf, sizeof(struct pst_static), 1, 0);
     boottime_csecs = pst_buf.boot_time * 100;
-#elif NETSNMP_CAN_USE_SYSCTL
+#elif defined(NETSNMP_CAN_USE_SYSCTL)
     mib[0] = CTL_KERN;
     mib[1] = KERN_BOOTTIME;
 


### PR DESCRIPTION
NETSNMP_CAN_USE_SYSCTL could be not defined.
Fix compile warning / error if compiled with the compile flags
-Wundef or -Werror=undef.