### PR TITLE
snmpd: Fix potential NULL-dereference

### DIFF
--- a/agent/snmp_agent.c
+++ b/agent/snmp_agent.c
@@ -570,7 +570,7 @@ get_set_cache(netsnmp_agent_session *asp)
              * yyy-rks: investigate when/why sometimes they match,
              * sometimes they don't.
              */
-            if(asp->requests->agent_req_info != asp->reqinfo) {
+            if(asp->requests && asp->requests->agent_req_info != asp->reqinfo) {
                 /*
                  * - one don't match case: agentx subagents. prev asp & reqinfo
                  *   freed, request reqinfo ptrs not cleared.


### PR DESCRIPTION
Ensure the code 'asp->requests->agent_req_info' will not dereference a
NULL pointer.

Fixes: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=40086

Signed-off-by: David Korczynski <david@adalogics.com>