### PR TITLE
snmpd: always exit after displaying usage

### DIFF
--- a/agent/snmpd.c
+++ b/agent/snmpd.c
@@ -289,6 +289,8 @@ usage(char *prog)
            "  -S d|i|0-7\t\tuse -Ls <facility> instead\n"
            "\n"
            );
+    SOCK_CLEANUP;
+    exit(1);
 }
 
 static void
@@ -494,7 +496,6 @@ main(int argc, char *argv[])
         case '-':
             if (strcasecmp(optarg, "help") == 0) {
                 usage(argv[0]);
-                goto out;
             }
             if (strcasecmp(optarg, "version") == 0) {
                 version();
@@ -783,7 +784,6 @@ main(int argc, char *argv[])
             fprintf(stderr, "%s: Illegal argument -X:"
 		            "AgentX support not compiled in.\n", argv[0]);
             usage(argv[0]);
-            goto out;
 #endif
             break;
 


### PR DESCRIPTION
Currently, viewing the help text with `-h` results in `snmpd` being started in the background, whereas this does not happen with `--help`. Similarly, when an error is detected in command line syntax, the help text is displayed but sometimes `snmpd` gets started anyway, depending on the execution path.

This patch makes `snmpd` consistently terminate whenever the `usage` function gets called. It also removes the `break` and `goto` statements no longer needed.