### PR TITLE
snmpd: Ensure contextNameLen follows buffer size

### DIFF
--- a/agent/mibgroup/agentx/protocol.c
+++ b/agent/mibgroup/agentx/protocol.c
@@ -1643,6 +1643,11 @@ agentx_parse(netsnmp_session * session, netsnmp_pdu *pdu, u_char * data,
          * expects to find the context in the PDU's context field.  Therefore we
          * need to copy the context into the PDU's context fields.  */
         if (pdu->community_len > 0 && pdu->contextName == NULL) {
+            /*
+             * strlen() is safe here because snmp_clone_mem() '\0'-terminates its output
+             */
+            if (strlen(pdu->community) != pdu->community_len)
+                goto parse_err;
             pdu->contextName    = strdup((char *) pdu->community);
             pdu->contextNameLen = pdu->community_len;
         }


### PR DESCRIPTION
Ensure strlen is equal to community_len before the code
  ```
  pdu->contextName    = strdup((char *) pdu->community);
  pdu->contextNameLen = pdu->community_len;
  ```

This ensures `contextNameLen` is not above the size of the buffer returned by `strdup`.
Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=40431

Signed-off-by: David Korczynski <david@adalogics.com>