### PR TITLE
mibgroup: fix logic error

### DIFF
--- a/agent/mibgroup/mibII/kernel_linux.c
+++ b/agent/mibgroup/mibII/kernel_linux.c
@@ -438,9 +438,6 @@ linux_read_icmp_msg_stat(struct icmp_mib *icmpstat,
 
     if ((ret = linux_read_mibII_stats()) == -1) {
         return -1;
-    } else if (ret) {
-       memcpy(icmpmsgstat, &cached_icmp4_msg_mib, sizeof(*icmpmsgstat));
-       *flag = 1; /* We have a valid icmpmsg */
     }
 
     memcpy(icmpstat, &cached_icmp_mib, sizeof(*icmpstat));

--- a/agent/mibgroup/mibII/kernel_linux.c
+++ b/agent/mibgroup/mibII/kernel_linux.c
@@ -438,7 +438,7 @@ linux_read_icmp_msg_stat(struct icmp_mib *icmpstat,
 
     if ((ret = linux_read_mibII_stats()) == -1) {
         return -1;
-    } else if (!ret) {
+    } else if (ret) {
        memcpy(icmpmsgstat, &cached_icmp4_msg_mib, sizeof(*icmpmsgstat));
        *flag = 1; /* We have a valid icmpmsg */
     }

--- a/agent/mibgroup/mibII/kernel_linux.c
+++ b/agent/mibgroup/mibII/kernel_linux.c
@@ -438,7 +438,7 @@ linux_read_icmp_msg_stat(struct icmp_mib *icmpstat,
 
     if ((ret = linux_read_mibII_stats()) == -1) {
         return -1;
-    } else if (ret) {
+    } else if (!ret) {
        memcpy(icmpmsgstat, &cached_icmp4_msg_mib, sizeof(*icmpmsgstat));
        *flag = 1; /* We have a valid icmpmsg */
     }


### PR DESCRIPTION
linux_read_mibII_stats() returned 0 if
ret is successful, or -1 if ret is fail
