### PR TITLE
testing/fuzzing: Add transport fuzzer

### DIFF
--- a/testing/fuzzing/build.sh
+++ b/testing/fuzzing/build.sh
@@ -20,7 +20,17 @@ if [ -z "${LIB_FUZZING_ENGINE+x}" ]; then
 	echo "Skipping compilation of fuzz tests"
 	exit 0
     fi
+else
+  # Handle OSS-Specific actions.
+  # Some fuzzers will leak memory. Surpress leak checking on these as
+  # ASAN will report leaks instantly and exit the fuzzing process.
+  # The goal is to prioritise more important bugs for now.
+  for fuzzer in transport mib agent_e2e api; do
+    echo "[libfuzzer]" > $OUT/snmp_${fuzzer}_fuzzer.options
+    echo "detect_leaks=0" >> $OUT/snmp_${fuzzer}_fuzzer.options
+  done
 fi
+
 
 export CC CXX CFLAGS CXXFLAGS SRC WORK OUT LIB_FUZZING_ENGINE
 

--- a/testing/fuzzing/snmp_transport_fuzzer.c
+++ b/testing/fuzzing/snmp_transport_fuzzer.c
@@ -1,0 +1,136 @@
+ /*
+  * Copyright (c) 2021, Net-snmp authors
+  * All rights reserved.
+  *
+  * Redistribution and use in source and binary forms, with or without
+  * modification, are permitted provided that the following conditions are met:
+  *
+  * * Redistributions of source code must retain the above copyright notice, this
+  *   list of conditions and the following disclaimer.
+  *
+  * * Redistributions in binary form must reproduce the above copyright notice,
+  *   this list of conditions and the following disclaimer in the documentation
+  *   and/or other materials provided with the distribution.
+  *
+  * * Neither the name of the copyright holder nor the names of its
+  *   contributors may be used to endorse or promote products derived from
+  *   this software without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  */
+#include <net-snmp/net-snmp-config.h>
+#include <net-snmp/net-snmp-includes.h>
+#include <net-snmp/library/snmpIPBaseDomain.h>
+#include <net-snmp/library/snmpUDPIPv6Domain.h>
+#include <net-snmp/library/snmpIPXDomain.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include "ada_fuzz_header.h"
+
+int
+LLVMFuzzerInitialize(int *argc, char ***argv)
+{
+    if (getenv("NETSNMP_DEBUGGING") != NULL) {
+        /*
+         * Turn on all debugging, to help understand what
+         * bits of the parser are running.
+         */
+        snmp_enable_stderrlog();
+        snmp_set_do_debugging(1);
+        debug_register_tokens("");
+    }
+    return 0;
+}
+
+int
+LLVMFuzzerTestOneInput(const uint8_t * data, size_t size)
+{
+    /*
+     * Force the fuzzer to create larger strings as we use
+     * a lot of the data.
+     */
+    if (size < 550) {
+        return 0;
+    }
+    af_gb_init();
+
+    const uint8_t  *data2 = data;
+    size_t          size2 = size;
+
+    netsnmp_ds_set_string(NETSNMP_DS_LIBRARY_ID, NETSNMP_DS_LIB_APPTYPE,
+                          "testprog");
+
+    init_snmp_transport();
+    netsnmp_tdomain_init();
+
+    /*
+     * Main fuzzing logic
+     */
+    char           *app = af_gb_get_null_terminated(&data2, &size2);
+    char           *str = af_gb_get_null_terminated(&data2, &size2);
+    char           *default_domain =
+        af_gb_get_null_terminated(&data2, &size2);
+    char           *default_target =
+        af_gb_get_null_terminated(&data2, &size2);
+
+    if (app && str && default_domain && default_target) {
+        netsnmp_tdomain_transport_full(app, str, 0, default_domain,
+                                       default_target);
+    }
+
+    char           *prefix = af_gb_get_null_terminated(&data2, &size2);
+    char           *fmt_data = af_gb_get_null_terminated(&data2, &size2);
+    netsnmp_transport *t2 = NULL;
+    if (prefix && fmt_data) {
+        netsnmp_ipv6_fmtaddr(prefix, t2, fmt_data, strlen(fmt_data));
+
+        struct sockaddr_in6 addr;
+        netsnmp_sockaddr_in6(&addr, prefix, 5123);
+    }
+
+    /*
+     * Security parsing routines.
+     */
+    char           *udp6_token = af_gb_get_null_terminated(&data2, &size2);
+    char           *udp6_param = af_gb_get_null_terminated(&data2, &size2);
+    if (udp6_token && udp6_param) {
+        netsnmp_udp6_parse_security(udp6_token, udp6_param);
+    }
+
+    char           *udp_token = af_gb_get_null_terminated(&data2, &size2);
+    char           *udp_param = af_gb_get_null_terminated(&data2, &size2);
+    if (udp_token && udp_param) {
+        netsnmp_udp_parse_security(udp_token, udp_param);
+    }
+
+    struct netsnmp_ep_str ep_str;
+    char           *endpoint = af_gb_get_null_terminated(&data2, &size2);
+    if (endpoint) {
+        netsnmp_parse_ep_str(&ep_str, endpoint);
+    }
+
+    char           *unix_token = af_gb_get_null_terminated(&data2, &size2);
+    char           *unix_param = af_gb_get_null_terminated(&data2, &size2);
+    if (unix_token && unix_param) {
+        netsnmp_unix_parse_security(unix_token, unix_param);
+    }
+
+    /*
+     * Cleanup
+     */
+    netsnmp_clear_tdomain_list();
+    shutdown_snmp_transport();
+
+    af_gb_cleanup();
+    return 0;
+}


### PR DESCRIPTION
Add transport fuzzer which was previously removed because it used
undeclared functions (https://github.com/net-snmp/net-snmp/pull/366).

Signed-off-by: David Korczynski <david@adalogics.com>