### PR TITLE
testing/fulltests/support/simple_eval_tools.sh: support non-GNU getopt

### DIFF
--- a/testing/fulltests/support/simple_eval_tools.sh
+++ b/testing/fulltests/support/simple_eval_tools.sh
@@ -525,6 +525,7 @@ STARTPROG() {
     if test -f $CFG_FILE; then
 	COMMAND="$COMMAND -C -c $CFG_FILE"
     fi
+    COMMAND="$COMMAND -f"
     if [ "x$PORT_SPEC" != "x" ]; then
         COMMAND="$COMMAND $PORT_SPEC"
     fi
@@ -537,7 +538,7 @@ STARTPROG() {
         echo $COMMAND >> $LOG_FILE.command
     fi
     {
-	{ $COMMAND -f; } >$LOG_FILE.stdout 2>&1
+	{ $COMMAND; } >$LOG_FILE.stdout 2>&1
 	echo $? >$LOG_FILE.exitcode
     } &
 }


### PR DESCRIPTION
Not all implementations of getopt() handle options appearing after
operands. POSIX doesn't require that, it's a GNU extension.
Running the testsuite from version 5.9.2+ on such a system results in
even simple tests failing as the agent attempts to find to port "-f"

```
trace: netsnmp_agent_listen_on(): /data/omnios-build/omniosorg/bloody/_build/net-snmp-5.9.3/net-snmp-5.9.3/./agent/snmp_agent.c, 1418:
snmp_agent: init_master_agent; "udp:127.0.0.1:8799" registered as an agent NSAP
trace: init_master_agent(): /data/omnios-build/omniosorg/bloody/_build/net-snmp-5.9.3/net-snmp-5.9.3/./agent/snmp_agent.c, 1510:
snmp_agent: installing master agent on port -f
```