### PR TITLE
libsnmp: Fix stack-based buffer overflow

### DIFF
--- a/snmplib/parse.c
+++ b/snmplib/parse.c
@@ -3447,6 +3447,10 @@ check_utc(const char *utc)
     int             len, year, month, day, hour, minute;
 
     len = strlen(utc);
+    if (len == 0) {
+        print_error("Timestamp has zero length", utc, QUOTESTRING);
+        return;
+    }
     if (utc[len - 1] != 'Z' && utc[len - 1] != 'z') {
         print_error("Timestamp should end with Z", utc, QUOTESTRING);
         return;


### PR DESCRIPTION
Ensure len is above 0 before the code 'utc[len - 1]'.
Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=40508

Signed-off-by: David Korczynski <david@adalogics.com>