### PR TITLE
snmpd: Fix memory allocation

### DIFF
--- a/agent/snmp_agent.c
+++ b/agent/snmp_agent.c
@@ -3771,7 +3771,9 @@ handle_pdu(netsnmp_agent_session *asp)
     case SNMP_MSG_INTERNAL_SET_RESERVE1:
 #endif /* NETSNMP_NO_WRITE_SUPPORT */
         asp->vbcount = count_varbinds(asp->pdu->variables);
-        asp->requests = calloc(asp->vbcount, sizeof(netsnmp_request_info));
+        asp->requests =
+            calloc(asp->vbcount ? asp->vbcount : 1,
+                   sizeof(netsnmp_request_info));
         /*
          * collect varbinds 
          */


### PR DESCRIPTION
Ensure memory allocation of more than 1 byte in case asp->vbcount is 0
Further clarification of this is found here:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=39901#c1

This also fixes
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=39930

Signed-off-by: David Korczynski <david@adalogics.com>