### PR TITLE
testing/fuzzing: Fix size calculation

### DIFF
--- a/testing/fuzzing/snmp_config_mem_fuzzer.c
+++ b/testing/fuzzing/snmp_config_mem_fuzzer.c
@@ -56,7 +56,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     size--;
 
     // Allocate a large destination buffer
-    char *dst_buf = malloc((size*3) + 100);
+    char *dst_buf = malloc((size*sizeof(oid)));
     size_t len = size;
     
     char *src_buf = malloc(size+1);


### PR DESCRIPTION
Ensure output buffer is sized relative to sizeof(oid).

Signed-off-by: David Korczynski <david@adalogics.com>