### PR TITLE
libnsmp: Fix off-by-one read

### DIFF
--- a/snmplib/read_config.c
+++ b/snmplib/read_config.c
@@ -829,7 +829,7 @@ read_config(const char *filename,
 
             linelen += strlen(line + linelen);
 
-            if (line[linelen - 1] == '\n') {
+            if (linelen > 0 && line[linelen - 1] == '\n') {
               line[linelen - 1] = '\0';
               break;
             }


### PR DESCRIPTION
Prevent that the code 'line[linelen - 1]' reads a negative index.
This fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=36908

Signed-off-by: David Korczynski <david@adalogics.com>