### PR TITLE
testing/fuzzing: Fix cast to avoid compiler warning

### DIFF
--- a/testing/fuzzing/agentx_parse_fuzzer.c
+++ b/testing/fuzzing/agentx_parse_fuzzer.c
@@ -53,7 +53,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     netsnmp_session session;
 
     session.version = AGENTX_VERSION_1;
-    if (agentx_parse(&session, pdu, (unsigned char *)data, size) == SNMP_ERR_NOERROR) {
+    if (agentx_parse(&session, pdu, NETSNMP_REMOVE_CONST(u_char*, data), size) ==
+        SNMP_ERR_NOERROR) {
       u_char *buf = malloc(size);
       memcpy(buf, data, size);
       size_t buf_len = size;


### PR DESCRIPTION
Signed-off-by: David Korczynski <david@adalogics.com>