### PR TITLE
testing/fuzzing: fix transport fuzzer coverage

### DIFF
--- a/testing/fuzzing/snmp_transport_fuzzer.c
+++ b/testing/fuzzing/snmp_transport_fuzzer.c
@@ -76,18 +76,6 @@ LLVMFuzzerTestOneInput(const uint8_t * data, size_t size)
     /*
      * Main fuzzing logic
      */
-    char           *app = af_gb_get_null_terminated(&data2, &size2);
-    char           *str = af_gb_get_null_terminated(&data2, &size2);
-    char           *default_domain =
-        af_gb_get_null_terminated(&data2, &size2);
-    char           *default_target =
-        af_gb_get_null_terminated(&data2, &size2);
-
-    if (app && str && default_domain && default_target) {
-        netsnmp_tdomain_transport_full(app, str, 0, default_domain,
-                                       default_target);
-    }
-
     char           *prefix = af_gb_get_null_terminated(&data2, &size2);
     char           *fmt_data = af_gb_get_null_terminated(&data2, &size2);
     netsnmp_transport *t2 = NULL;


### PR DESCRIPTION
This patch fixes an unexpected-exit issue
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=40640 which
is likely the cause of a coverage failure issue
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=46588

The problem is netsnmp_tdomain_transport_full eventually forks the
process and also calls exit, which is not compatible with fuzzing. As
such, the function should not be called by the fuzzer.

Signed-off-by: David Korczynski <david@adalogics.com>