### PR TITLE
Avoid openssl error ring memory segmentation fault (NETSNMP C API)

### DIFF
--- a/snmplib/transports/snmpTLSBaseDomain.c
+++ b/snmplib/transports/snmpTLSBaseDomain.c
@@ -1228,16 +1228,9 @@ void _openssl_log_error(int rc, SSL *con, const char *location) {
         /* if we have a text translation: */
         if (data && (flags & ERR_TXT_STRING)) {
             snmp_log(LOG_ERR, "  Textual Error: %s\n", data);
-            /*
-             * per openssl man page: If it has been allocated by
-             * OPENSSL_malloc(), *flags&ERR_TXT_MALLOCED is true.
-             *
-             * arggh... stupid openssl prototype for ERR_get_error_line_data
-             * wants a const char **, but returns something that we might
-             * need to free??
-             */
-            if (flags & ERR_TXT_MALLOCED)
-                OPENSSL_free(NETSNMP_REMOVE_CONST(void *, data));        }
+        }
+    /* clear openssl error ring buffer */
+    ERR_clear_error();
     }
     
     snmp_log(LOG_ERR, "---- End of OpenSSL Errors ----\n");

--- a/snmplib/transports/snmpTLSBaseDomain.c
+++ b/snmplib/transports/snmpTLSBaseDomain.c
@@ -1229,9 +1229,9 @@ void _openssl_log_error(int rc, SSL *con, const char *location) {
         if (data && (flags & ERR_TXT_STRING)) {
             snmp_log(LOG_ERR, "  Textual Error: %s\n", data);
         }
+    }
     /* clear openssl error ring buffer */
     ERR_clear_error();
-    }
-    
+
     snmp_log(LOG_ERR, "---- End of OpenSSL Errors ----\n");
 }


### PR DESCRIPTION
There is an invalid double OPENSSL_free in the openssl at the same memory address caused by snmpTLSBaseDomain.c.
(Target memory is used by openssl to manage an internal error ring).

Due to the release of the protected openssl memory in the netsnmp library it can happen that the memory is released twice at a later point in time and a crash occurs.

We found the problem especially when multiple TLS-based traps are sent over the NETSMP C API and the trap target is not reachable. 


code in openSSL(1.1.1l)
https://github.com/openssl/openssl/blob/master/crypto/err/err.c
```
#define err_clear_data(p, i) \
do { \
if ((p)->err_data_flags[i] & ERR_TXT_MALLOCED) {\
OPENSSL_free((p)->err_data[i]); \
(p)->err_data[i] = NULL; \
} \
(p)->err_data_flags[i] = 0; \
} while (0)
```
