### PR TITLE
libsnmp: Fix a read-past-end-of-buffer

### DIFF
--- a/snmplib/mib.c
+++ b/snmplib/mib.c
@@ -5688,6 +5688,8 @@ _add_strings_to_oid(void *tp, char *cp,
                 objid[*objidlen] = *cp++;
                 (*objidlen)++;
             }
+            if (!*cp)
+                goto bad_id;
             cp2 = cp + 1;
             if (!*cp2)
                 cp2 = NULL;


### PR DESCRIPTION
Prevent that cp2 reads past end of the cp buffer. This patch fixes
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=36874

Signed-off-by: David Korczynski <david@adalogics.com>