### PR TITLE
net-snmp-create-v3-user: fix directory variable references

### DIFF
--- a/net-snmp-create-v3-user.in
+++ b/net-snmp-create-v3-user.in
@@ -134,8 +134,12 @@ if test ! -d "$outfile"; then
     touch "$outfile"
 fi
 echo "$line" >> "$outfile"
-# Avoid that configure complains that this script ignores @datarootdir@
-echo "@datarootdir@" >/dev/null
+prefix="@prefix@"
+datarootdir="@datarootdir@"
+# Avoid that shellcheck complains about unused variables.
+# The data directory (@datadir@) may contain references
+# to these variables.
+: "${prefix}" "${datarootdir}"
 outfile="@datadir@/snmp/snmpd.conf"
 line="$token $user"
 echo "adding the following line to $outfile:"


### PR DESCRIPTION
With the default configure directories, the net-snmp-create-v3-user tries to write to `${datarootdir}/snmp/snmpd.conf` without setting `datarootdir` thus in essence it tries to write to `/snmp/snmpd.conf` which usually does not exist.

This patch fixes the problem by setting `datarootdir` and `prefix` (the default `datarootdir` is `${prefix}/share` thus `prefix` must be set too).