### PR TITLE
libsnmp: Set Linux VRF iface on Trap sink IP addresses for TCP transport

### DIFF
--- a/snmplib/transports/snmpTCPDomain.c
+++ b/snmplib/transports/snmpTCPDomain.c
@@ -200,6 +200,17 @@ netsnmp_tcp_transport(const struct netsnmp_ep *ep, int local)
 
     t->flags = NETSNMP_TRANSPORT_FLAG_STREAM;
 
+    /* for Linux VRF Traps we try to bind the iface if clientaddr is not set */
+    if (local == 0  && ep && ep->iface) {
+        rc = netsnmp_bindtodevice(t->sock, ep->iface);
+        if (rc)
+            DEBUGMSGTL(("netsnmp_tcp", "VRF: Could not bind socket %d to %s\n",
+                t->sock, ep->iface));
+        else
+            DEBUGMSGTL(("netsnmp_tcp", "VRF: Bound socket %d to %s\n",
+                t->sock, ep->iface));
+    }
+
     if (local) {
 #ifndef NETSNMP_NO_LISTEN_SUPPORT
         int opt = 1;

--- a/snmplib/transports/snmpTCPIPv6Domain.c
+++ b/snmplib/transports/snmpTCPIPv6Domain.c
@@ -195,6 +195,17 @@ netsnmp_tcp6_transport(const struct netsnmp_ep *ep, int local)
 
     t->flags = NETSNMP_TRANSPORT_FLAG_STREAM;
 
+    /* for Linux VRF Traps we try to bind the iface if clientaddr is not set */
+    if (local == 0 && ep && ep->iface) {
+        rc = netsnmp_bindtodevice(t->sock, ep->iface);
+        if (rc)
+            DEBUGMSGTL(("netsnmp_tcp", "VRF: Could not bind socket %d to %s\n",
+                t->sock, ep->iface));
+        else
+            DEBUGMSGTL(("netsnmp_tcp", "VRF: Bound socket %d to %s\n",
+                t->sock, ep->iface));
+    }
+
     if (local) {
 #ifndef NETSNMP_NO_LISTEN_SUPPORT
         int opt = 1;


### PR DESCRIPTION
It's based on the 02de400544dea6804c348c457a5ea5ea5531b12d for fixes an issue #12 with TCP transport
(fix #389)

Signed-off-by: Dmitrii Turlupov <dturlupov@factor-ts.ru>