### PR TITLE
libsnmp: Fix spurious buffer read

### DIFF
--- a/snmplib/snmp_api.c
+++ b/snmplib/snmp_api.c
@@ -7600,6 +7600,13 @@ snmp_add_var(netsnmp_pdu *pdu,
                 result = SNMPERR_MALLOC;
                 break;
             }
+            if (ix < 0 || ix >= buf_len) {
+               result = SNMPERR_RANGE;
+               snmp_set_detail(cp);
+               SNMP_FREE(buf);
+               SNMP_FREE(vp);
+               goto out;
+            }
             bit = 0x80 >> ltmp % 8;
             buf[ix] |= bit;
 	    


### PR DESCRIPTION
Ensure 'ix' is in range of 'buf' so the code 'buf[ix] |= bit;' is valid.
This fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=37564

Signed-off-by: David Korczynski <david@adalogics.com>