### PR TITLE
Allow perl compiler name to contain periods

### DIFF
--- a/configure
+++ b/configure
@@ -25132,7 +25132,7 @@ if test "x$install_perl" != "xno" ; then
         { $as_echo "$as_me:${as_lineno-$LINENO}: checking for Perl cc" >&5
 $as_echo_n "checking for Perl cc... " >&6; }
 
-        PERLCC=`$myperl -V:cc | $myperl -n -e 'print if (s/^\s*cc=.([-=\w\s\/]+).;\s*/$1/);'`
+        PERLCC=`$myperl -V:cc | $myperl -n -e 'print if (s/^\s*cc=.([-=\w\s\/.]+).;\s*/$1/);'`
 
         if test "x$PERLCC" != "x" ; then
             { $as_echo "$as_me:${as_lineno-$LINENO}: result: $PERLCC" >&5

--- a/configure.d/config_project_perl_python
+++ b/configure.d/config_project_perl_python
@@ -87,7 +87,7 @@ if test "x$install_perl" != "xno" ; then
     if test "x$enable_perl_cc_checks" != "xno" ; then
         AC_MSG_CHECKING([for Perl cc])
         changequote(, )
-        PERLCC=`$myperl -V:cc | $myperl -n -e 'print if (s/^\s*cc=.([-=\w\s\/]+).;\s*/$1/);'`
+        PERLCC=`$myperl -V:cc | $myperl -n -e 'print if (s/^\s*cc=.([-=\w\s\/.]+).;\s*/$1/);'`
         changequote([, ])
         if test "x$PERLCC" != "x" ; then
             AC_MSG_RESULT([$PERLCC])


### PR DESCRIPTION
Fixes: https://sourceforge.net/p/net-snmp/patches/1375/

The net-snmp configure script imposes restrictions on the name of the compiler that was used to compile perl. Particularly, it does not allow the name to contain a period. If it does, the perl module is not built. This is what happens on Mac OS X 10.6 when perl was built with `/usr/bin/gcc-4.2`:

```
checking if we are in the source tree so we can install Perl modules... Yes
checking for Perl cc... checking for potential embedded Perl support... disabled
checking if we can install the Perl modules... no
```

This PR fixes the configure script to allow periods in the compiler name, and now the output is:

```
checking if we are in the source tree so we can install Perl modules... Yes
checking for Perl cc... /usr/bin/gcc-4.2
checking whether /usr/bin/gcc-4.2 is a GNU C compiler... yes
configure: WARNING: Embedded perl defaulting to off
checking for potential embedded Perl support... disabled
checking if we can install the Perl modules... yes -- not embeddable
```

MacPorts has been using this patch [since 2008](https://trac.macports.org/browser/trunk/dports/net/net-snmp/files/patch-configure.diff?rev=41554).
