### PR TITLE
don't try to install factory.h

### DIFF
--- a/snmplib/Makefile.in
+++ b/snmplib/Makefile.in
@@ -56,7 +56,6 @@ INCLUDESUBDIRHEADERS=README \
 	data_list.h \
 	default_store.h \
 	dir_utils.h \
-	factory.h \
 	fd_event_manager.h \
 	file_utils.h \
 	getopt.h \


### PR DESCRIPTION
87d45755edd made factory.h a private header, but snmplib/Makefile.in
continues to try to install it from include/net-snmp/library, resulting
in an error from "make install".

I'm a bit surprised to run into this, so maybe I'm missing something though...