### PR TITLE
Perl agent: setValue() value conversion and logging improvements

### DIFF
--- a/perl/agent/agent.xs
+++ b/perl/agent/agent.xs
@@ -3,6 +3,8 @@
 #include "EXTERN.h"
 #include "perl.h"
 #include "XSUB.h"
+#include <float.h>
+#include <math.h>
 #include <netdb.h>
 #include <sys/socket.h>
 
@@ -635,7 +637,7 @@ nari_setValue(me, type, value)
 		  /* Might be ok - got a double that might be an actual integer */
 		  dtmp = SvNVX(value);
 		  ltmp = SvIV(value);
-		  if (dtmp != ltmp) {
+		  if (fabs(dtmp - ltmp) > fabs(NV_EPSILON * dtmp)) {
 			snmp_log(LOG_ERR, "Could not convert double to integer in setValue: '%.20g'\n", dtmp);
 			RETVAL = 0;
 			break;
@@ -685,7 +687,7 @@ nari_setValue(me, type, value)
 		  /* Might be ok - got a double that might be an actual unsigned */
 		  dtmp = SvNVX(value);
 		  utmp = SvIV(value);
-		  if (dtmp != utmp) {
+		  if (fabs(dtmp - utmp) > fabs(NV_EPSILON * dtmp)) {
 			snmp_log(LOG_ERR, "Could not convert double to unsigned in setValue: '%.20g'\n", dtmp);
 			RETVAL = 0;
 			break;
@@ -728,7 +730,7 @@ nari_setValue(me, type, value)
 		  /* Might be ok - got a double that might be an actual unsigned */
 		  dtmp = SvNVX(value);
 		  ulltmp = SvIV(value);
-		  if (dtmp != ulltmp) {
+		  if (fabs(dtmp - ulltmp) > fabs(NV_EPSILON * dtmp)) {
 			snmp_log(LOG_ERR, "Could not convert double to unsigned in setValue: '%.20g'\n", dtmp);
 			RETVAL = 0;
 			break;

--- a/perl/agent/agent.xs
+++ b/perl/agent/agent.xs
@@ -636,7 +636,7 @@ nari_setValue(me, type, value)
 		  dtmp = SvNVX(value);
 		  ltmp = SvIV(value);
 		  if (dtmp != ltmp) {
-			snmp_log(LOG_ERR, "Could not convert double to integer in setValue: '%f'\n", dtmp);
+			snmp_log(LOG_ERR, "Could not convert double to integer in setValue: '%.20g'\n", dtmp);
 			RETVAL = 0;
 			break;
 		  }
@@ -686,7 +686,7 @@ nari_setValue(me, type, value)
 		  dtmp = SvNVX(value);
 		  utmp = SvIV(value);
 		  if (dtmp != utmp) {
-			snmp_log(LOG_ERR, "Could not convert double to unsigned in setValue: '%f'\n", dtmp);
+			snmp_log(LOG_ERR, "Could not convert double to unsigned in setValue: '%.20g'\n", dtmp);
 			RETVAL = 0;
 			break;
 		  }
@@ -729,7 +729,7 @@ nari_setValue(me, type, value)
 		  dtmp = SvNVX(value);
 		  ulltmp = SvIV(value);
 		  if (dtmp != ulltmp) {
-			snmp_log(LOG_ERR, "Could not convert double to unsigned in setValue: '%f'\n", dtmp);
+			snmp_log(LOG_ERR, "Could not convert double to unsigned in setValue: '%.20g'\n", dtmp);
 			RETVAL = 0;
 			break;
 		  }

--- a/perl/agent/agent.xs
+++ b/perl/agent/agent.xs
@@ -636,7 +636,7 @@ nari_setValue(me, type, value)
 		  dtmp = SvNVX(value);
 		  ltmp = SvIV(value);
 		  if (dtmp != ltmp) {
-			snmp_log(LOG_ERR, "Could not convert double to integer in setValue: '%f'", dtmp);
+			snmp_log(LOG_ERR, "Could not convert double to integer in setValue: '%f'\n", dtmp);
 			RETVAL = 0;
 			break;
 		  }
@@ -650,7 +650,7 @@ nari_setValue(me, type, value)
 	          stringptr = SvPV(value, stringlen);
 		  ltmp = strtol( stringptr, NULL, 0 );
 		  if (errno == EINVAL) {
-		  	snmp_log(LOG_ERR, "Could not convert string to number in setValue: '%s'", stringptr);
+			snmp_log(LOG_ERR, "Could not convert string to number in setValue: '%s'\n", stringptr);
 			RETVAL = 0;
 			break;
 		  }
@@ -686,7 +686,7 @@ nari_setValue(me, type, value)
 		  dtmp = SvNVX(value);
 		  utmp = SvIV(value);
 		  if (dtmp != utmp) {
-			snmp_log(LOG_ERR, "Could not convert double to unsigned in setValue: '%f'", dtmp);
+			snmp_log(LOG_ERR, "Could not convert double to unsigned in setValue: '%f'\n", dtmp);
 			RETVAL = 0;
 			break;
 		  }
@@ -700,7 +700,7 @@ nari_setValue(me, type, value)
 	          stringptr = SvPV(value, stringlen);
 		  utmp = strtoul( stringptr, NULL, 0 );
 		  if (errno == EINVAL) {
-		  	snmp_log(LOG_ERR, "Could not convert string to number in setValue: '%s'", stringptr);
+			snmp_log(LOG_ERR, "Could not convert string to number in setValue: '%s'\n", stringptr);
 			RETVAL = 0;
 			break;
 		  }
@@ -729,7 +729,7 @@ nari_setValue(me, type, value)
 		  dtmp = SvNVX(value);
 		  ulltmp = SvIV(value);
 		  if (dtmp != ulltmp) {
-			snmp_log(LOG_ERR, "Could not convert double to unsigned in setValue: '%f'", dtmp);
+			snmp_log(LOG_ERR, "Could not convert double to unsigned in setValue: '%f'\n", dtmp);
 			RETVAL = 0;
 			break;
 		  }
@@ -744,7 +744,7 @@ nari_setValue(me, type, value)
 	          errno = 0;
 		  ulltmp = strtoull( stringptr, NULL, 0 );
 		  if (errno != 0) {
-		      snmp_log(LOG_ERR, "Could not convert string to number in setValue: '%s'", stringptr);
+		      snmp_log(LOG_ERR, "Could not convert string to number in setValue: '%s'\n", stringptr);
 		      RETVAL = 0;
 		  } else
 


### PR DESCRIPTION
This PR includes few fixes and improvements to the setValue() value conversion by using a scaled epsilon to check for rounding relative errors, and logging more useful double values, and adding missing newlines.