### PR TITLE
fuzzing: add new api fuzzer

### DIFF
--- a/include/net-snmp/ada_fuzz_header.h
+++ b/include/net-snmp/ada_fuzz_header.h
@@ -1,0 +1,119 @@
+/*
+  * Copyright (c) 2021, Net-snmp authors
+  * All rights reserved.
+  *
+  * Redistribution and use in source and binary forms, with or without
+  * modification, are permitted provided that the following conditions are met:
+  *
+  * * Redistributions of source code must retain the above copyright notice, this
+  *   list of conditions and the following disclaimer.
+  *
+  * * Redistributions in binary form must reproduce the above copyright notice,
+  *   this list of conditions and the following disclaimer in the documentation
+  *   and/or other materials provided with the distribution.
+  *
+  * * Neither the name of the copyright holder nor the names of its
+  *   contributors may be used to endorse or promote products derived from
+  *   this software without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+// Simple garbage collector 
+#define GB_SIZE 100
+
+void *pointer_arr[GB_SIZE];
+static int pointer_idx = 0;
+
+// If the garbage collector is used then this must be called as first thing
+// during a fuzz run.
+void af_gb_init() {
+  pointer_idx = 0;
+
+   for (int i = 0; i < GB_SIZE; i++) {
+     pointer_arr[i] = NULL;
+   }
+}
+
+void af_gb_cleanup() {
+  for(int i = 0; i < GB_SIZE; i++) {
+    if (pointer_arr[i] != NULL) {
+      free(pointer_arr[i]);
+    }
+  }
+}
+
+char *af_get_null_terminated(const uint8_t **data, size_t *size) {
+#define STR_SIZE 75
+  if (*size < STR_SIZE || (int)*size < 0) {
+    return NULL;
+  }
+
+  char *new_s = malloc(STR_SIZE + 1);
+  memcpy(new_s, *data, STR_SIZE);
+  new_s[STR_SIZE] = '\0';
+
+  *data = *data+STR_SIZE;
+  *size -= STR_SIZE;
+  return new_s;
+}
+
+char *af_gb_get_random_data(const uint8_t **data, size_t *size, size_t to_get) {
+  if (*size < to_get || (int)*size < 0) {
+    return NULL;
+  }
+
+  char *new_s = malloc(to_get);
+  memcpy(new_s, *data, to_get);
+
+  pointer_arr[pointer_idx++] = (void*)new_s;
+  
+  *data = *data + to_get;
+  *size -= to_get;
+
+  return new_s;
+}
+
+char *af_gb_get_null_terminated(const uint8_t **data, size_t *size) {
+
+  char *nstr = af_get_null_terminated(data, size);
+  if (nstr == NULL) {
+    return NULL;
+  }
+  pointer_arr[pointer_idx++] = (void*)nstr;
+  return nstr;
+}
+
+char *af_gb_alloc_data(size_t len) {
+  char *ptr = calloc(1, len);
+  pointer_arr[pointer_idx++] = (void*)ptr;
+  
+  return ptr;
+}
+
+short af_get_short(const uint8_t **data, size_t *size) {
+  if (*size <= 0) return 0;
+  short c = (short)(*data)[0];
+  *data += 1;
+  *size -= 1;
+  return c;
+}
+
+int af_get_int(const uint8_t **data, size_t *size) {
+  if (*size <= 4) return 0;
+  const uint8_t *ptr = *data;
+  int val = *((int*)ptr);
+  *data += 4;
+  *size -= 4;
+  return val;
+}
+// end simple garbage collector.

--- a/testing/fuzzing/snmp_api_fuzzer.c
+++ b/testing/fuzzing/snmp_api_fuzzer.c
@@ -1,0 +1,105 @@
+/*
+  * Copyright (c) 2021, Net-snmp authors
+  * All rights reserved.
+  *
+  * Redistribution and use in source and binary forms, with or without
+  * modification, are permitted provided that the following conditions are met:
+  *
+  * * Redistributions of source code must retain the above copyright notice, this
+  *   list of conditions and the following disclaimer.
+  *
+  * * Redistributions in binary form must reproduce the above copyright notice,
+  *   this list of conditions and the following disclaimer in the documentation
+  *   and/or other materials provided with the distribution.
+  *
+  * * Neither the name of the copyright holder nor the names of its
+  *   contributors may be used to endorse or promote products derived from
+  *   this software without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  */
+#include <net-snmp/net-snmp-config.h>
+#include <net-snmp/net-snmp-includes.h>
+/* We build with the agent/mibgroup/agentx dir in an -I */
+#include <protocol.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include <net-snmp/ada_fuzz_header.h>
+
+int LLVMFuzzerInitialize(int *argc, char ***argv) {
+    if (getenv("NETSNMP_DEBUGGING") != NULL) {
+        /*
+         * Turn on all debugging, to help understand what
+         * bits of the parser are running.
+         */
+        snmp_enable_stderrlog();
+        snmp_set_do_debugging(1);
+        debug_register_tokens("");
+    }
+    return 0;
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    af_gb_init();
+    uint8_t *data2 = data;
+    size_t size2 = size;
+
+    netsnmp_pdu *pdu = SNMP_MALLOC_TYPEDEF(netsnmp_pdu);
+    netsnmp_session session;
+
+    session.version = AGENTX_VERSION_1;
+    agentx_parse(&session, pdu, (unsigned char *)data, size);
+
+    // Add a variable with random type and value to the PDU
+    char *value = af_gb_get_random_data(&data2, &size2, 20);
+    if (value != NULL) {
+        value[19] = '\0';
+        oid name[] = {2, 1, 0};
+        int name_len = OID_LENGTH(name);
+        char c = (char)af_get_short(&data2, &size2);
+        snmp_add_var(pdu, name, name_len, c, value);
+    }
+
+    char *cp1 = af_gb_get_null_terminated(&data2, &size2);
+    if (cp1 != NULL) {
+        // Target snmp_pdu_build
+        size_t build_out_length = strlen(cp1);
+        snmp_pdu_build(pdu, cp1, &build_out_length);
+
+        // Target snmp_parse
+        char *parse_data = af_gb_get_null_terminated(&data2, &size2);
+        netsnmp_session sess = {};
+        memset(&sess, 0, sizeof(sess));
+        sess.version = af_get_int(&data2, &size2);
+        if (parse_data != NULL) {
+            size_t parse_data_len = strlen(parse_data);
+            snmp_parse(NULL, &sess, pdu, (unsigned char *)parse_data, parse_data_len);
+        }
+
+        // Target snmp_build
+        char *out_pkt = malloc(1000);
+        size_t pkt_len = 1000;
+        size_t offset = 0;
+        snmp_build(&out_pkt, &pkt_len, &offset, &sess, pdu);
+
+        // Target snmp utils
+        snmpv3_make_report(pdu, af_get_int(&data2, &size2));
+        snmpv3_get_report_type(pdu);
+        free(out_pkt);
+    }
+
+    snmp_free_pdu(pdu);
+    af_gb_cleanup();
+    return 0;
+}


### PR DESCRIPTION
@bvanassche this PR adds a new API fuzzer. The fuzzer relies on a small library that makes fuzzer-writing easier by taking care of extracting various data types, e.g. null-terminated strings, seeded with fuzzer input. The library is available here: https://github.com/AdaLogics/fuzz-headers and I use it to fuzz other important OSS projects, e.g. Apache-httpd, and soon also OpenVPN and more. I would be very happy to continue using that library for writing net-snmp fuzzers. However, I see that you are refining the infrastructure around building fuzzers so am not entirely sure where I should include downloading the small library (it's just a header file for now). Could you perhaps elaborate a bit on how you prefer to have the build scripts? I could also help with migrating the build scripts to the OSS-Fuzz infra as I am very familiar with that.