### PR TITLE
Fix compatibility with Clang 16

### DIFF
--- a/agent/mibgroup/agentx/protocol.c
+++ b/agent/mibgroup/agentx/protocol.c
@@ -1900,7 +1900,7 @@ parse_err:
 
 #ifdef TESTING
 
-testit(netsnmp_pdu *pdu1)
+void testit(netsnmp_pdu *pdu1)
 {
     char            packet1[BUFSIZ];
     char            packet2[BUFSIZ];
@@ -1969,7 +1969,8 @@ testit(netsnmp_pdu *pdu1)
 
 
 
-main()
+int
+main(void)
 {
     netsnmp_pdu     pdu1;
     oid             oid_buf[] = { 1, 3, 6, 1, 2, 1, 10 };

--- a/agent/mibgroup/header_complex.c
+++ b/agent/mibgroup/header_complex.c
@@ -569,7 +569,7 @@ header_complex_dump(struct header_complex_index *thestuff)
     }
 }
 
-main()
+int main(void)
 {
     oid             oidsave[MAX_OID_LEN];
     int             len = MAX_OID_LEN, len2;

--- a/agent/mibgroup/if-mib/data_access/interface_linux.c
+++ b/agent/mibgroup/if-mib/data_access/interface_linux.c
@@ -38,7 +38,7 @@ static struct pci_access *pci_access;
 /* Avoid letting libpci call exit(1) when no PCI bus is available. */
 static int do_longjmp =0;
 static jmp_buf err_buf;
-static void
+PCI_NONRET static void
 netsnmp_pci_error(char *msg, ...)
 {
     va_list args;

--- a/configure.d/config_os_functions
+++ b/configure.d/config_os_functions
@@ -224,7 +224,14 @@ AC_CACHE_VAL(
 #ifdef HAVE_SYS_FS_TYPES_H
 #include <sys/fs_types.h>
 #endif
-int main ()
+#ifdef HAVE_SYS_STATFS_H
+#include <sys/statfs.h>
+#endif
+#ifdef HAVE_SYS_STATVFS_H
+#include <sys/statvfs.h>
+#endif
+
+int main (void)
 {
 struct fs_data fsd;
 /* Ultrix's statfs returns 1 for success,

--- a/configure.d/config_os_misc4
+++ b/configure.d/config_os_misc4
@@ -185,8 +185,13 @@ else
 #if HAVE_SYS_SYSCTL_H
 # include <sys/sysctl.h>
 #endif
+#if HAVE_STDLIB_H
+# include <stdlib.h>
+#endif
 
-main() {
+#include <stddef.h>
+
+int main(void) {
   int                 mib[2];
   size_t              len;
   struct timeval boottime;


### PR DESCRIPTION
Clang 16 makes -Wimplicit-function-declaration and -Wimplicit-int an error by default.
Unfortunately, this can lead to misconfiguration or miscompilation of software as configure
tests may then return the wrong result.

We also fix -Wstrict-prototypes while here as it's easy to do and it prepares
us for C23.

For more information, see LWN.net [0] or LLVM's Discourse [1], the Gentoo wiki [2],
or the (new) c-std-porting mailing list [3].

[0] https://lwn.net/Articles/913505/
[1] https://discourse.llvm.org/t/configure-script-breakage-with-the-new-werror-implicit-function-declaration/65213
[2] https://wiki.gentoo.org/wiki/Modern_C_porting
[3] hosted at lists.linux.dev.

Signed-off-by: Sam James <sam@gentoo.org>