### PR TITLE
libsnmp: Fix stack-based buffer overflow

### DIFF
--- a/snmplib/parse.c
+++ b/snmplib/parse.c
@@ -2262,7 +2262,7 @@ parse_ranges(FILE * fp, struct range_list **retp)
         rpp = &(*rpp)->next;
 
     } while (nexttype == BAR);
-    if (size) {
+    if (size && nexttype <= MAXTOKEN) {
         if (nexttype != RIGHTPAREN)
             print_error("Expected \")\" after SIZE", nexttoken, nexttype);
         nexttype = get_token(fp, nexttoken, nexttype);


### PR DESCRIPTION
Ensure the code `get_token(fp, nexttoken, nexttype);` does not have
nexttype larger than MAXTOKEN as otherwise nexttoken can overflow.

Fixes: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=37187

Signed-off-by: David Korczynski <david@adalogics.com>