### PR TITLE
Add virtiofs to other_fs

### DIFF
--- a/agent/mibgroup/hardware/fsys/fsys_mntent.c
+++ b/agent/mibgroup/hardware/fsys/fsys_mntent.c
@@ -83,6 +83,7 @@ static const char *other_fs[] = {
     "reiserfs",
     "simfs",
     "tmpfs",
+    "virtiofs",
     "vxfs",
     "xfs",
     "zfs",


### PR DESCRIPTION
virtiofs is a relatively new virtual filesystem. At present, it is misdetected by net-snmp and needs to be added to the other_fs array.
