### PR TITLE
fix-endofmib-rfc3416-compliance

### DIFF
--- a/agent/snmp_agent.c
+++ b/agent/snmp_agent.c
@@ -3395,7 +3395,6 @@ check_getnext_results(netsnmp_agent_session *asp)
                  * illegal response from a subagent.  Change it back to NULL 
                  *  xxx-rks: err, how do we know this is a subagent?
                  */
-                request->requestvb->type = ASN_NULL;
                 request->inclusive = 1;
             }
 


### PR DESCRIPTION
Hi, 

We are currently implementing a custom mib handler.  We are running into an issue where we try to provide error handling conform the RFC3416, in particular in regards of the `GetNextRequest-PDU` and providing an endOfMibView warning according to the RFC:

```
      (2)   If the requested variable binding's name does not
            lexicographically precede the name of any variable
            accessible by this request, i.e., there is no lexicographic
            successor, then the corresponding variable binding produced
            in the Response-PDU has its value field set to
            "endOfMibView", and its name field set to the variable
            binding's name in the request.
```

We currently register our handlers using the functions `netsnmp_create_handler_registration`, `netsnmp_create_watcher_info` & `netsnmp_register_watched_instance2`.

Our current issue is when we set the error after processing the `netsnmp_request_info *requests` (per request), we use `netsnmp_request_set_error(request, SNMP_ENDOFMIBVIEW)` to set the error, which internally sets the varbind in the request to SNMP_ENDOFMIBVIEW. 

We perform a GETNEXT request on the last accessible instance of our custom table, for which we would expect a similar response as to the provided example for `snmpgetnext` on it's manpage:

```
   % snmpgetnext -v 2c -c demopublic test.net-snmp.org .2.0.9999
   joint-iso-ccitt.0.9999 = No more variables left in this MIB View (It is past the end of the MIB tree)
```

However, in our case, it appears as if the  SNMP_ENDOFMIBVIEW error is ignored in it's entirety, as it seems that net-snmp keeps calling our handler with non existing OID's that in turn also return SNMP_ENDOFMIBVIEW in our handler until it reaches a OID that is accessible outside our MIB registration.

I would expect that after setting the SNMP_ENDOFMIBVIEW no more getnext request would be processed.

So I had a look into the current implementation of net-snmp, and came across the following code:

[snmp_agent.c:3398](https://github.com/net-snmp/net-snmp/blob/d0cb4afee07c5edb41ae9758c6b9be192e581b8a/agent/snmp_agent.c#L3398)

It appears to go through this function, appropriately called `check_getnext_results`, which in turn overwrites the varbind type to NULL if SNMP_ENDOFMIBVIEW is set.

I am not entirely sure what is meant with "illegal response from a subagent", and it is mentioned that it cannot be verified if the (to be generated?) response comes from a subagent (in our case it is definitely not). Hence I would not expect that all responses would get this varbind type overwritten when SNMP_ENDOFMIBVIEW is set. 

I would suggest to not override the varbind type at least, as suggested in my pull request. Hopefully a suitable solution will be in place. If this is cannot be changed at all at least provide additional debug messages to let the implementer know that internally something has changed to the varbind after the handler finished processing the request. 

If I remove the override as suggested in my PULL request, it is possible to set the SNMP_ENDOFMIBVIEW in my handler callback with the expected snmpgetnext response. 

Kind Regards,

Eldin
