### PR TITLE
Add ignoremount config option

### DIFF
--- a/agent/mibgroup/hardware/fsys/fsys_mntent.c
+++ b/agent/mibgroup/hardware/fsys/fsys_mntent.c
@@ -179,8 +179,7 @@ _fsys_type( char *typename )
 void
 netsnmp_fsys_arch_init( void )
 {
-    snmpd_register_config_handler("ignoremount", parse_mount_config,
-                                  free_mount_config, "name");
+    return;
 }
 
 #define ITEM_STRING	1
@@ -220,7 +219,7 @@ parse_mount_config(const char *token, char *cptr)
         config_perror("Missing NAME parameter");
         return;
     }
-    d_new = (conf_mount_list *) malloc(sizeof(conf_mount_list));
+    d_new = malloc(sizeof(conf_mount_list));
     if (!d_new) {
         config_perror("Out of memory");
         return;

--- a/agent/mibgroup/hardware/fsys/hw_fsys.c
+++ b/agent/mibgroup/hardware/fsys/hw_fsys.c
@@ -90,6 +90,9 @@ void init_hw_fsys( void ) {
         DEBUGMSGTL(("fsys", "Reloading Hardware FileSystems on-demand (%p)\n",
                                _fsys_cache));
     }
+
+    snmpd_register_config_handler("ignoremount", parse_mount_config,
+                                  free_mount_config, "name");
 }
 
 void shutdown_hw_fsys( void ) {


### PR DESCRIPTION
We monitor many hosts, but we want the ability to ignore certain mounts for a couple of reasons:

1) some mounts (such as backup mounts) will always be near 100%, but we do not care
2) some mounts are on systems which get so heavily used that snmpd will hang trying to check on their usage.  While this is obviously a problem we should solve (fix the storage system), having snmpd ignore them is a cheaper option

The attached patch adds an "ignoremount" option to snmpd.conf which can be used like so:
```
ignoremount /disk1
ignoremount /disk2
```
This makes the snmpd agent completely skip over the configured mounts for all mount related inquiries.  We have been dragging this patch along for a few years now, and would love to see it in upstream.