### PR TITLE
Overhaul support for the SNMPv3+SSH transport

### DIFF
--- a/dist/net-snmp.spec
+++ b/dist/net-snmp.spec
@@ -57,6 +57,7 @@ BuildRequires: bzip2
 BuildRequires: gcc
 BuildRequires: perl
 BuildRequires: rpm-devel
+BuildRequires: libnl3-devel
 %if 0%{?netsnmp_embedded_perl}
 Requires: perl
 BuildRequires: perl(ExtUtils::Embed)

--- a/include/net-snmp/library/default_store.h
+++ b/include/net-snmp/library/default_store.h
@@ -36,7 +36,7 @@ extern          "C" {
 #endif
 
 #define NETSNMP_DS_MAX_IDS 3
-#define NETSNMP_DS_MAX_SUBIDS 48        /* needs to be a multiple of 8 */
+#define NETSNMP_DS_MAX_SUBIDS 64        /* needs to be a multiple of 8 */
 
     /*
      * begin storage definitions 
@@ -105,7 +105,8 @@ extern          "C" {
 #define NETSNMP_DS_LIB_DISABLE_V3          45 /* disable SNMPv3 */
 #define NETSNMP_DS_LIB_FILTER_SOURCE       46 /* filter pkt by source IP */
 #define NETSNMP_DS_LIB_ADD_FORWARDER_INFO  47 /* add info about forwarder to SNMP packets */
-#define NETSNMP_DS_LIB_MAX_BOOL_ID         48 /* match NETSNMP_DS_MAX_SUBIDS */
+#define NETSNMP_DS_LIB_SSH_AGENT           48 /* enable ssh agent forwarding */
+#define NETSNMP_DS_LIB_MAX_BOOL_ID         64 /* match NETSNMP_DS_MAX_SUBIDS */
 
     /*
      * library integers 
@@ -130,7 +131,7 @@ extern          "C" {
 #define NETSNMP_DS_LIB_RETRIES             15
 #define NETSNMP_DS_LIB_MSG_SEND_MAX        16 /* global max response size */
 #define NETSNMP_DS_LIB_FILTER_TYPE         17 /* 0=NONE, 1=whitelist, -1=blacklist */
-#define NETSNMP_DS_LIB_MAX_INT_ID          48 /* match NETSNMP_DS_MAX_SUBIDS */
+#define NETSNMP_DS_LIB_MAX_INT_ID          64 /* match NETSNMP_DS_MAX_SUBIDS */
     
     /*
      * special meanings for the default SNMP version slot (NETSNMP_DS_LIB_SNMPVERSION) 
@@ -185,7 +186,7 @@ extern          "C" {
 #define NETSNMP_DS_LIB_OUTPUT_PRECISION  35
 #define NETSNMP_DS_LIB_TLS_MIN_VERSION   36
 #define NETSNMP_DS_LIB_TLS_MAX_VERSION   37
-#define NETSNMP_DS_LIB_MAX_STR_ID        48 /* match NETSNMP_DS_MAX_SUBIDS */
+#define NETSNMP_DS_LIB_MAX_STR_ID        64 /* match NETSNMP_DS_MAX_SUBIDS */
 
     /*
      * end storage definitions 

--- a/include/net-snmp/library/snmpSSHDomain.h
+++ b/include/net-snmp/library/snmpSSHDomain.h
@@ -19,14 +19,19 @@ extern          "C" {
 /*
  * The SNMP over SSH over IPv4 transport domain is identified by
  * transportDomainSshIpv4 as defined in RFC 3419.
+ *
+ * FIXME: above is wrong. Closest definition seems to be
+ * transportDomainTcpIpv4 and transportDomainTcpIpv6
+ *
+ * Looks like oid is 1.3.6.1.6.1.7 snmpSSHDomain from rfc5592
  */
 
 #define TRANSPORT_DOMAIN_SSH_IP		1,3,6,1,2,1,100,1,100
 NETSNMP_IMPORT const oid netsnmp_snmpSSHDomain[];
 enum { netsnmp_snmpSSHDomain_len = 9 };
 
-netsnmp_transport *netsnmp_ssh_transport(const struct sockaddr_in *addr,
-                                         int local);
+netsnmp_transport *netsnmp_ssh_transport(const struct netsnmp_ep *ep,
+                                         int local, int domain);
 
 /*
  * "Constructor" for transport domain object.

--- a/man/snmp.conf.5.def
+++ b/man/snmp.conf.5.def
@@ -275,6 +275,8 @@ through the \fBsshtosnmp\fR unix socket.  The socket needs to be read/write
 privileged for SSH users that are allowed to connect to the SNMP
 service (VACM access still needs to be granted as well, most likely
 through the TSM security model).
+.IP "sshagent yes"
+Should ssh attempt to obtain keys from an ssh agent in addition to local keys.
 .IP "sshusername NAME"
 Sets the SSH user name for logging into the remote system.
 .IP "sshpubkey FILE"

--- a/man/snmpd.8.def
+++ b/man/snmpd.8.def
@@ -256,7 +256,7 @@ The SSH transport, on the server side, is actually just a unix
 named pipe that can be connected to via a ssh subsystem configured in
 the main ssh server.  The pipe location (configurable with the
 sshtosnmpsocket token in snmp.conf) is
-.I /var/net\-snmp/sshtosnmp.
+.I PERSISTENT_DIRECTORY/sshdomainsocket.
 Packets should be submitted to it via the sshtosnmp application, which
 also sends the user ID as well when starting the connection.  The TSM
 security model should be used when packets should process it.
@@ -271,16 +271,16 @@ configuration file (which is normally
 using the following configuration line:
 .TP 8
 .IP
-Subsystem snmp /usr/local/bin/sshtosnmp
+Subsystem snmp /usr/local/bin/sshtosnmp PERSISTENT_DIRECTORY/sshdomainsocket
 .IP
 The
 .I sshtosnmp
 command will need read/write access to the 
-.I /var/net\-snmp/sshtosnmp
+.I PERSISTENT_DIRECTORY/sshdomainsocket
 pipe.  Although it should be fairly safe to grant access to the
 average user since it still requires modifications to the ACM settings
 before the user can perform operations, paranoid administrators may
-want to make the /var/net\-snmp directory accessible only by users in a
+want to make the PERSISTENT_DIRECTORY directory accessible only by users in a
 particular group.  Use the
 .I sshtosnmpsocketperms
 snmp.conf configure option to set the permissions, owner and group of

--- a/snmplib/snmp_api.c
+++ b/snmplib/snmp_api.c
@@ -2094,6 +2094,7 @@ snmpv3_verify_msg(netsnmp_request_list *rp, netsnmp_pdu *pdu)
 {
     netsnmp_pdu    *rpdu;
 
+    /* XX: This function silently rejects. Add error handling. */
     if (!rp || !rp->pdu || !pdu)
         return 0;
     /*

--- a/snmplib/transports/snmpSSHDomain.c
+++ b/snmplib/transports/snmpSSHDomain.c
@@ -56,10 +56,13 @@
 
 #include <net-snmp/library/snmp.h>
 #include <net-snmp/library/snmp_transport.h>
-#include <net-snmp/library/snmpIPv4BaseDomain.h>
+#include <net-snmp/library/snmpIPBaseDomain.h>
 #include <net-snmp/library/snmpSocketBaseDomain.h>
 #include <net-snmp/library/read_config.h>
+#include <net-snmp/library/snmp_secmod.h>
+#include <net-snmp/library/snmptsm.h>
 
+netsnmp_feature_require(transport_cache);
 netsnmp_feature_require(user_information);
 
 #define MAX_NAME_LENGTH 127
@@ -70,15 +73,21 @@ netsnmp_feature_require(user_information);
 #define DEFAULT_SOCK_NAME "sshdomainsocket"
 
 typedef struct netsnmp_ssh_addr_pair_s {
-    struct sockaddr_in remote_addr;
+    union {
+        struct sockaddr_in in;
+        struct sockaddr_in6 in6;
+    } remote_addr;
     struct in_addr local_addr;
     LIBSSH2_SESSION *session;
     LIBSSH2_CHANNEL *channel;
+    LIBSSH2_AGENT *agent;
     char username[MAX_NAME_LENGTH+1];
     struct sockaddr_un unix_socket_end;
     char socket_path[MAXPATHLEN];
+    int remote_addr_len;
 } netsnmp_ssh_addr_pair;
 
+/* XX: looks like the wrong oid, see header */
 const oid netsnmp_snmpSSHDomain[] = { TRANSPORT_DOMAIN_SSH_IP };
 static netsnmp_tdomain sshDomain;
 
@@ -129,6 +138,9 @@ static void netsnmp_ssh_get_taddr(struct netsnmp_transport_s *t,
     case sizeof(struct sockaddr_in):
         netsnmp_ipv4_get_taddr(t, addr, addr_len);
         break;
+    case sizeof(struct sockaddr_in6):
+        netsnmp_ipv6_get_taddr(t, addr, addr_len);
+        break;
     default:
         *addr = NULL;
         netsnmp_assert(0);
@@ -170,6 +182,7 @@ netsnmp_ssh_recv(netsnmp_transport *t, void *buf, int size,
 	    }
 	    DEBUGMSGTL(("ssh", "recv fd %d got %d bytes\n",
 			t->sock, rc));
+            /* XX: if we read zero bytes, server probably not running */
 	}
     } else if (t != NULL) {
 
@@ -346,9 +359,16 @@ netsnmp_ssh_recv(netsnmp_transport *t, void *buf, int size,
         /* we're on the server... */
         /* XXX: this doesn't copy properly and can get pointer
            reference issues */
-        if (strlen(getenv("USER")) > 127) {
+        const char *securityName = getenv("USER");
+        if (!securityName) {
+            snmp_log(LOG_ERR, "USER environment variable missing, no username available\n\n");
+            return -1;
+        }
+	if (strlen(securityName) > (sizeof(tmStateRef->securityName) - 1)) {
             /* ruh roh */
             /* XXX: clean up */
+            snmp_log(LOG_ERR, "User name '%s' too long for snmp\n",
+                     securityName);
             return -1;
         }
 
@@ -375,7 +395,7 @@ netsnmp_ssh_send(netsnmp_transport *t, const void *buf, int size,
     int rc = -1;
 
     netsnmp_ssh_addr_pair *addr_pair = NULL;
-    const netsnmp_tmStateReference *tmStateRef = NULL;
+    netsnmp_tmStateReference *tmStateRef = NULL;
 
     if (t != NULL && t->data != NULL) {
 	addr_pair = (netsnmp_ssh_addr_pair *) t->data;
@@ -383,7 +403,7 @@ netsnmp_ssh_send(netsnmp_transport *t, const void *buf, int size,
 
     if (opaque != NULL && *opaque != NULL &&
         *olength == sizeof(netsnmp_tmStateReference)) {
-        tmStateRef = (const netsnmp_tmStateReference *) *opaque;
+        tmStateRef = (netsnmp_tmStateReference *) *opaque;
     }
 
     if (!tmStateRef) {
@@ -393,11 +413,16 @@ netsnmp_ssh_send(netsnmp_transport *t, const void *buf, int size,
     }
 
     if (NULL != t && NULL != addr_pair && NULL != addr_pair->channel) {
-        if (addr_pair->username[0] == '\0') {
+        if ((NETSNMP_TM_SAME_SECURITY_NOT_REQUIRED == tmStateRef->sameSecurity) && (!tmStateRef->securityNameLen)) {
+            /* first message sent */
+            tmStateRef->securityNameLen = strlcpy(tmStateRef->securityName, addr_pair->username,
+                    sizeof(tmStateRef->securityName));
+        } else if (addr_pair->username[0] == '\0') {
             strlcpy(addr_pair->username, tmStateRef->securityName,
                     sizeof(addr_pair->username));
-        } else if (strcmp(addr_pair->username, tmStateRef->securityName) != 0 ||
-                   strlen(addr_pair->username) != tmStateRef->securityNameLen) {
+        } else if ((NETSNMP_TM_USE_SAME_SECURITY == tmStateRef->sameSecurity) &&
+	           (strcmp(addr_pair->username, tmStateRef->securityName) != 0 ||
+                   strlen(addr_pair->username) != tmStateRef->securityNameLen)) {
             /* error!  they must always match */
             snmp_log(LOG_ERR, "netsnmp_ssh_send was passed a tmStateReference with a securityName not equal to previous messages\n");
             return -1;
@@ -562,8 +587,6 @@ netsnmp_ssh_accept(netsnmp_transport *t)
 
 }
 
-
-
 /*
  * Open a SSH-based transport for SNMP.  Local is TRUE if addr is the local
  * address to bind to (i.e. this is a server-type session); otherwise addr is 
@@ -571,12 +594,12 @@ netsnmp_ssh_accept(netsnmp_transport *t)
  */
 
 netsnmp_transport *
-netsnmp_ssh_transport(const struct sockaddr_in *addr, int local)
+netsnmp_ssh_transport(const struct netsnmp_ep *ep, int local, int domain)
 {
     netsnmp_transport *t = NULL;
     netsnmp_ssh_addr_pair *addr_pair = NULL;
     int rc = 0;
-    int i, auth_pw = 0;
+    int i;
     const char *fingerprint;
     char *userauthlist;
     struct sockaddr_un *unaddr;
@@ -586,11 +609,15 @@ netsnmp_ssh_transport(const struct sockaddr_in *addr, int local)
     char tmpsockpath[MAXPATHLEN];
 
 #ifdef NETSNMP_NO_LISTEN_SUPPORT
-    if (local)
+    if (local) {
         return NULL;
+    }
 #endif /* NETSNMP_NO_LISTEN_SUPPORT */
 
-    if (addr == NULL || addr->sin_family != AF_INET) {
+    if (local && PF_UNIX != domain) {
+        return NULL;
+    }
+    if (!local && (PF_INET != domain && PF_INET6 != domain)) {
         return NULL;
     }
 
@@ -626,7 +653,7 @@ netsnmp_ssh_transport(const struct sockaddr_in *addr, int local)
         /* XXX: get data from the transport def for it's location */
         unaddr->sun_family = AF_UNIX;
         if (NULL == sockpath) {
-            snprintf(tmpsockpath, sizeof(tmpsocketpath), "%s/%s",
+            snprintf(tmpsockpath, sizeof(tmpsockpath), "%s/%s",
                      get_persistent_directory(), DEFAULT_SOCK_NAME);
             sockpath = tmpsockpath;
         }
@@ -730,21 +757,36 @@ netsnmp_ssh_transport(const struct sockaddr_in *addr, int local)
         char *username;
         char *keyfilepub;
         char *keyfilepriv;
-        
+        int agent;
+
         /* use the requested user name */
-        /* XXX: default to the current user name on the system like ssh does */
         username = netsnmp_ds_get_string(NETSNMP_DS_LIBRARY_ID,
                                          NETSNMP_DS_LIB_SSH_USERNAME);
+        if (!username || 0 == *username) {
+            username = getenv("USER");
+        }
         if (!username || 0 == *username) {
             snmp_log(LOG_ERR, "You must specify a ssh username to use.  See the snmp.conf manual page\n");
             netsnmp_transport_free(t);
             return NULL;
         }
 
+        /* username too long, complain */
+        if (strlen(username) > (sizeof(addr_pair->username) - 1)) {
+            snmp_log(LOG_ERR, "Your ssh username is longer than %d characters.\n", (int)(sizeof(addr_pair->username) - 1));
+            netsnmp_transport_free(t);
+            return NULL;
+	}
+	strlcpy(addr_pair->username, username, sizeof(addr_pair->username));
+
+        /* should we attempt agent forwarding */
+	agent = netsnmp_ds_get_boolean(NETSNMP_DS_LIBRARY_ID,
+                                       NETSNMP_DS_LIB_SSH_AGENT);
+
         /* use the requested public key file */
         keyfilepub = netsnmp_ds_get_string(NETSNMP_DS_LIBRARY_ID,
                                            NETSNMP_DS_LIB_SSH_PUBKEY);
-        if (!keyfilepub || 0 == *keyfilepub) {
+        if (!agent && (!keyfilepub || 0 == *keyfilepub)) {
             /* XXX: default to ~/.ssh/id_rsa.pub */
             snmp_log(LOG_ERR, "You must specify a ssh public key file to use.  See the snmp.conf manual page\n");
             netsnmp_transport_free(t);
@@ -754,26 +796,42 @@ netsnmp_ssh_transport(const struct sockaddr_in *addr, int local)
         /* use the requested private key file */
         keyfilepriv = netsnmp_ds_get_string(NETSNMP_DS_LIBRARY_ID,
                                             NETSNMP_DS_LIB_SSH_PRIVKEY);
-        if (!keyfilepriv || 0 == *keyfilepriv) {
+        if (!agent && (!keyfilepriv || 0 == *keyfilepriv)) {
             /* XXX: default to keyfilepub without the .pub suffix */
             snmp_log(LOG_ERR, "You must specify a ssh private key file to use.  See the snmp.conf manual page\n");
             netsnmp_transport_free(t);
             return NULL;
         }
 
-        /* xxx: need an ipv6 friendly one too (sigh) */
+        /*
+         * Handle both IPv4 and IPv6 connections here.
+         */
 
-        /* XXX: not ideal when structs don't actually match size wise */
-        memcpy(&(addr_pair->remote_addr), addr, sizeof(struct sockaddr_in));
-
-        t->sock = socket(PF_INET, SOCK_STREAM, 0);
+	t->sock = socket(domain, SOCK_STREAM, 0);
         if (t->sock < 0) {
+            snmp_log(LOG_ERR,"Could not allocate socket for ssh: %s\n",
+                     strerror(errno));
             netsnmp_transport_free(t);
             return NULL;
         }
 
-        t->remote_length = sizeof(*addr);
-        t->remote = netsnmp_memdup(addr, sizeof(*addr));
+        if (PF_INET == domain) {
+            const struct sockaddr_in *addr = &ep->a.sin;
+
+	    t->remote_length = sizeof(*addr);
+            t->remote = netsnmp_memdup(addr, sizeof(*addr));
+
+            memcpy(&(addr_pair->remote_addr), addr, t->remote_length);
+        }
+        else if (PF_INET6 == domain) {
+            const struct sockaddr_in6 *addr = &ep->a.sin6;
+
+            t->remote_length = sizeof(*addr);
+            t->remote = netsnmp_memdup(addr, sizeof(*addr));
+
+            memcpy(&(addr_pair->remote_addr), addr, t->remote_length);
+        }
+
         if (!t->remote) {
             netsnmp_ssh_close(t);
             netsnmp_transport_free(t);
@@ -787,9 +845,11 @@ netsnmp_ssh_transport(const struct sockaddr_in *addr, int local)
          * had completed.  So this can block.
          */
 
-        rc = connect(t->sock, addr, sizeof(struct sockaddr));
+        rc = connect(t->sock, t->remote, t->remote_length);
 
         if (rc < 0) {
+            snmp_log(LOG_ERR,"Could not connect to ssh server: %s\n",
+                     strerror(errno));
             netsnmp_ssh_close(t);
             netsnmp_transport_free(t);
             return NULL;
@@ -834,30 +894,86 @@ netsnmp_ssh_transport(const struct sockaddr_in *addr, int local)
         DEBUGMSG(("ssh", "Authentication methods: %s\n", userauthlist));
 
         /* XXX: allow other types */
-        /* XXX: 4 seems magic to me... */
-        if (strstr(userauthlist, "publickey") != NULL) {
-            auth_pw |= 4;
-        }
+	if (strstr(userauthlist, "publickey") != NULL) {
 
-        /* XXX: hard coded paths and users */
-        if (auth_pw & 4) {
-            /* public key */
-            if (libssh2_userauth_publickey_fromfile(addr_pair->session,
-                                                    username,
-                                                    keyfilepub, keyfilepriv,
-                                                    NULL)) {
-                snmp_log(LOG_ERR,"Authentication by public key failed!\n");
-                goto shutdown;
-            } else {
-                DEBUGMSG(("ssh",
-                          "\tAuthentication by public key succeeded.\n"));
+            int agents = 0, locals = 0;
+
+            /* try agent supplied keys */
+            if (agent) {
+
+                struct libssh2_agent_publickey *identity, *prev_identity = NULL;
+
+                /* Connect to the ssh-agent */
+                addr_pair->agent = libssh2_agent_init(addr_pair->session);
+
+                if (!addr_pair->agent) {
+                    snmp_log(LOG_ERR, "SSH agent could not be initialised\n");
+                    goto shutdown;
+                }
+                if (libssh2_agent_connect(addr_pair->agent)) {
+                    snmp_log(LOG_ERR,"could not connect to SSH agent\n");
+                    goto shutdown;
+                }
+                if (libssh2_agent_list_identities(addr_pair->agent)) {
+                    snmp_log(LOG_ERR,"could not request identities from SSH agent\n");
+                    goto shutdown;
+                }
+
+		while (1) {
+                    rc = libssh2_agent_get_identity(addr_pair->agent, &identity, prev_identity);
+
+                    if (rc == 1) {
+                        agent = 0;
+                        break;
+                    } else if (rc < 0) {
+                        snmp_log(LOG_ERR,"could not obtain identity from SSH agent\n");
+                        goto shutdown;
+                    } else if (libssh2_agent_userauth(addr_pair->agent, username, identity)) {
+                        DEBUGMSGTL(("ssh", "\tAuthentication with username %s and public key %s failed\n",
+                                    username, identity->comment));
+                        agents++;
+                    }
+                    else {
+                        DEBUGMSGTL(("ssh",
+                                    "\tAuthentication with username %s and agent key %s succeeded.\n",
+                                    username, identity->comment));
+                        goto authenticated;
+                    }
+                    prev_identity = identity;
+		}
+
+	    }
+
+            /* try local keys */
+            if (!agent) {
+
+                if (!keyfilepub || !*keyfilepub || !keyfilepriv || !*keyfilepriv) {
+                    /* skip attempt */
+		} else if (libssh2_userauth_publickey_fromfile(addr_pair->session,
+                                                        username,
+                                                        keyfilepub, keyfilepriv,
+                                                        NULL)) {
+                    locals++;
+                } else {
+                    DEBUGMSGTL(("ssh",
+                              "\tAuthentication with username %s and local key %s succeeded.\n",
+                              username, keyfilepriv));
+                    goto authenticated;
+                }
             }
+
+	    /* no luck with login */
+	    snmp_log(LOG_ERR,"Authentication by public key failed: %d agent key(s), %d local key(s)\n",
+                     agents, locals);
+	    goto shutdown;
+
         } else {
-            snmp_log(LOG_ERR,"Authentication by public key failed!\n");
+            snmp_log(LOG_ERR,"Authentication by public key not supported (%s)!\n", userauthlist);
             goto shutdown;
         }
 
         /* we've now authenticated both sides; contining onward ... */
+        authenticated:
 
         /* Request a channel */
         if (!(addr_pair->channel =
@@ -897,30 +1013,157 @@ netsnmp_ssh_transport(const struct sockaddr_in *addr, int local)
     return t;
 }
 
+netsnmp_transport *
+netsnmp_ssh_transport_with_source(const struct netsnmp_ep *ep,
+                                  int flags,
+                                  const struct netsnmp_ep *src_addr,
+                                  int domain)
+{
+    netsnmp_transport *t = NULL;
+    int                local = flags & NETSNMP_TSPEC_LOCAL;
+
+    DEBUGMSGTL(("ssh:create", "from addr with source\n"));
+
+    if (!local && src_addr) {
+        /** check for existing cached transport */
+        t = netsnmp_transport_cache_get(domain, SOCK_DGRAM, local,
+                                        (const void *)src_addr,
+                                        sizeof(*src_addr));
+    }
+
+    /** if no cached transport found, create one */
+    if (NULL == t) {
+        t = netsnmp_ssh_transport(ep, local, domain);
+        if (NULL == t) {
+            netsnmp_transport_free(t);
+            return NULL;
+        }
+
+        netsnmp_transport_cache_save(domain, SOCK_DGRAM, local,
+                                     (const void *)src_addr,
+                                     sizeof(*src_addr), t);
+    }
+
+    /** get local socket address */
+#if 0
+    if (!local) {
+        netsnmp_udp6_transport_get_bound_addr(t);
+    }
+#endif
+
+    return t;
+}
 
 
 netsnmp_transport *
 netsnmp_ssh_create_tstring(const char *str, int local,
 			   const char *default_target)
 {
-    struct sockaddr_in addr;
+    struct netsnmp_ep ep = { 0 };
+    netsnmp_transport *t;
 
-    if (netsnmp_sockaddr_in2(&addr, str, default_target)) {
-        return netsnmp_ssh_transport(&addr, local);
-    } else {
-        return NULL;
+    DEBUGMSGTL(("ssh:create", "from tstring %s\n", str));
+
+    if (local) {
+        return netsnmp_ssh_transport(NULL, local, PF_UNIX);
     }
+
+    if (netsnmp_sockaddr_in3(&ep, str, default_target))
+        t = netsnmp_ssh_transport(&ep, local, PF_INET);
+#ifdef NETSNMP_TRANSPORT_UDPIPV6_DOMAIN
+    else if (netsnmp_sockaddr_in6_3(&ep, str, default_target))
+        t = netsnmp_ssh_transport(&ep, local, PF_INET6);
+#endif
+    else
+        return NULL;
+
+    return t;
 }
 
+static netsnmp_transport *
+_tspec_v4(const struct netsnmp_ep *ep, netsnmp_tdomain_spec *tspec)
+{
+    int local = tspec->flags & NETSNMP_TSPEC_LOCAL;
 
+    if (NULL != tspec->source) {
+        struct netsnmp_ep src_addr;
+
+        /** get sockaddr from source */
+        if (!netsnmp_sockaddr_in3(&src_addr, tspec->source, NULL))
+            return NULL;
+        return netsnmp_ssh_transport_with_source(ep, local, &src_addr, PF_INET);
+    }
+
+    /** no source and default client address ok */
+    return netsnmp_ssh_transport(ep, local, PF_INET);
+}
+
+#ifdef NETSNMP_TRANSPORT_UDPIPV6_DOMAIN
+static netsnmp_transport *
+_tspec_v6(const struct netsnmp_ep *ep, netsnmp_tdomain_spec *tspec)
+{
+    int local = tspec->flags & NETSNMP_TSPEC_LOCAL;
+
+    if (NULL != tspec->source) {
+        struct netsnmp_ep src_addr;
+
+        /** get sockaddr from source */
+        if (!netsnmp_sockaddr_in6_3(&src_addr, tspec->source, NULL))
+            return NULL;
+        return netsnmp_ssh_transport_with_source(ep, local, &src_addr, PF_INET6);
+    }
+
+    /** no source and default client address ok */
+    return netsnmp_ssh_transport(ep, local, PF_INET6);
+}
+#endif /* NETSNMP_TRANSPORT_UDPIPV6_DOMAIN */
+
+netsnmp_transport *
+netsnmp_ssh_create_tspec(netsnmp_tdomain_spec *tspec)
+{
+    struct netsnmp_ep ep;
+    int local;
+
+    DEBUGMSGTL(("ssh:create", "from tspec\n"));
+
+    if (NULL == tspec)
+        return NULL;
+
+    local = tspec->flags & NETSNMP_TSPEC_LOCAL;
+
+    if (local) {
+        return netsnmp_ssh_transport(NULL, local, PF_UNIX);
+    }
+
+    if (netsnmp_sockaddr_in3(&ep, tspec->target, tspec->default_target))
+        return _tspec_v4(&ep, tspec);
+#ifdef NETSNMP_TRANSPORT_UDPIPV6_DOMAIN
+    else if (netsnmp_sockaddr_in6_3(&ep, tspec->target, tspec->default_target))
+        return _tspec_v6(&ep, tspec);
+#endif
+
+    return NULL;
+}
 
 netsnmp_transport *
 netsnmp_ssh_create_ostring(const void *o, size_t o_len, int local)
 {
-    struct sockaddr_in sin;
+    struct netsnmp_ep ep;
+    memset(&ep, 0, sizeof(ep));
 
-    if (netsnmp_ipv4_ostring_to_sockaddr(&sin, o, o_len))
-        return netsnmp_ssh_transport(&sin, local);
+    DEBUGMSGTL(("ssh:create", "from ostring\n"));
+
+    if (local) {
+        return netsnmp_ssh_transport(NULL, local, PF_UNIX);
+    }
+
+    /* XX: make order of IPv4/IPv6 configurable */
+    if (netsnmp_ipv4_ostring_to_sockaddr(&ep.a.sin, o, o_len))
+        return netsnmp_ssh_transport(&ep, local, PF_INET);
+#ifdef NETSNMP_TRANSPORT_UDPIPV6_DOMAIN
+    else if (netsnmp_ipv6_ostring_to_sockaddr(&ep.a.sin6, o, o_len))
+        return netsnmp_ssh_transport(&ep, local, PF_INET6);
+#endif
     else
         netsnmp_assert(0);
     return NULL;
@@ -981,6 +1224,7 @@ netsnmp_ssh_ctor(void)
     sshDomain.prefix[0] = "ssh";
 
     sshDomain.f_create_from_tstring_new = netsnmp_ssh_create_tstring;
+    sshDomain.f_create_from_tspec       = netsnmp_ssh_create_tspec;
     sshDomain.f_create_from_ostring     = netsnmp_ssh_create_ostring;
 
     register_config_handler("snmp", "sshtosnmpsocketperms",
@@ -990,6 +1234,10 @@ netsnmp_ssh_ctor(void)
     netsnmp_ds_register_config(ASN_OCTET_STR, "snmp", "sshtosnmpsocket",
                                NETSNMP_DS_LIBRARY_ID,
                                NETSNMP_DS_LIB_SSHTOSNMP_SOCKET);
+
+    netsnmp_ds_register_config(ASN_BOOLEAN, "snmp", "sshagent",
+                               NETSNMP_DS_LIBRARY_ID,
+                               NETSNMP_DS_LIB_SSH_AGENT);
 
     netsnmp_ds_register_config(ASN_OCTET_STR, "snmp", "sshusername",
                                NETSNMP_DS_LIBRARY_ID,


### PR DESCRIPTION
Attempts to connect on RHEL9 machines would fail on sendmsg(). Avoid EINVAL when passing credentials over SSH unix domain socket.

Align the socket path with the SSH transport.

Add option to log in using an sshagent in addition to explicit keys.

Initial IPv6 support.