### PR TITLE
Two compilation fixes for FreeBSD 14

### DIFF
--- a/agent/mibgroup/ip-mib/data_access/scalars_sysctl.c
+++ b/agent/mibgroup/ip-mib/data_access/scalars_sysctl.c
@@ -274,6 +274,16 @@ netsnmp_arch_ip_scalars_register_handlers(void)
 {
     static oid ipReasmTimeout_oid[] = { 1, 3, 6, 1, 2, 1, 4, 13, 0 };
 
+#ifdef freebsd14
+#define	FRAGTTL_CTL	"net.inet.ip.fragttl"
+    int intval;
+
+    if (sysctlbyname(FRAGTTL_CTL, &intval, &(size_t){sizeof(int)}, NULL, 0) < 0)
+        DEBUGMSGTL(("access::ipReasmTimeout", "sysctl %s failed - %s\n",
+                    FRAGTTL_CTL,
+                    strerror(errno)));
+    ipReasmTimeout_val = intval;
+#else
     /* 
      * This value is static at compile time on FreeBSD; it really should be a
      * probed via either sysctl or sysconf at runtime as the compiled value and
@@ -283,6 +293,7 @@ netsnmp_arch_ip_scalars_register_handlers(void)
      * particular PR_SLOWHZ).
      */
     ipReasmTimeout_val = IPFRAGTTL / PR_SLOWHZ;
+#endif
 
     netsnmp_register_long_instance("ipReasmTimeout",
                                    ipReasmTimeout_oid,

--- a/configure
+++ b/configure
@@ -30865,41 +30865,42 @@ fi
 
 
 #   Check whether TCP timer constants are indeed constant
-#       or depend on the kernel clock tick 'hz'.        (FreeBSD 4.x)
+#       or depend on the kernel clock tick 'hz'.        (FreeBSD)
 #
 #       If the latter, then we will need to have a local
 #       variable 'hz' defined and with a suitable value,
 #       whenever we want to  use one one of these 'constants'.
 #
-# 	    used in agent only
-#
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether TCP timers depend on 'hz'" >&5
-$as_echo_n "checking whether TCP timers depend on 'hz'... " >&6; }
-if ${ac_cv_TCPTV_NEEDS_HZ+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether TCP timers depend on 'hz'" >&5
+printf %s "checking whether TCP timers depend on 'hz'... " >&6; }
+if test ${ac_cv_TCPTV_NEEDS_HZ+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
 #include <netinet/tcp_timer.h>
-TCPTV_SRTTDFLT
+TCPTV_MIN
+TCPTV_REXMTMAX
 
 _ACEOF
 if (eval "$ac_cpp conftest.$ac_ext") 2>&5 |
-  $EGREP "hz" >/dev/null 2>&1; then :
+  $EGREP "hz" >/dev/null 2>&1
+then :
   ac_cv_TCPTV_NEEDS_HZ=yes
-else
+else $as_nop
   ac_cv_TCPTV_NEEDS_HZ=no
 fi
-rm -f conftest*
+rm -rf conftest*
 
 fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_TCPTV_NEEDS_HZ" >&5
-$as_echo "$ac_cv_TCPTV_NEEDS_HZ" >&6; }
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_TCPTV_NEEDS_HZ" >&5
+printf "%s\n" "$ac_cv_TCPTV_NEEDS_HZ" >&6; }
 
 if test "x$ac_cv_TCPTV_NEEDS_HZ" = "xyes"; then
 
-$as_echo "#define TCPTV_NEEDS_HZ 1" >>confdefs.h
+printf "%s\n" "#define TCPTV_NEEDS_HZ 1" >>confdefs.h
 
 fi
 

--- a/configure.d/config_os_misc4
+++ b/configure.d/config_os_misc4
@@ -213,20 +213,19 @@ fi
 
 
 #   Check whether TCP timer constants are indeed constant
-#       or depend on the kernel clock tick 'hz'.        (FreeBSD 4.x)
+#       or depend on the kernel clock tick 'hz'.        (FreeBSD)
 #
 #       If the latter, then we will need to have a local
 #       variable 'hz' defined and with a suitable value,
 #       whenever we want to  use one one of these 'constants'.
-#
-# 	    used in agent only
 #
 AC_CACHE_CHECK([whether TCP timers depend on 'hz'],
     ac_cv_TCPTV_NEEDS_HZ,
    [AC_EGREP_CPP(hz,
         [
 #include <netinet/tcp_timer.h>
-TCPTV_SRTTDFLT
+TCPTV_MIN
+TCPTV_REXMTMAX
         ],
         ac_cv_TCPTV_NEEDS_HZ=yes,
         ac_cv_TCPTV_NEEDS_HZ=no)])
@@ -234,7 +233,7 @@ TCPTV_SRTTDFLT
 if test "x$ac_cv_TCPTV_NEEDS_HZ" = "xyes"; then
     AC_DEFINE(TCPTV_NEEDS_HZ, 1,
         [Define if the TCP timer constants in <netinet/tcp_timer.h>
-         depend on the integer variable 'hz'.  @<:@FreeBSD 4.x@:>@])
+         depend on the integer variable 'hz'.  @<:@FreeBSD@:>@])
 fi
 
 


### PR DESCRIPTION
The first patch is actually a fix for all modern FreeBSD versions, as they compile but end up with wrong values.