### PR TITLE
Fix for Solaris ifHighSpeed issue

### DIFF
--- a/agent/mibgroup/if-mib/data_access/interface_solaris2.c
+++ b/agent/mibgroup/if-mib/data_access/interface_solaris2.c
@@ -121,7 +121,7 @@ netsnmp_arch_interface_container_load(netsnmp_container* container,
         entry->type = ife.ifType;
         entry->mtu = ife.ifMtu;
         entry->speed = ife.ifSpeed;
-        entry->speed_high = entry->speed / 1000000;
+        entry->speed_high = ife.ifHighSpeed;
         entry->ns_flags |= NETSNMP_INTERFACE_FLAGS_HAS_HIGH_SPEED;
         entry->oper_status = ife.ifOperStatus;
         entry->admin_status = ife.ifAdminStatus;

--- a/agent/mibgroup/kernel_sunos5.c
+++ b/agent/mibgroup/kernel_sunos5.c
@@ -4,7 +4,7 @@
  */
 /*
  * Portions of this file are copyrighted by:
- * Copyright © 2003 Sun Microsystems, Inc. All rights reserved.
+ * Copyright Â© 2003 Sun Microsystems, Inc. All rights reserved.
  * Use is subject to license terms specified in the COPYING file
  * distributed with the Net-SNMP package.
  */
@@ -1626,6 +1626,7 @@ set_if_info(mib2_ifEntry_t *ifp, unsigned index, char *name, uint64_t flags,
             int mtu)
 { 
     boolean_t havespeed = B_FALSE;
+    uint64_t ifspeed = 0;
 
     /*
      * Set basic information 
@@ -1643,7 +1644,7 @@ set_if_info(mib2_ifEntry_t *ifp, unsigned index, char *name, uint64_t flags,
     /*
      * Get link speed
      */
-    if ((getKstatInt(NULL, name, "ifspeed", &ifp->ifSpeed) == 0)) {
+    if ((getKstat(name, "ifspeed", &ifspeed) == 0)) {
         /*
          * check for SunOS patch with half implemented ifSpeed 
          */
@@ -1651,14 +1652,19 @@ set_if_info(mib2_ifEntry_t *ifp, unsigned index, char *name, uint64_t flags,
             ifp->ifSpeed *= 1000000;
         }
 	havespeed = B_TRUE;
-    } else if (getKstatInt(NULL, name, "ifSpeed", &ifp->ifSpeed) == 0) {
+    } else if (getKstat(name, "ifSpeed", &ifspeed) == 0) {
         /*
          * this is good 
          */
 	havespeed = B_TRUE;
-    } else if (getKstatInt("link", name, "ifspeed", &ifp->ifSpeed) == 0) {
-	havespeed = B_TRUE;
     }
+	
+    if (ifspeed > 0xffffffff) {
+        ifp->ifSpeed = 0xffffffff;
+    } else {
+        ifp->ifSpeed = ifspeed;
+    }
+    ifp->ifHighSpeed = ifspeed / 1000000;
 
     /* make ifOperStatus depend on link status if available */
     if (ifp->ifAdminStatus == 1) {

--- a/agent/mibgroup/kernel_sunos5.h
+++ b/agent/mibgroup/kernel_sunos5.h
@@ -166,6 +166,8 @@ typedef struct mib2_ifEntry {
      */
     int             ifCollisions;
     int             flags;           /* interface flags (IFF_*) */
+	
+    Gauge ifHighSpeed;
 } mib2_ifEntry_t;
 
 /*-


### PR DESCRIPTION
The ifHighSpeed value is not being fetched correctly for Solaris systems as seen in the following output

For a 10Gbps interface, we see
# snmpwalk -v 2c -c public localhost ifdescr
IF-MIB::ifDescr.2 = STRING: net0
#

# snmpwalk -v 2c -c public localhost ifspeed
IF-MIB::ifSpeed.2 = Gauge32: 1410065408
#

# snmpwalk -v 2c -c public localhost ifHighSpeed
IF-MIB::ifHighSpeed.1 = Gauge32: 127
IF-MIB::ifHighSpeed.2 = Gauge32: 1410  

# dladm show-phys -Z
LINK            ZONE      MEDIA         STATE      SPEED  DUPLEX    DEVICE
net0            global    Ethernet      up         10000  full      ixgbe0

# kstat -p|grep speed
....
ixgbe:0:phys:ifspeed    10000000000   //10Gbps
..

The expected output is  10000000000 expressed in Mbps, i.e 10000
IF-MIB::ifSpeed.2 = Gauge32: 10000

The issue occurs as we are using an integer(Gauge) type to fetch the ifspeed value and simply convert it into Mbps for the ifHighSpeed value, which will fail for speeds  > INT_MAX-1. 

From the net-snmp documentation at http://www.net-snmp.org/docs/mibs/interfaces.html
"An estimate of the interface's current bandwidth in bits per second.  For interfaces which do not vary in bandwidth
or for those where no accurate estimation can be made, this object should contain the nominal bandwidth.  If the
bandwidth of the interface is greater than the maximum value reportable by this object then this object should report its
maximum value (4,294,967,295) and ifHighSpeed must be used to report the interace's speed.  For a sub-layer which has
no concept of bandwidth, this object should be zero.
"

The fix will use a uint64 type for storing the ifspeed value, and will display the ifspeed value as per the docs.

Here's the output after applying the fix
# snmpwalk -c public -v 2c localhost ifSpeed
IF-MIB::ifSpeed.2 = Gauge32: 4294967295

# snmpwalk -c public -v 2c localhost ifHighSpeed
IF-MIB::ifHighSpeed.2 = Gauge32: 10000

