### PR TITLE
Fix netsnmp_request_set_error_idx function to point the indicated varbind.

### DIFF
--- a/agent/snmp_agent.c
+++ b/agent/snmp_agent.c
@@ -4017,7 +4017,7 @@ netsnmp_request_set_error_idx(netsnmp_request_info *request,
     /*
      * Skip to the indicated varbind
      */
-    for ( i=2; i<idx; i++) {
+    for ( i=2; i<=idx; i++) {
         req = req->next;
         if (!req)
             return SNMPERR_NO_VARS;


### PR DESCRIPTION
Description - Funciton netsnmp_request_set_error_idx which is used to set the error status of the varbind which caused error response is not pointing to correct varbind.

Example - Consider the value of idx (pdu->errindex) to be 3, then the for loop conditions will make req pointer to point to position 2, hence request at position 2 will be marked with error_value(pdu->errstat).

Fix - changed  'i<idx' to 'i<=idx' to point to indicated varbind.