### PR TITLE
migrate fuzzers from oss-fuzz repo.

### DIFF
--- a/fuzzing/agentx_parse_fuzzer.c
+++ b/fuzzing/agentx_parse_fuzzer.c
@@ -1,0 +1,59 @@
+ /*
+  * Copyright (c) 2021, Net-snmp authors
+  * All rights reserved.
+  *
+  * Redistribution and use in source and binary forms, with or without
+  * modification, are permitted provided that the following conditions are met:
+  *
+  * * Redistributions of source code must retain the above copyright notice, this
+  *   list of conditions and the following disclaimer.
+  *
+  * * Redistributions in binary form must reproduce the above copyright notice,
+  *   this list of conditions and the following disclaimer in the documentation
+  *   and/or other materials provided with the distribution.
+  *
+  * * Neither the name of the copyright holder nor the names of its
+  *   contributors may be used to endorse or promote products derived from
+  *   this software without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#include <net-snmp/net-snmp-config.h>
+#include <net-snmp/net-snmp-includes.h>
+/* We build with the agent/mibgroup/agentx dir in an -I */
+#include <protocol.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+int LLVMFuzzerInitialize(int *argc, char ***argv) {
+    if (getenv("NETSNMP_DEBUGGING") != NULL) {
+        /*
+         * Turn on all debugging, to help understand what
+         * bits of the parser are running.
+         */
+        snmp_enable_stderrlog();
+        snmp_set_do_debugging(1);
+        debug_register_tokens("");
+    }
+    return 0;
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    netsnmp_pdu *pdu = SNMP_MALLOC_TYPEDEF(netsnmp_pdu);
+    netsnmp_session session;
+
+    session.version = AGENTX_VERSION_1;
+    agentx_parse(&session, pdu, (unsigned char *)data, size);
+    snmp_free_pdu(pdu);
+    return 0;
+}

--- a/fuzzing/parse_octet_hint_fuzzer.c
+++ b/fuzzing/parse_octet_hint_fuzzer.c
@@ -1,0 +1,65 @@
+ /*
+  * Copyright (c) 2021, Net-snmp authors
+  * All rights reserved.
+  *
+  * Redistribution and use in source and binary forms, with or without
+  * modification, are permitted provided that the following conditions are met:
+  *
+  * * Redistributions of source code must retain the above copyright notice, this
+  *   list of conditions and the following disclaimer.
+  *
+  * * Redistributions in binary form must reproduce the above copyright notice,
+  *   this list of conditions and the following disclaimer in the documentation
+  *   and/or other materials provided with the distribution.
+  *
+  * * Neither the name of the copyright holder nor the names of its
+  *   contributors may be used to endorse or promote products derived from
+  *   this software without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#include <net-snmp/net-snmp-config.h>
+#include <net-snmp/net-snmp-includes.h>
+#include <assert.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+int LLVMFuzzerInitialize(int *argc, char ***argv) {
+    if (getenv("NETSNMP_DEBUGGING") != NULL) {
+        /*
+         * Turn on all debugging, to help understand what
+         * bits of the parser are running.
+         */
+        snmp_enable_stderrlog();
+        snmp_set_do_debugging(1);
+        debug_register_tokens("");
+    }
+    return 0;
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    char *hint, *value;
+    int value_start, new_val_len;
+    unsigned char *new_val;
+
+    hint = strndup((const char *)data, size);
+    value_start = strlen(hint);
+    assert(value_start <= size);
+    value = strndup((const char *)data + value_start, size - value_start);
+    parse_octet_hint(hint, value, &new_val, &new_val_len);
+    free(new_val);
+    free(hint);
+    free(value);
+    return 0; 
+}

--- a/fuzzing/read_objid_fuzzer.c
+++ b/fuzzing/read_objid_fuzzer.c
@@ -1,0 +1,59 @@
+ /*
+  * Copyright (c) 2021, Net-snmp authors
+  * All rights reserved.
+  *
+  * Redistribution and use in source and binary forms, with or without
+  * modification, are permitted provided that the following conditions are met:
+  *
+  * * Redistributions of source code must retain the above copyright notice, this
+  *   list of conditions and the following disclaimer.
+  *
+  * * Redistributions in binary form must reproduce the above copyright notice,
+  *   this list of conditions and the following disclaimer in the documentation
+  *   and/or other materials provided with the distribution.
+  *
+  * * Neither the name of the copyright holder nor the names of its
+  *   contributors may be used to endorse or promote products derived from
+  *   this software without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#include <net-snmp/net-snmp-config.h>
+#include <net-snmp/net-snmp-includes.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+int LLVMFuzzerInitialize(int *argc, char ***argv) {
+    if (getenv("NETSNMP_DEBUGGING") != NULL) {
+        /*
+         * Turn on all debugging, to help understand what
+         * bits of the parser are running.
+         */
+        snmp_enable_stderrlog();
+        snmp_set_do_debugging(1);
+        debug_register_tokens("");
+    }
+    return 0;
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    oid *objid = malloc(MAX_OID_LEN * sizeof(oid));
+    size_t objidlen = MAX_OID_LEN;
+    char *input;
+
+    input = strndup((const char *)data, size);
+    read_objid(input, objid, &objidlen);
+    free(objid);
+    free(input);
+    return 0;
+}

--- a/fuzzing/snmp_mib_fuzzer.c
+++ b/fuzzing/snmp_mib_fuzzer.c
@@ -1,0 +1,73 @@
+ /*
+  * Copyright (c) 2021, Net-snmp authors
+  * All rights reserved.
+  *
+  * Redistribution and use in source and binary forms, with or without
+  * modification, are permitted provided that the following conditions are met:
+  *
+  * * Redistributions of source code must retain the above copyright notice, this
+  *   list of conditions and the following disclaimer.
+  *
+  * * Redistributions in binary form must reproduce the above copyright notice,
+  *   this list of conditions and the following disclaimer in the documentation
+  *   and/or other materials provided with the distribution.
+  *
+  * * Neither the name of the copyright holder nor the names of its
+  *   contributors may be used to endorse or promote products derived from
+  *   this software without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#include <net-snmp/net-snmp-config.h>
+#include <net-snmp/net-snmp-includes.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+int LLVMFuzzerInitialize(int *argc, char ***argv) {
+    if (getenv("NETSNMP_DEBUGGING") != NULL) {
+        /*
+         * Turn on all debugging, to help understand what
+         * bits of the parser are running.
+         */
+        snmp_enable_stderrlog();
+        snmp_set_do_debugging(1);
+        debug_register_tokens("");
+    }
+    return 0;
+}
+
+int SecmodInMsg_CB(struct snmp_secmod_incoming_params *sp1) {
+    return SNMPERR_SUCCESS;
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    char *filename;
+    if (asprintf(&filename, "/tmp/fuzzed-mib.%d", getpid()) == -1) {
+        return 0;
+    }
+
+    FILE *fp = fopen(filename, "wb");
+    if (!fp) {
+        return 0;
+    }
+    fwrite(data, size, 1, fp);
+    fclose(fp);
+
+    // Read the file
+    read_mib(filename);
+
+    unlink(filename);
+    free(filename);
+    return 0;
+}

--- a/fuzzing/snmp_parse_fuzzer.c
+++ b/fuzzing/snmp_parse_fuzzer.c
@@ -1,0 +1,57 @@
+ /*
+  * Copyright (c) 2021, Net-snmp authors
+  * All rights reserved.
+  *
+  * Redistribution and use in source and binary forms, with or without
+  * modification, are permitted provided that the following conditions are met:
+  *
+  * * Redistributions of source code must retain the above copyright notice, this
+  *   list of conditions and the following disclaimer.
+  *
+  * * Redistributions in binary form must reproduce the above copyright notice,
+  *   this list of conditions and the following disclaimer in the documentation
+  *   and/or other materials provided with the distribution.
+  *
+  * * Neither the name of the copyright holder nor the names of its
+  *   contributors may be used to endorse or promote products derived from
+  *   this software without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#include <net-snmp/net-snmp-config.h>
+#include <net-snmp/net-snmp-includes.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+int LLVMFuzzerInitialize(int *argc, char ***argv) {
+    if (getenv("NETSNMP_DEBUGGING") != NULL) {
+        /*
+         * Turn on all debugging, to help understand what
+         * bits of the parser are running.
+         */
+        snmp_enable_stderrlog();
+        snmp_set_do_debugging(1);
+        debug_register_tokens("");
+    }
+    return 0;
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    size_t bytes_remaining = size;
+    netsnmp_pdu *pdu = SNMP_MALLOC_TYPEDEF(netsnmp_pdu);
+
+    netsnmp_session sess = { };
+    snmpv3_parse(pdu, (unsigned char *)data, &bytes_remaining, NULL, &sess);
+    snmp_free_pdu(pdu);
+    return 0;
+}

--- a/fuzzing/snmp_parse_oid_fuzzer.c
+++ b/fuzzing/snmp_parse_oid_fuzzer.c
@@ -1,0 +1,63 @@
+ /*
+  * Copyright (c) 2021, Net-snmp authors
+  * All rights reserved.
+  *
+  * Redistribution and use in source and binary forms, with or without
+  * modification, are permitted provided that the following conditions are met:
+  *
+  * * Redistributions of source code must retain the above copyright notice, this
+  *   list of conditions and the following disclaimer.
+  *
+  * * Redistributions in binary form must reproduce the above copyright notice,
+  *   this list of conditions and the following disclaimer in the documentation
+  *   and/or other materials provided with the distribution.
+  *
+  * * Neither the name of the copyright holder nor the names of its
+  *   contributors may be used to endorse or promote products derived from
+  *   this software without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#include <net-snmp/net-snmp-config.h>
+#include <net-snmp/net-snmp-includes.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+int LLVMFuzzerInitialize(int *argc, char ***argv) {
+    if (getenv("NETSNMP_DEBUGGING") != NULL) {
+        /*
+         * Turn on all debugging, to help understand what
+         * bits of the parser are running.
+         */
+        snmp_enable_stderrlog();
+        snmp_set_do_debugging(1);
+        debug_register_tokens("");
+    }
+    return 0;
+}
+
+int SecmodInMsg_CB(struct snmp_secmod_incoming_params *sp1) {
+    return SNMPERR_SUCCESS;
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    oid *root = malloc(MAX_OID_LEN * sizeof(oid));
+    size_t rootlen;
+    char *input;
+
+    input = strndup((const char *)data, size);
+    snmp_parse_oid((const char *)input, root, &rootlen);
+    free(root);
+    free(input);
+    return 0; 
+}

--- a/fuzzing/snmp_pdu_parse_fuzzer.c
+++ b/fuzzing/snmp_pdu_parse_fuzzer.c
@@ -1,0 +1,56 @@
+ /*
+  * Copyright (c) 2021, Net-snmp authors
+  * All rights reserved.
+  *
+  * Redistribution and use in source and binary forms, with or without
+  * modification, are permitted provided that the following conditions are met:
+  *
+  * * Redistributions of source code must retain the above copyright notice, this
+  *   list of conditions and the following disclaimer.
+  *
+  * * Redistributions in binary form must reproduce the above copyright notice,
+  *   this list of conditions and the following disclaimer in the documentation
+  *   and/or other materials provided with the distribution.
+  *
+  * * Neither the name of the copyright holder nor the names of its
+  *   contributors may be used to endorse or promote products derived from
+  *   this software without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#include <net-snmp/net-snmp-config.h>
+#include <net-snmp/net-snmp-includes.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+int LLVMFuzzerInitialize(int *argc, char ***argv) {
+    if (getenv("NETSNMP_DEBUGGING") != NULL) {
+        /*
+         * Turn on all debugging, to help understand what
+         * bits of the parser are running.
+         */
+        snmp_enable_stderrlog();
+        snmp_set_do_debugging(1);
+        debug_register_tokens("");
+    }
+    return 0;
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    size_t bytes_remaining = size;
+    netsnmp_pdu *pdu = SNMP_MALLOC_TYPEDEF(netsnmp_pdu);
+
+    snmp_pdu_parse(pdu, (unsigned char *)data, &bytes_remaining);
+    snmp_free_pdu(pdu);
+    return 0;
+}

--- a/fuzzing/snmp_scoped_pdu_parse_fuzzer.c
+++ b/fuzzing/snmp_scoped_pdu_parse_fuzzer.c
@@ -1,0 +1,56 @@
+ /*
+  * Copyright (c) 2021, Net-snmp authors
+  * All rights reserved.
+  *
+  * Redistribution and use in source and binary forms, with or without
+  * modification, are permitted provided that the following conditions are met:
+  *
+  * * Redistributions of source code must retain the above copyright notice, this
+  *   list of conditions and the following disclaimer.
+  *
+  * * Redistributions in binary form must reproduce the above copyright notice,
+  *   this list of conditions and the following disclaimer in the documentation
+  *   and/or other materials provided with the distribution.
+  *
+  * * Neither the name of the copyright holder nor the names of its
+  *   contributors may be used to endorse or promote products derived from
+  *   this software without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#include <net-snmp/net-snmp-config.h>
+#include <net-snmp/net-snmp-includes.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+int LLVMFuzzerInitialize(int *argc, char ***argv) {
+    if (getenv("NETSNMP_DEBUGGING") != NULL) {
+        /*
+         * Turn on all debugging, to help understand what
+         * bits of the parser are running.
+         */
+        snmp_enable_stderrlog();
+        snmp_set_do_debugging(1);
+        debug_register_tokens("");
+    }
+    return 0;
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    size_t bytes_remaining = size;
+    netsnmp_pdu *pdu = SNMP_MALLOC_TYPEDEF(netsnmp_pdu);
+
+    snmpv3_scopedPDU_parse(pdu, (unsigned char *)data, &bytes_remaining);
+    snmp_free_pdu(pdu);
+    return 0;
+}


### PR DESCRIPTION
Migrate fuzzers from the oss-fuzz repository to the net-snmp repository. We discussed this briefly over the mailing list and this PR in combination with the one in the oss-fuzz repo https://github.com/google/oss-fuzz/pull/6113 achieves it

I also made the build script in oss-fuzz more general such that we can simply add new fuzzers in the `fuzzing` directory in the net-snmp repository by having a `_fuzzer.c` suffix. 

@fenner @bvanassche 