### PR TITLE
snmpd: fix possible NULL-dereference in debug message

### DIFF
--- a/agent/snmp_agent.c
+++ b/agent/snmp_agent.c
@@ -581,13 +581,15 @@ get_set_cache(netsnmp_agent_session *asp)
                             asp->reqinfo, asp->requests->agent_req_info));
                 for(; tmp; tmp = tmp->next)
                     tmp->agent_req_info = asp->reqinfo;
-            } else {
+            } else if (asp->requests) {
                 /*
                  * - match case: ?
                  */
                 DEBUGMSGTL(("verbose:asp",
                             "  reqinfo %p matches cached reqinfo %p\n",
                             asp->reqinfo, asp->requests->agent_req_info));
+            } else {
+                DEBUGMSGTL(("verbose:asp", "  asp->requests is NULL\n"));
             }
 
             SNMP_FREE(ptr);


### PR DESCRIPTION
This addresses Bart's comment here: https://github.com/net-snmp/net-snmp/pull/358#issuecomment-949642525