### PR TITLE
Fix inconsistent use of #if vs. #ifdef HAVE_PCRE_H

### DIFF
--- a/agent/mibgroup/host/data_access/swrun.c
+++ b/agent/mibgroup/host/data_access/swrun.c
@@ -17,7 +17,7 @@
 #include "swrun.h"
 #include "swrun_private.h"
 
-#if HAVE_PCRE_H
+#ifdef HAVE_PCRE_H
 #include <pcre.h>
 #endif
 
@@ -100,7 +100,7 @@ swrun_max_processes( void )
 #endif /* NETSNMP_FEATURE_REMOVE_SWRUN_MAX_PROCESSES */
 
 #ifndef NETSNMP_FEATURE_REMOVE_SWRUN_COUNT_PROCESSES_BY_REGEX
-#if HAVE_PCRE_H
+#ifdef HAVE_PCRE_H
 int
 swrun_count_processes_by_regex( char *name, netsnmp_regex_ptr regexp )
 {

--- a/agent/mibgroup/if-mib/data_access/interface.c
+++ b/agent/mibgroup/if-mib/data_access/interface.c
@@ -16,7 +16,7 @@
 #include "if-mib/ifTable/ifTable.h"
 #include "if-mib/data_access/interface.h"
 #include "interface_private.h"
-#if HAVE_PCRE_H
+#ifdef HAVE_PCRE_H
 #include <pcre.h>
 #elif HAVE_REGEX_H
 #include <sys/types.h>
@@ -840,7 +840,7 @@ int netsnmp_access_interface_max_reached(const char *name)
 int netsnmp_access_interface_include(const char *name)
 {
     netsnmp_include_if_list *if_ptr;
-#if HAVE_PCRE_H
+#ifdef HAVE_PCRE_H
     int                      found_ndx[3];
 #endif
 
@@ -856,7 +856,7 @@ int netsnmp_access_interface_include(const char *name)
 
 
     for (if_ptr = include_list; if_ptr; if_ptr = if_ptr->next) {
-#if HAVE_PCRE_H
+#ifdef HAVE_PCRE_H
         if (pcre_exec(if_ptr->regex_ptr, NULL, name, strlen(name), 0, 0,
                       found_ndx, 3) >= 0)
             return TRUE;
@@ -980,7 +980,7 @@ _parse_include_if_config(const char *token, char *cptr)
 {
     netsnmp_include_if_list *if_ptr, *if_new;
     char                    *name, *st;
-#if HAVE_PCRE_H
+#ifdef HAVE_PCRE_H
     const char              *pcre_error;
     int                     pcre_error_offset;
 #elif HAVE_REGEX_H
@@ -1012,7 +1012,7 @@ _parse_include_if_config(const char *token, char *cptr)
             config_perror("Out of memory");
             goto err;
         }
-#if HAVE_PCRE_H
+#ifdef HAVE_PCRE_H
         if_new->regex_ptr = pcre_compile(if_new->name, 0,  &pcre_error,
                                          &pcre_error_offset, NULL);
         if (!if_new->regex_ptr) {
@@ -1063,7 +1063,7 @@ _free_include_if_config(void)
 
     while (if_ptr) {
         if_next = if_ptr->next;
-#if HAVE_PCRE_H
+#ifdef HAVE_PCRE_H
         free(if_ptr->regex_ptr);
 #elif HAVE_REGEX_H
         regfree(if_ptr->regex_ptr);

--- a/agent/mibgroup/struct.h
+++ b/agent/mibgroup/struct.h
@@ -30,7 +30,7 @@ struct extensible {
 
 struct myproc {
     char            name[STRMAX];
-#if HAVE_PCRE_H
+#ifdef HAVE_PCRE_H
     netsnmp_regex_ptr regexp;
 #endif
     char            fixcmd[STRMAX];

--- a/agent/mibgroup/ucd-snmp/proc.c
+++ b/agent/mibgroup/ucd-snmp/proc.c
@@ -39,7 +39,7 @@
 #  include <time.h>
 # endif
 #endif
-#if HAVE_PCRE_H
+#ifdef HAVE_PCRE_H
 #include <pcre.h>
 #endif
 
@@ -134,7 +134,7 @@ proc_free_config(void)
     for (ptmp = procwatch; ptmp != NULL;) {
         ptmp2 = ptmp;
         ptmp = ptmp->next;
-#if HAVE_PCRE_H
+#ifdef HAVE_PCRE_H
         free(ptmp2->regexp.regex_ptr);
 #endif
         free(ptmp2);
@@ -208,7 +208,7 @@ proc_parse_config(const char *token, char *cptr)
     if (*procp == NULL)
         return;                 /* memory alloc error */
     numprocs++;
-#if HAVE_PCRE_H
+#ifdef HAVE_PCRE_H
     (*procp)->regexp.regex_ptr = NULL;
 #endif
     /*
@@ -220,7 +220,7 @@ proc_parse_config(const char *token, char *cptr)
         cptr = skip_not_white(cptr);
         if ((cptr = skip_white(cptr))) {
             (*procp)->min = atoi(cptr);
-#if HAVE_PCRE_H
+#ifdef HAVE_PCRE_H
             cptr = skip_not_white(cptr);
             if ((cptr = skip_white(cptr))) {
                 const char *pcre_error;
@@ -406,7 +406,7 @@ sh_count_procs(char *procname)
   return swrun_count_processes_by_name( procname );
 }
 
-#if HAVE_PCRE_H
+#ifdef HAVE_PCRE_H
 netsnmp_feature_require(swrun_count_processes_by_regex);
 int
 sh_count_procs_by_regex(char *procname, netsnmp_regex_ptr regexp)

--- a/include/net-snmp/data_access/interface.h
+++ b/include/net-snmp/data_access/interface.h
@@ -10,7 +10,7 @@
 extern          "C" {
 #endif
 
-#if HAVE_PCRE_H
+#ifdef HAVE_PCRE_H
 #include <pcre.h>
 #elif HAVE_REGEX_H
 #include <regex.h>
@@ -211,7 +211,7 @@ typedef struct _conf_if_list {
     typedef netsnmp_conf_if_list conf_if_list; /* backwards compat */
 
 typedef struct _include_if_list {
-#if HAVE_PCRE_H
+#ifdef HAVE_PCRE_H
     pcre                    *regex_ptr;
 #elif HAVE_REGEX_H
     regex_t                 *regex_ptr;


### PR DESCRIPTION
HAVE_PCRE_H is undefined if <pcre.h> could or should not be used.
Fix compiler warnings / errors if compiled with the compiler flags
-Wundef or -Werror=undef.