### PR TITLE
libsnmp: Fix NULL-dereference

### DIFF
--- a/snmplib/parse.c
+++ b/snmplib/parse.c
@@ -1592,6 +1592,10 @@ do_subtree(struct tree *root, struct node **nodes)
         tp->number_modules = 1;
         tp->module_list = &(tp->modid);
         tree_from_node(tp, np);
+        if (!otp && !xxroot) {
+          free(tp);
+          return;
+        }
         tp->next_peer = otp ? otp->next_peer : xxroot->child_list;
         if (otp)
             otp->next_peer = tp;


### PR DESCRIPTION
Ensure no derefence occurs if both otp and xxroot are NULL.
Fixes: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=39072

Signed-off-by: David Korczynski <david@adalogics.com>