### PR TITLE
Net-snmp(version 1) returns wrong value error-index in SNMP when used as proxy pass

### DIFF
--- a/agent/snmp_agent.c
+++ b/agent/snmp_agent.c
@@ -1989,7 +1989,7 @@ netsnmp_wrap_up_request(netsnmp_agent_session *asp, int status)
 #ifndef NETSNMP_NO_WRITE_SUPPORT
             (asp->pdu->command != SNMP_MSG_SET) &&
 #endif /* NETSNMP_NO_WRITE_SUPPORT */
-            (asp->pdu->version == SNMP_VERSION_1)) {
+            (asp->pdu->version == SNMP_VERSION_1) && asp->index < 1) {
             netsnmp_variable_list *var_ptr = asp->pdu->variables;
             int                    i = 1;
 
@@ -2007,6 +2007,11 @@ netsnmp_wrap_up_request(netsnmp_agent_session *asp, int status)
                 var_ptr = var_ptr->next_variable;
                 ++i;
             }
+        }
+        
+        else
+        {
+          status = asp->status ;
         }
 #endif /* snmpv1 support */
 
@@ -4017,7 +4022,7 @@ netsnmp_request_set_error_idx(netsnmp_request_info *request,
     /*
      * Skip to the indicated varbind
      */
-    for ( i=2; i<idx; i++) {
+    for ( i=2; i<=idx; i++) {
         req = req->next;
         if (!req)
             return SNMPERR_NO_VARS;


### PR DESCRIPTION
Issue 1 :
-------------------------------------------------------------------------------------------------------
Description - In net-snmp(version 1), the value of errorindex is always getting set to the position of 
last OID variable instead of pointing to the proper variable which caused the error response.

Test case:-
 
$ snmpget -v1 -c cmty_remotehost1 localhost SNMPv2-MIB::sysName.1 SNMPv2-MIB::sysDescr.0 SNMPv2-MIB::sysObjectID.0
Error in packet
Reason: (noSuchName) There is no such variable name in this MIB.
Failed object: SNMPv2-MIB::sysObjectID.0

Error in packet
Reason: (noSuchName) There is no such variable name in this MIB.
Failed object: SNMPv2-MIB::sysDescr.0

Error in packet
Reason: (noSuchName) There is no such variable name in this MIB.
Failed object: SNMPv2-MIB::sysName.1

In the above command "SNMPv2-MIB::sysName.1" is the incorrect OID but "sysObjectID.0"( last variable ) is marked
as incorrect , and eventually all variables are marked incorrect in subsequent requests.

The above behaviour is occuring only in v1 proxy mode.

Cause - netsnmp_wrap_up_request has asp->pdu->variables->type set as 129 (nosuchinstance) for all
the requested variables when response is received by proxy. 'While loop' inside netsnmp_wrap_up_request
function marks every variable incorrect incrementally and ends up setting errorindex as the position
of last variable.

Fix - When response is received by proxy, the function netsnmp_request_set_error_idx sets the 
request->status = error_value to the request( variable ) which caused error response.
The corresponding request->index(position of variable) is assigned as asp->index, which is passed to netsnmp_wrap_up_request.
When asp->index > 0 , skip the while loop as we already have position of the incorrect variable
as asp->index.

Issue 2
----------------------------------------------------------------------------------------------------------
Fix netsnmp_request_set_error_idx function to point to indicated varbind.

Description - Funciton netsnmp_request_set_error_idx which is used to set the error status of
the varbind which caused error response is not pointing to correct varbind.
Example - Consider the value of idx (pdu->errindex) to be 3, then the for loop conditions will make req
pointer to point to position 2, hence request at position 2 will be marked with error_value(pdu->errstat).

Fix - changed  'i<idx' to 'i<=idx' to point to indicated varbind.
