### PR TITLE
mib2c-update: Fix misbehavior when the path includes space

### DIFF
--- a/local/mib2c-update
+++ b/local/mib2c-update
@@ -32,8 +32,8 @@ FIRST_RUN=0
 #
 debug()
 {
-    if [ $UPDATE_DEBUG -ge 1 ]; then
-        echo $1
+    if [ "$UPDATE_DEBUG" -ge 1 ]; then
+        echo "$1"
     fi
 }
 
@@ -50,7 +50,7 @@ die()
 
 safecd()
 {
-    cd $1
+    cd "$1"
     if [ $? -ne 0 ]; then
         die "changing to directory $1 from $PWD failed!"
     fi
@@ -96,7 +96,7 @@ check_setup()
 #        rc=0
 #    fi
 
-    if [ $rc -eq 0 ] && [ $UPDATE_NOPROBE -ne 1 ]; then
+    if [ "$rc" -eq 0 ] && [ "$UPDATE_NOPROBE" -ne 1 ]; then
         mib2c -c unknown  > /dev/null 2>&1
         if [ $? -eq 0 ]; then
             error "WARNING: mib2c returns 0 on error conditions!"
@@ -125,11 +125,11 @@ do_diff()
     local rcs=0
     safecd $DD_ORIG
     echo "  checking files in $1 ($PWD)"
-    files=`ls *$UPDATE_OID* 2>/dev/null`
-    if [ ! -z "$files" ]; then
+	files=`ls ./*"$UPDATE_OID"* 2>/dev/null`
+    if [ -n "$files" ]; then
         for f in $files; do
             diff -U $FUZZ -p -b -w --show-c-function \
-                -I "$""Id:" $f $DD_CURR/$f >> $DD_OUTPUT
+                -I "\$Id:" "$f" "$DD_CURR/$f" >> "$DD_OUTPUT"
             rc=$?
             rcs=`expr $rcs + $rc`
             if [ $rc -eq 1 ]; then
@@ -137,11 +137,11 @@ do_diff()
             fi
         done
     fi
-    if [ $rcs -eq 0 ]; then
-        rm -f $DD_OUTPUT
+    if [ "$rcs" -eq 0 ]; then
+        rm -f "$DD_OUTPUT"
     fi
     safecd -
-    return $rcs
+    return "$rcs"
 }
 
 #----------------------------------------------------------------------
@@ -150,18 +150,18 @@ do_cp()
 {
     src=$1
     dest=$2
-    if [ ! -d $dest ]; then
+    if [ ! -d "$dest" ]; then
         die "dest $dest is not a directory"
     fi
-    if [ ! -d $src ]; then
+    if [ ! -d "$src" ]; then
         die "src $src is not a directory"
     fi
-    safecd $src
-    files=`ls *$UPDATE_OID* 2>/dev/null| egrep "(file|onf|m2d|txt|\.c|\.h)$"`
+    safecd "$src"
+    files=`ls ./*"$UPDATE_OID"* 2>/dev/null| egrep "(file|onf|m2d|txt|\.c|\.h)$"`
     if [ -z "$files" ]; then
        echo "   no files to copy from $src"
     else
-       safecp $files $dest
+       safecp $files "$dest"
        if [ $? -ne 0 ]; then
            die "error while copying files from $src to $dest in $PWD"
        fi
@@ -174,14 +174,14 @@ do_cp()
 save_diff()
 {
     echo "Creating patch for your custom code"
-    cnt=`ls $UPDATE_CURR/*$UPDATE_OID* 2>/dev/null | egrep "(file|onf|m2d|txt|\.c|\.h)$" | wc -l`
-    if [ $cnt -eq 0 ]; then
+    cnt=`ls ./"$UPDATE_CURR/"*"$UPDATE_OID"* 2>/dev/null | egrep "(file|onf|m2d|txt|\.c|\.h)$" | wc -l`
+    if [ "$cnt" -eq 0 ]; then
         echo "   no custom code!"
         FIRST_RUN=1
         return
     fi
 
-    do_diff $UPDATE_ORIG/ $UPDATE_CURR/ $UPDATE_PATCH/custom.$UPDATE_DATE
+    do_diff "$UPDATE_ORIG/" "$UPDATE_CURR/" "$UPDATE_PATCH/custom.$UPDATE_DATE"
     if [ $? -eq 0 ]; then
         echo "   no custom code changes found."
     fi
@@ -191,15 +191,15 @@ save_diff()
 #
 gen_code()
 {
-    copy_defaults . $UPDATE_NEW
+    copy_defaults . "$UPDATE_NEW"
 
-    safecd $UPDATE_NEW
-    files=`ls *$UPDATE_OID* 2>/dev/null | grep -v "^default"`
-    if [ ! -z "$files" ]; then
+    safecd "$UPDATE_NEW"
+    files=`ls ./*"$UPDATE_OID"* 2>/dev/null | grep -v "^default"`
+    if [ -n "$files" ]; then
        rm -f $files > /dev/null 2>&1 
     fi
     echo "mib2c $@ -c $UPDATE_CONF $UPDATE_MIB2C_OPTS $UPDATE_OID"
-    mib2c $@ -c $UPDATE_CONF $UPDATE_MIB2C_OPTS $UPDATE_OID
+    mib2c "$@" -c "$UPDATE_CONF" "$UPDATE_MIB2C_OPTS" "$UPDATE_OID"
     if [ $? -ne 0 ]; then
         die "bad rc $rc from mib2 while generation new code."
     fi
@@ -211,12 +211,12 @@ gen_code()
 check_new()
 {
     echo "Checking for updates to generated code"
-    do_diff $UPDATE_ORIG/ $UPDATE_NEW/ $UPDATE_PATCH/generated.$UPDATE_DATE
+    do_diff "$UPDATE_ORIG/" "$UPDATE_NEW/" "$UPDATE_PATCH/generated.$UPDATE_DATE"
     if [ $? -eq 0 ]; then
         echo "Generated code has not changed."
-        safecd $UPDATE_PATCH
-        files=`ls *.$UPDATE_DATE 2>/dev/null `
-        if [ ! -z "$files" ]; then
+        safecd "$UPDATE_PATCH"
+        files=`ls ./*".$UPDATE_DATE" 2>/dev/null `
+        if [ -n "$files" ]; then
            rm $files
         fi
         exit 0
@@ -227,17 +227,17 @@ check_new()
 #
 merge_code()
 {
-    files=`ls $UPDATE_MERGED/* 2>/dev/null `
-    if [ ! -z "$files" ]; then
-       rm $UPDATE_MERGED/*
+    files=`ls "$UPDATE_MERGED/"* 2>/dev/null `
+    if [ -n "$files" ]; then
+       rm "$UPDATE_MERGED/"*
     fi
-    do_cp $UPDATE_NEW $UPDATE_MERGED
+    do_cp "$UPDATE_NEW" $UPDATE_MERGED""
 
-    if [ -f $UPDATE_PATCH/custom.$UPDATE_DATE ]; then
+    if [ -f "$UPDATE_PATCH/custom.$UPDATE_DATE" ]; then
        touch .M2C-UPDATE-MERGE-FAILED
        echo "Patching new generated code in $UPDATE_MERGED ($PWD)"
        # --forward = ignore already applied
-       patch --forward -F $FUZZ -N -d $UPDATE_MERGED -i $UPDATE_PATCH/custom.$UPDATE_DATE
+       patch --forward -F "$FUZZ" -N -d "$UPDATE_MERGED" -i "$UPDATE_PATCH/custom.$UPDATE_DATE"
        if [ $? -ne 0 ]; then
            error "Could not apply custom code patch to new generated code"
            die   "You must fix the problem in $UPDATE_MERGED, and then re-run mib2c-update."
@@ -250,12 +250,12 @@ copy_defaults()
 {
     SRC=$1
     DST=$2
-    if [ -d $SRC/defaults ]; then
-       safecp -a $SRC/defaults $DST
+    if [ -d "$SRC/defaults" ]; then
+       safecp -a "$SRC/defaults" "$DST"
     else
-        files=`ls $SRC/default-*.m2d 2>/dev/null `
-        if [ ! -z "$files" ]; then
-           safecp $files $DST
+        files=`ls "$SRC/default-"*.m2d 2>/dev/null `
+        if [ -n "$files" ]; then
+           safecp $files "$DST"
         fi
     fi
 
@@ -264,28 +264,28 @@ copy_defaults()
 copy_merged()
 {
     echo "Backing up current code to $UPDATE_BACKUP/curr"
-    do_cp $UPDATE_CURR $UPDATE_BACKUP/curr/
-    copy_defaults . $UPDATE_BACKUP/curr/
+    do_cp "$UPDATE_CURR" "$UPDATE_BACKUP/curr/"
+    copy_defaults . "$UPDATE_BACKUP/curr/"
 
     echo "Copying merged code to $UPDATE_CURR"
-    do_cp $UPDATE_MERGED $UPDATE_CURR/
+    do_cp "$UPDATE_MERGED" "$UPDATE_CURR/"
 
 
     echo "Backing up original code to $UPDATE_BACKUP/orig"
-    do_cp $UPDATE_ORIG $UPDATE_BACKUP/orig/
+    do_cp "$UPDATE_ORIG" "$UPDATE_BACKUP/orig/"
     echo "Saving new original code to $UPDATE_ORIG"
-    do_cp $UPDATE_NEW $UPDATE_ORIG/
+    do_cp "$UPDATE_NEW" "$UPDATE_ORIG/"
 }
 
 copy_new()
 {
     echo "Copying code to $UPDATE_CURR"
-    do_cp $UPDATE_NEW $UPDATE_CURR/
+    do_cp "$UPDATE_NEW" "$UPDATE_CURR/"
     # copy defaults back to current dir (which may not be UPDATE_CURR)
-    copy_defaults $UPDATE_NEW .
+    copy_defaults "$UPDATE_NEW" .
 
     echo "Saving original code to $UPDATE_ORIG"
-    do_cp $UPDATE_NEW $UPDATE_ORIG/
+    do_cp "$UPDATE_NEW" "$UPDATE_ORIG/"
 }
 
 copy_code()
@@ -297,15 +297,15 @@ copy_code()
     fi
 
     # always get defaults from UPDATE_NEW, since those are what were used.
-    copy_defaults $UPDATE_NEW .
+    copy_defaults "$UPDATE_NEW" .
 }
 
 
 #----------------------------------------------------------------------
 UPDATE_NOPROBE=0
 
-if [ -f $HOME/.mib2c-updaterc ]; then
-    . $HOME/.mib2c-updaterc
+if [ -f "$HOME/.mib2c-updaterc" ]; then
+    . "$HOME/.mib2c-updaterc"
 fi
 
 if [ -f "$PWD/.mib2c-updaterc" ]; then
@@ -337,7 +337,7 @@ if [ -f .M2C-UPDATE-MERGE-FAILED ]; then
         echo "[r)e-run from scratch]"
         echo "[q)uit]"
         echo "(c|r|q) ?"
-        read ans
+        read -r ans
         if [ "x$ans" = "xr" ]; then
             rm .M2C-UPDATE-MERGE-FAILED
             break
@@ -345,7 +345,7 @@ if [ -f .M2C-UPDATE-MERGE-FAILED ]; then
             echo "Have you have manually merged all the"
             echo "changes into the merged directory?"
             echo "(y|n)"
-            read ans
+            read -r ans
             if [ "x$ans" != "xy" ]; then
                 echo "Ok. Try again after you've done that."
                 exit 1

--- a/local/mib2c-update
+++ b/local/mib2c-update
@@ -69,11 +69,11 @@ safecp()
 check_setup()
 {
     rc=1
-    for d in $UPDATE_CURR $UPDATE_ORIG $UPDATE_NEW $UPDATE_MERGED $UPDATE_PATCH $UPDATE_BACKUP $UPDATE_BACKUP/curr $UPDATE_BACKUP/orig
+    for d in "$UPDATE_CURR" "$UPDATE_ORIG" "$UPDATE_NEW" "$UPDATE_MERGED" "$UPDATE_PATCH" "$UPDATE_BACKUP" "$UPDATE_BACKUP/curr" "$UPDATE_BACKUP/orig"
     do
-        if [ ! -d $d ]; then
+        if [ ! -d "$d" ]; then
             echo "Creating missing directory $d"
-            mkdir -p $d
+            mkdir -p "$d"
             if [ $? -ne 0 ]; then
                 error "Could not create directory $d"
                 rc=0
@@ -308,8 +308,8 @@ if [ -f $HOME/.mib2c-updaterc ]; then
     . $HOME/.mib2c-updaterc
 fi
 
-if [ -f $PWD/.mib2c-updaterc ]; then
-    . $PWD/.mib2c-updaterc
+if [ -f "$PWD/.mib2c-updaterc" ]; then
+    . "$PWD/.mib2c-updaterc"
 else
    echo "creating example .mib2c-udpaterc. edit as needed and re-run "
    echo "mib2c-update."


### PR DESCRIPTION
When the path name includes space, the script will create the wrong directories.

### Executed command:
```bash
$ cd "/path/to/foo bar"
$ mib2c-update
```

### Output:
```
/usr/bin/mib2c-update: line 311: [: /path/to/foo: binary operator expected
creating example .mib2c-udpaterc. edit as needed and re-run
mib2c-update.
Creating missing directory /path/to/foo
Creating missing directory bar
Creating missing directory bar/.orig
Creating missing directory bar/.new
Creating missing directory bar/.merged
Creating missing directory bar/.patch
Creating missing directory bar/.backup
Creating missing directory bar/.backup/curr
Creating missing directory bar/.backup/orig
ERROR: Environment variable missing! Set UPDATE_OID in .mib2c-updaterc
ERROR: Environment variable missing! Set UPDATE_CONF in .mib2c-updaterc
ERROR: WARNING: mib2c returns 0 on error conditions!
```

### Resulted Directory
```
/path/to
├── foo
└── foo\ bar
    ├── .mib2c-updaterc
    └── bar
        ├── .backup
        │   ├── curr
        │   └── orig
        ├── .merged
        ├── .new
        ├── .orig
        └── .patch

10 directories, 1 file
```