### PR TITLE
libsnmp: Fix stack-based buffer underflow

### DIFF
--- a/snmplib/parse.c
+++ b/snmplib/parse.c
@@ -2716,6 +2716,15 @@ parse_objecttype(FILE * fp, char *name)
                     return NULL;
                 }
 
+                /*
+                 * Ensure strlen(defbuf) is above zero
+                 */
+                if (strlen(defbuf) == 0) {
+                    print_error("Bad DEFAULTVALUE", quoted_string_buffer,
+                                type);
+                    free_node(np);
+                    return NULL;
+                }
                 defbuf[strlen(defbuf) - 1] = 0;
                 np->defaultValue = strdup(defbuf);
             }


### PR DESCRIPTION
Ensure `strlen(defbuf)` is above zero before the code
`defbuf[strlen(defbuf) - 1] = 0;`
Fixes: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=40699

Signed-off-by: David Korczynski <david@adalogics.com>