### PR TITLE
Add ignoremount config option v2

### DIFF
--- a/agent/mibgroup/hardware/fsys/hw_fsys.c
+++ b/agent/mibgroup/hardware/fsys/hw_fsys.c
@@ -9,6 +9,12 @@
 #ifdef HAVE_INTTYPES_H
 #include <inttypes.h>
 #endif
+#if defined(HAVE_PCRE_H)
+#include <pcre.h>
+#elif defined(HAVE_REGEX_H)
+#include <sys/types.h>
+#include <regex.h>
+#endif
 
 netsnmp_feature_child_of(hw_fsys_get_container, netsnmp_unused);
 
@@ -21,6 +27,10 @@ static netsnmp_cache     *_fsys_cache;
 static netsnmp_container *_fsys_container;
 static int         _fsys_idx;
 
+static void _parse_mount_config(const char *, char *);
+static void _free_mount_config(void);
+
+conf_mount_list *ignoremount_list;
 
 /*
  * Architecture-independent processing of loading filesystem statistics
@@ -93,6 +103,9 @@ void init_hw_fsys( void ) {
         DEBUGMSGTL(("fsys", "Reloading Hardware FileSystems on-demand (%p)\n",
                                _fsys_cache));
     }
+
+    snmpd_register_config_handler("ignoremount", _parse_mount_config,
+                                  _free_mount_config, "name");
 }
 
 void shutdown_hw_fsys( void ) {
@@ -340,4 +353,103 @@ netsnmp_fsys_calculate32(netsnmp_fsys_info *f)
                 " used %" PRIu64 " -> %lu\n",
 		(uint64_t)f->size, f->size_32, (uint64_t)f->units, f->units_32,
 		(uint64_t)f->avail, f->avail_32, (uint64_t)f->used, f->used_32));
+}
+
+static void
+_parse_mount_config(const char *token, char *cptr)
+{
+    conf_mount_list *m_new;
+    char            *name, *st = NULL;
+#if defined(HAVE_PCRE_H)
+    const char      *pcre_error;
+    int             pcre_error_offset;
+    int             is_regex = 0;
+#elif defined(HAVE_REGEX_H)
+    int             r = 0;
+    int             is_regex = 0;
+#endif
+
+    name = strtok_r(cptr, " \t", &st);
+    if (strcmp(name, "-r") == 0) {
+#if defined(HAVE_PCRE_H) || defined(HAVE_REGEX_H)
+        is_regex = 1;
+        name = strtok_r(NULL, " \t", &st);
+#else
+        config_perror("Missing regex support");
+        return;
+#endif
+    }
+    if (!name) {
+        config_perror("Missing mount parameter");
+        return;
+    }
+    m_new = SNMP_MALLOC_TYPEDEF(conf_mount_list);
+    if (!m_new) {
+        config_perror("Out of memory");
+        goto err;
+    }
+    m_new->name = strdup(name);
+    if (!m_new->name) {
+        config_perror("Out of memory");
+        goto err;
+    }
+#if defined(HAVE_PCRE_H)
+    if (is_regex) {
+        m_new->regex_ptr = pcre_compile(m_new->name, 0, &pcre_error,
+                                        &pcre_error_offset, NULL);
+        if (!m_new->regex_ptr) {
+            config_perror(pcre_error);
+            goto err;
+        }
+    }
+#elif defined(HAVE_REGEX_H)
+    if (is_regex) {
+        m_new->regex_ptr = malloc(sizeof(regex_t));
+        if (!m_new->regex_ptr) {
+            config_perror("Out of memory");
+            goto err;
+        }
+        r = regcomp(m_new->regex_ptr, m_new->name, REG_NOSUB);
+        if (r) {
+            char buf[BUFSIZ];
+            size_t regerror_len = 0;
+
+            regerror_len = regerror(r, m_new->regex_ptr, buf, BUFSIZ);
+            if (regerror_len >= BUFSIZ)
+                buf[BUFSIZ - 1] = '\0';
+            else
+                buf[regerror_len] = '\0';
+            config_perror(buf);
+            goto err;
+        }
+    }
+#endif
+    m_new->next = ignoremount_list;
+    ignoremount_list = m_new;
+    return;
+
+err:
+    if (m_new) {
+#if defined(HAVE_PCRE_H) || defined(HAVE_REGEX_H)
+        free(m_new->regex_ptr);
+#endif
+        free(m_new->name);
+    }
+    free (m_new);
+}
+
+static void
+_free_mount_config(void)
+{
+    conf_mount_list *m_ptr = ignoremount_list, *m_next;
+    while (m_ptr) {
+        m_next = m_ptr->next;
+#if defined(HAVE_PCRE_H) || defined(HAVE_REGEX_H)
+        free(m_ptr->regex_ptr);
+#endif
+        free(m_ptr->name);
+        free(m_ptr);
+        m_ptr = m_next;
+    }
+    ignoremount_list = NULL;
 }

--- a/agent/mibgroup/hardware/fsys/hw_fsys.h
+++ b/agent/mibgroup/hardware/fsys/hw_fsys.h
@@ -1,2 +1,19 @@
+#if defined(HAVE_PCRE_H)
+#include <pcre.h>
+#elif defined(HAVE_REGEX_H)
+#include <sys/types.h>
+#include <regex.h>
+#endif
+
 void init_hw_fsys(void);
 void shutdown_hw_fsys( void );
+
+typedef struct _conf_mount_list {
+#if defined(HAVE_PCRE_H)
+    pcre                    *regex_ptr;
+#elif defined(HAVE_REGEX_H)
+    regex_t                 *regex_ptr;
+#endif
+    char                    *name;
+    struct _conf_mount_list *next;
+} conf_mount_list;

--- a/man/snmpd.conf.5.def
+++ b/man/snmpd.conf.5.def
@@ -614,11 +614,24 @@ to determine the list of devices that will be scanned.
 .IP
 The pattern can include one or more wildcard expressions.
 See \fIsnmpd.examples(5)\fR for illustration of the wildcard syntax.
+.IP "ignoremount [-r] STRING"
+controls which mounts should be omitted from the hrStorageTable.
+If the Net-SNMP agent gets hung on accessing a filesystem, or the
+filesystem is always mostly full (and thus leads to spurious alerts),
+you can omit it by listing the full path in this directive.
+.RE
+.IP
+If the "-r" option is provided, the pattern can include one or more
+regular expressions.
 .IP "skipNFSInHostResources true"
 controls whether NFS and NFS-like file systems should be omitted
 from the hrStorageTable (true or 1) or not (false or 0, which is the default).
 If the Net-SNMP agent gets hung on NFS-mounted filesystems, you
 can try setting this to '1'.
+.RE
+.IP
+Alternately, more granular control over which mounts should be omitted
+from the hrStorageTable can be achieved via the \fIignoremount\fR directive.
 .IP "storageUseNFS [1|2]"
 controls how NFS and NFS-like file systems should be reported
 in the hrStorageTable.


### PR DESCRIPTION
As was attempted before (https://github.com/net-snmp/net-snmp/pull/324), I would like to add the "ignoremount" option we have been using for a few years into upstream.

We monitor many hosts, but we want the ability to ignore certain mounts for a couple of reasons:

  1. Some mounts (such as backup mounts) will always be near 100%, but we do not care.  Ignoring them in net-snmp is easier than in our monitoring system
  2. Some mounts are on systems which get so heavily used that snmpd will hang trying to check on their usage. While this is obviously a problem we should solve (fix the storage system), having snmpd ignore them is a cheaper option

The attached patch adds an "ignoremount" option to snmpd.conf which can be used like so:

ignoremount /mnt/foo
ignoremount /var/bar
ignoremount -r /var/backup/big[1-4]

This makes the snmpd agent completely skip over the configured mounts for all statistic related inquiries - they show as 0% used instead.

Changes from v1:
* Added regex and pcre support
* Moved config option parsing into generic code
* Updated manpage

Please pull, thanks.