### PR TITLE
convert all calls to `egrep` / `fgrep` to `grep -E` / `grep -F`, respectively

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -119,7 +119,7 @@ agentxtrap snmptrapd: @FEATURETARGS@
 # local build rules
 #
 sedscript: sedscript.in include/net-snmp/net-snmp-config.h $(srcdir)/agent/mibgroup/mibdefs.h
-	$(CPP) $(srcdir)/sedscript.in | egrep '^s[/#]' | sed 's/REMOVEME//g;s# */#/#g;s/ *#/#/g;s#/ *#/#g;s/# g/#g/;' > sedscript
+	$(CPP) $(srcdir)/sedscript.in | ${EGREP} '^s[/#]' | sed 's/REMOVEME//g;s# */#/#g;s/ *#/#/g;s#/ *#/#g;s/# g/#g/;' > sedscript
 	echo 's/VERSIONINFO/$(VERSION)/g' >> sedscript
 	echo 's#DATADIR#$(datadir)#g' >> sedscript
 	echo 's#LIBDIR#$(libdir)#g' >> sedscript

--- a/configure.d/config_modules_agent
+++ b/configure.d/config_modules_agent
@@ -814,8 +814,8 @@ AC_MSG_RESULT($NETSNMP_DEFAULT_MIBS)
 #
 
 if echo " $agent_module_list " | \
-   fgrep ' agentx/agentx_config ' | \
-   fgrep ' agentx/protocol ' > /dev/null ; then
+   $FGREP ' agentx/agentx_config ' | \
+   $FGREP ' agentx/protocol ' > /dev/null ; then
    NETSNMP_HAVE_AGENTX_LIBS_TRUE=''
    NETSNMP_HAVE_AGENTX_LIBS_FALSE='#'
 else

--- a/dist/RELEASE-INSTRUCTIONS
+++ b/dist/RELEASE-INSTRUCTIONS
@@ -87,7 +87,7 @@ STEP: 1.6: Check for changes
 
   Commands to execute:
 
-    svn -u status | egrep '^[^\?]'
+    svn -u status | grep -E '^[^\?]'
 
   (Leaving Step: 1)
 

--- a/dist/makerelease.xml
+++ b/dist/makerelease.xml
@@ -21,7 +21,7 @@
 	    them before continuing!
 	  </text>
 	  <commands>
-	    <command expectfailure="1">find . -name 'net-snmp-5*' | egrep '^[^\?]'</command>
+	    <command expectfailure="1">find . -name 'net-snmp-5*' | grep -E '^[^\?]'</command>
 	  </commands>
 	</step>
 	<step type="system" title="Setup Check">
@@ -130,7 +130,7 @@
 	  this step finds outstanding modified files you need to check
 	  them in or revert them before continuing!</text>
 	  <commands>
-	    <command expectfailure="1">git status --porcelain | egrep '^[^\?]'</command>
+	    <command expectfailure="1">git status --porcelain | grep -E '^[^\?]'</command>
 	  </commands>
 	</step>
       </steps>

--- a/dist/net-snmp-solaris-build/buildpackage-solaris
+++ b/dist/net-snmp-solaris-build/buildpackage-solaris
@@ -94,7 +94,7 @@ f snmp /etc/init.d/snmpd=./snmpd-init.d 0755 root sys
 ==
 
 pkgproto -c snmp $TMP=/ |\
-egrep -v '^d .* / |^d .* /var |^d .* /opt |^ .*perllocal.pod=' |\
+grep -E -v '^d .* / |^d .* /var |^d .* /opt |^ .*perllocal.pod=' |\
 sed -e "s/ $owner $group\$//" >> prototype || exit $?
 # and ignore top level directories (must pre-exist)
 

--- a/dist/nsb-functions
+++ b/dist/nsb-functions
@@ -364,10 +364,10 @@ nsb_make()
    # checking $? would only get us the rc from tee, which is useless
 
    nsb_info "Checking for errors..."
-   egrep -i "error|fail|warn|no such|exists|t find |ermission denied" $nsb_make_OUTPUT \
+   grep -E -i "error|fail|warn|no such|exists|t find |ermission denied" $nsb_make_OUTPUT \
          > nsb_make-$target-allerrs.$NSB_DATE
    # allow for a few exceptions
-   egrep -v -i "^ok|testing .*failure|[a-z&_](fail|error)|warn|error(mib|\.3)|(LOG|SNMP)_ERR|In function|= FAILURE|DEBUGMSG|/\*|static library .* is not portable" nsb_make-$target-allerrs.$NSB_DATE \
+   grep -E -v -i "^ok|testing .*failure|[a-z&_](fail|error)|warn|error(mib|\.3)|(LOG|SNMP)_ERR|In function|= FAILURE|DEBUGMSG|/\*|static library .* is not portable" nsb_make-$target-allerrs.$NSB_DATE \
          > nsb_make-$target-errs.$NSB_DATE
    if [ -s nsb_make-$target-errs.$NSB_DATE ]; then
       nsb_prompt "press enter to view errors"

--- a/dist/patme
+++ b/dist/patme
@@ -101,7 +101,7 @@ sub load_primaries {
        patch_info =>
        qw_primary('check','Checking code directory status:', '',
 		  [qw_paragraph('patch pieces:',
-				sub { capture("egrep '^(---|\\+\\+\\+)' " . 
+				sub { capture("grep -E '^(---|\\+\\+\\+)' " . 
 					      qwparam('patchfile'))},
 				width => 80,
 				height => 30),

--- a/local/gittools/shell-functions
+++ b/local/gittools/shell-functions
@@ -26,7 +26,7 @@ _ns_switchtobuilddir () {
 
 _ns_getbuilddir() {
     nssuffix=${1:-$nssuffix}
-    nsbranch=`git branch | egrep '^\*' | sed 's/^..//'`
+    nsbranch=`git branch | grep -E '^\*' | sed 's/^..//'`
     NSBUILDDIR="$nsbuildroot/$nsbranch"
     NSSRCDIR="$PWD"
 
@@ -334,7 +334,7 @@ nsrollup() {
             fi
 
 	    if [ -f dist/release ] ; then
-		if [ "`egrep ^$branch dist/release`" = "$branch rc" ] ; then
+		if [ "`grep -E ^$branch dist/release`" = "$branch rc" ] ; then
 		    $nsverbose Skipping: branch is in rc phase of release
 		    nsbranchesnotdone="$nsbranchesnotdone $branch"
 
@@ -411,7 +411,7 @@ nsrollup() {
 }
 
 nspull() {
-    nscurrentbranch=`git branch | egrep '^\*' | sed 's/^..//'`
+    nscurrentbranch=`git branch | grep -E '^\*' | sed 's/^..//'`
     _ns_checkclean
     if [ $NSCLEAN != 1 ]; then
 	return

--- a/local/mib2c-update
+++ b/local/mib2c-update
@@ -157,7 +157,7 @@ do_cp()
         die "src $src is not a directory"
     fi
     safecd "$src"
-    files=`ls ./*"$UPDATE_OID"* 2>/dev/null| egrep "(file|onf|m2d|txt|\.c|\.h)$"`
+    files=`ls ./*"$UPDATE_OID"* 2>/dev/null| grep -E "(file|onf|m2d|txt|\.c|\.h)$"`
     if [ -z "$files" ]; then
        echo "   no files to copy from $src"
     else
@@ -174,7 +174,7 @@ do_cp()
 save_diff()
 {
     echo "Creating patch for your custom code"
-    cnt=`ls ./"$UPDATE_CURR/"*"$UPDATE_OID"* 2>/dev/null | egrep "(file|onf|m2d|txt|\.c|\.h)$" | wc -l`
+    cnt=`ls ./"$UPDATE_CURR/"*"$UPDATE_OID"* 2>/dev/null | grep -E "(file|onf|m2d|txt|\.c|\.h)$" | wc -l`
     if [ "$cnt" -eq 0 ]; then
         echo "   no custom code!"
         FIRST_RUN=1

--- a/local/minimalist/feature-remove
+++ b/local/minimalist/feature-remove
@@ -99,15 +99,15 @@ for i in `grep NETSNMP_FEATURE_PROVIDE_ $featureheaderin | sed 's/.*FEATURE_PROV
     #
     # check to see if something required a parent
     #
-    elif egrep NETSNMP_FEATURE_${i}_CHILD_OF $featureheaderglobal > /dev/null ; then
-	parentnames=`egrep NETSNMP_FEATURE_${i}_CHILD_OF $featureheaderglobal | sed 's/.*CHILD_OF_//;s/ .*//;'`
+    elif grep -E NETSNMP_FEATURE_${i}_CHILD_OF $featureheaderglobal > /dev/null ; then
+	parentnames=`grep -E NETSNMP_FEATURE_${i}_CHILD_OF $featureheaderglobal | sed 's/.*CHILD_OF_//;s/ .*//;'`
 
 	foundone=0
 	for parentname in $parentnames ; do
    	    # if the parent was desired, then we are too:
 	    
 	    if test $foundone = 0 ; then
-		if egrep "NETSNMP_FEATURE_HAS_${parentname} " $featureheader > /dev/null ; then
+		if grep -E "NETSNMP_FEATURE_HAS_${parentname} " $featureheader > /dev/null ; then
        		    echo "#define NETSNMP_FEATURE_HAS_$i 1" >> $featureheader
 		    haslist="${haslist}${i} "
 		    foundone=1

--- a/local/snmp-ucd.sh
+++ b/local/snmp-ucd.sh
@@ -60,7 +60,7 @@ killproc() {	# <program> [signal]
 	#
         pid=`pidofproc $base 2>/dev/null`
 	[ -z "$pid" ] && {
-		pid=`ps $PSARGS | egrep $base | egrep -v egrep | egrep -v $0 | awk '{ print $2 }'`;
+		pid=`ps $PSARGS | grep $base | grep -v grep | grep -v $0 | awk '{ print $2 }'`;
 	}
 	[ -z "$pid" ] && {
 		echo "`basename $0`: killproc: Could not find process ID."

--- a/net-snmp-create-v3-user.in
+++ b/net-snmp-create-v3-user.in
@@ -3,7 +3,7 @@
 # this shell script is designed to add new SNMPv3 users
 # to Net-SNMP config file.
 
-if @PSCMD@ | egrep ' snmpd *$' > /dev/null 2>&1 ; then
+if @PSCMD@ | @EGREP@ ' snmpd *$' > /dev/null 2>&1 ; then
     echo "Apparently at least one snmpd demon is already running."
     echo "You must stop them in order to use this command."
     exit 1

--- a/testing/fulltests/support/simple_eval_tools.sh
+++ b/testing/fulltests/support/simple_eval_tools.sh
@@ -474,7 +474,7 @@ CHECKANDDIE() {
 # Returns: Count of matched lines.
 #
 CHECKEXACT() {	# <pattern_to_match_exactly>
-	rval=`egrep -c "^$*\$|^$*[^a-zA-Z0-9_]|[^a-zA-Z0-9_]$*\$|[^a-zA-Z0-9_]$*[^a-zA-Z0-9_]" "$junkoutputfile" 2>/dev/null`
+	rval=`grep -E -c "^$*\$|^$*[^a-zA-Z0-9_]|[^a-zA-Z0-9_]$*\$|[^a-zA-Z0-9_]$*[^a-zA-Z0-9_]" "$junkoutputfile" 2>/dev/null`
 	snmp_last_test_result=$rval
 	EXPECTRESULT 1  # default
 	return $rval


### PR DESCRIPTION
This series converts all `egrep`/`fgrep` calls to `grep -E` / `grep -F`, respectively.
GNU grep 3.8 started throwing warnings on direct usage of the deprecated commands.

`local/snmp-ucd.sh` has a change (https://github.com/net-snmp/net-snmp/commit/3e06aefaab2a910299b5a57ee94f94c764746816#diff-8b9cf6640de0be65b31b980fabddbae605b8eba8c94ba391b04fad9a49eb4513) what warrants some extra review

Distro tracker: https://bugzilla.opensuse.org/show_bug.cgi?id=1203096

cc: @abergmann