### PR TITLE
[TSM] TLS TCP Support the configuration of min/max tls version

### DIFF
--- a/include/net-snmp/library/default_store.h
+++ b/include/net-snmp/library/default_store.h
@@ -4,7 +4,7 @@
  */
 /*
  * Portions of this file are copyrighted by:
- * Copyright © 2003 Sun Microsystems, Inc. All rights reserved.
+ * Copyright Â© 2003 Sun Microsystems, Inc. All rights reserved.
  * Use is subject to license terms specified in the COPYING file
  * distributed with the Net-SNMP package.
  *
@@ -183,6 +183,8 @@ extern          "C" {
 #define NETSNMP_DS_LIB_SSH_PUBKEY        33
 #define NETSNMP_DS_LIB_SSH_PRIVKEY       34
 #define NETSNMP_DS_LIB_OUTPUT_PRECISION  35
+#define NETSNMP_DS_LIB_TLS_MIN_VERSION   36
+#define NETSNMP_DS_LIB_TLS_MAX_VERSION   37
 #define NETSNMP_DS_LIB_MAX_STR_ID        48 /* match NETSNMP_DS_MAX_SUBIDS */
 
     /*

--- a/man/snmpd.conf.5.def
+++ b/man/snmpd.conf.5.def
@@ -203,6 +203,12 @@ HIGH:!AES128\-SHA
 .RE
 .IP
 The default value is whatever openssl itself was configured with.
+.IP "tlsMinVersion STRING"
+The function sets the minimum supported TLS protocol version. 
+OPTION can be one of < tls1 | tls1_1| tls1_2 | tls1_3 >.
+.IP "tlsMaxVersion STRING"
+The function sets the maximum supported TLS protocol version. 
+OPTION can be one of < tls1 | tls1_1| tls1_2 | tls1_3 >.
 .IP "[snmp] x509CRLFile"
 If you are using a Certificate Authority (CA) that publishes a
 Certificate Revocation List (CRL) then this token can be used to

--- a/snmplib/transports/snmpTLSTCPDomain.c
+++ b/snmplib/transports/snmpTLSTCPDomain.c
@@ -719,10 +719,6 @@ netsnmp_tlstcp_open_client(netsnmp_transport *t)
         return NULL;
     }
 
-#ifdef SSL_CTX_set_max_proto_version
-    SSL_CTX_set_max_proto_version(tlsdata->ssl_context, TLS1_VERSION);
-#endif
-
     /* RFC5953 Section 5.3.1:  Establishing a Session as a Client
        3)  Using the destTransportDomain and destTransportAddress values,
        the client will initiate the (D)TLS handshake protocol to
@@ -919,10 +915,6 @@ netsnmp_tlstcp_open_server(netsnmp_transport *t)
 
     /* create the OpenSSL TLS context */
     tlsdata->ssl_context = sslctx_server_setup(TLS_method());
-#ifdef SSL_CTX_set_max_proto_version
-    if (tlsdata->ssl_context)
-        SSL_CTX_set_max_proto_version(tlsdata->ssl_context, TLS1_VERSION);
-#endif
 
     t->sock = BIO_get_fd(tlsdata->accept_bio, NULL);
     t->flags |= NETSNMP_TRANSPORT_FLAG_LISTEN;


### PR DESCRIPTION
Until now, it has been limited to TLS1.0, which is no longer considered secure. I have also increased default minimum configuration to TLS1_2

Format for configuration options (tls1 | tls1_1| tls1_2 | tls1_3) similar to openssl s_client command

