### PR TITLE
ip-mib: Fix incorrect error handling for ipDefaultTTL sets

### DIFF
--- a/agent/mibgroup/ip-mib/data_access/scalars_linux.c
+++ b/agent/mibgroup/ip-mib/data_access/scalars_linux.c
@@ -139,7 +139,7 @@ netsnmp_arch_ip_scalars_ipDefaultTTL_set(u_long value)
 
     rc = fprintf(filep, "%ld", value);
     fclose(filep);
-    if (1 != rc) {
+    if (rc <= 0) {
         DEBUGMSGTL(("access:ipDefaultTTL", "could not write %s\n",
                     ipttl_name));
         return SNMP_ERR_GENERR;


### PR DESCRIPTION
An incorrect error check was causing failures to modify ipDefaultTTL when an integer with more than one digit is passed:

`
$ snmpget -v 2c -c private localhost .1.3.6.1.2.1.4.2.0
IP-MIB::ipDefaultTTL.0 = INTEGER: 64
$ snmpset -v 2c -c private localhost .1.3.6.1.2.1.4.2.0 i 128
Error in packet.
Reason: undoFailed
Failed object: IP-MIB::ipDefaultTTL.0

$ snmpset -v 2c -c private localhost .1.3.6.1.2.1.4.2.0 i 8
IP-MIB::ipDefaultTTL.0 = INTEGER: 8
$ snmpget -v 2c -c private localhost .1.3.6.1.2.1.4.2.0
IP-MIB::ipDefaultTTL.0 = INTEGER: 8

$ snmpset -v 2c -c private localhost .1.3.6.1.2.1.4.2.0 i 64
Error in packet.
Reason: (genError) A general failure occured
Failed object: IP-MIB::ipDefaultTTL.0
$ snmpget -v 2c -c private localhost .1.3.6.1.2.1.4.2.0
IP-MIB::ipDefaultTTL.0 = INTEGER: 8
`
