### PR TITLE
Fix deprecated retrans_time and base_reachable_time syscall warning

### DIFF
--- a/agent/mibgroup/if-mib/data_access/interface_linux.c
+++ b/agent/mibgroup/if-mib/data_access/interface_linux.c
@@ -308,7 +308,7 @@ _arch_interface_flags_v4_get(netsnmp_interface_entry *entry)
     snprintf(proc_path,  sizeof(proc_path),
              PROC_SYS_NET_IPVx_NEIGH_RETRANS_TIME_MS, 4, entry->name);
 
-    if ((stat(proc_path, &st) == 0)) {
+    if (stat(proc_path, &st) == 0) {
         proc_sys_retrans_time = PROC_SYS_NET_IPVx_NEIGH_RETRANS_TIME_MS;
         retrans_time_factor = 1;
     } else {
@@ -416,7 +416,7 @@ _arch_interface_flags_v6_get(netsnmp_interface_entry *entry)
     snprintf(proc_path,  sizeof(proc_path),
              PROC_SYS_NET_IPVx_NEIGH_RETRANS_TIME_MS, 6, entry->name);
 
-    if ((stat(proc_path, &st) == 0)) {
+    if (stat(proc_path, &st) == 0) {
         proc_sys_retrans_time = PROC_SYS_NET_IPVx_NEIGH_RETRANS_TIME_MS;
         retrans_time_factor = 1;
     } else {

--- a/ci/net-snmp-configure
+++ b/ci/net-snmp-configure
@@ -137,7 +137,7 @@ options=()
 options+=(--enable-developer)
 options+=(--enable-ipv6)
 options+=("--prefix=/usr/local/net-snmp-${branch_name}")
-options+=("--with-cflags=$cflags")
+options+=("--with-cflags=$CFLAGS")
 options+=(--with-defaults)
 transports=()
 # Mib names can be found as follows:

--- a/testing/fuzzing/build.sh
+++ b/testing/fuzzing/build.sh
@@ -3,18 +3,19 @@
 # Skip building the fuzz tests on OS/X and MinGW.
 [ "$(uname)" = Linux ] || exit 0
 
-# Skip building the fuzz tests if the oss-fuzz build infrastructure will be
-# used.
-[ -n "${LIB_FUZZING_ENGINE+x}" ] && exit 0
-
 scriptdir=$(cd "$(dirname "$0")" && pwd)
-CC=clang
-CXX=clang++
-CFLAGS="-Wall -Werror -fsanitize=fuzzer-no-link"
-CXXFLAGS="${CFLAGS} -lssl"
-WORK=${scriptdir}
-OUT=$WORK
-LIB_FUZZING_ENGINE="-fsanitize=fuzzer"
+
+# Only set environment variables if the oss-fuzz build infrastructure is not
+# used.
+if [ -z "${LIB_FUZZING_ENGINE+x}" ]; then
+    CC=clang
+    CXX=clang++
+    CFLAGS="-Wall -Werror -fsanitize=fuzzer-no-link"
+    CXXFLAGS="${CFLAGS} -lssl"
+    WORK=${scriptdir}
+    OUT=$WORK
+    LIB_FUZZING_ENGINE="-fsanitize=fuzzer"
+fi
 
 export CC CXX CFLAGS CXXFLAGS SRC WORK OUT LIB_FUZZING_ENGINE
 


### PR DESCRIPTION
Hi,

I ran into an issue that caused the following warning(s):

localhost kernel: ICMPv6: process 'snmp' is using deprecated sysctl (syscall) net.ipv6.neigh.bond0.retrans_time - use net.ipv6.neigh.bond0.retrans_time_ms instead

In our case, the snmp agent ran in a seperate network namespace, which does not have access to the "/proc/sys/net/ipv%d/neigh/default" network interface, which is currently used to determine if "reachable_time_ms" exists. By moving this check to where the actual "reachable_time_ms" value is read from a specific network interface. This issue is solved.

I noticed the same issue for "base_reachable_time" hence I fixed that in this pull request as well.

Kind Regards,

Eldin Zenderink