### PR TITLE
Disallow SET requests with NULL varbind

### DIFF
--- a/agent/snmp_agent.c
+++ b/agent/snmp_agent.c
@@ -3719,11 +3719,43 @@ netsnmp_handle_request(netsnmp_agent_session *asp, int status)
     return 1;
 }
 
+static int
+check_set_pdu_for_null_varbind(netsnmp_agent_session *asp)
+{
+    int i;
+    netsnmp_variable_list *v = NULL;
+
+    for (i = 1, v = asp->pdu->variables; v != NULL; i++, v = v->next_variable) {
+	if (v->type == ASN_NULL) {
+	    /*
+	     * Protect SET implementations that do not protect themselves
+	     * against wrong type.
+	     */
+	    DEBUGMSGTL(("snmp_agent", "disallowing SET with NULL var for varbind %d\n", i));
+	    asp->index = i;
+	    return SNMP_ERR_WRONGTYPE;
+	}
+    }
+    return SNMP_ERR_NOERROR;
+}
+
 int
 handle_pdu(netsnmp_agent_session *asp)
 {
     int             status, inclusives = 0;
     netsnmp_variable_list *v = NULL;
+
+#ifndef NETSNMP_NO_WRITE_SUPPORT
+    /*
+     * Check for ASN_NULL in SET request
+     */
+    if (asp->pdu->command == SNMP_MSG_SET) {
+	status = check_set_pdu_for_null_varbind(asp);
+	if (status != SNMP_ERR_NOERROR) {
+	    return status;
+	}
+    }
+#endif /* NETSNMP_NO_WRITE_SUPPORT */
 
     /*
      * for illegal requests, mark all nodes as ASN_NULL 

--- a/apps/snmpset.c
+++ b/apps/snmpset.c
@@ -182,6 +182,7 @@ main(int argc, char *argv[])
             case 'x':
             case 'd':
             case 'b':
+            case 'n': /* undocumented */
 #ifdef NETSNMP_WITH_OPAQUE_SPECIAL_TYPES
             case 'I':
             case 'U':

--- a/testing/fulltests/default/T0142snmpv2csetnull_simple
+++ b/testing/fulltests/default/T0142snmpv2csetnull_simple
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+. ../support/simple_eval_tools.sh
+
+HEADER SNMPv2c set of system.sysContact.0 with NULL varbind
+
+SKIPIF NETSNMP_DISABLE_SET_SUPPORT
+SKIPIF NETSNMP_NO_WRITE_SUPPORT
+SKIPIF NETSNMP_DISABLE_SNMPV2C
+SKIPIFNOT USING_MIBII_SYSTEM_MIB_MODULE
+
+#
+# Begin test
+#
+
+# standard V2C configuration: testcomunnity
+snmp_write_access='all'
+. ./Sv2cconfig
+STARTAGENT
+
+CAPTURE "snmpget -On $SNMP_FLAGS -c testcommunity -v 2c $SNMP_TRANSPORT_SPEC:$SNMP_TEST_DEST$SNMP_SNMPD_PORT .1.3.6.1.2.1.1.4.0"
+
+CHECK ".1.3.6.1.2.1.1.4.0 = STRING:"
+
+CAPTURE "snmpset -On $SNMP_FLAGS -c testcommunity -v 2c $SNMP_TRANSPORT_SPEC:$SNMP_TEST_DEST$SNMP_SNMPD_PORT .1.3.6.1.2.1.1.4.0 n x"
+
+CHECK "Reason: wrongType"
+
+STOPAGENT
+
+FINISHED


### PR DESCRIPTION
I'm creating a pull request here just to solicit reviews - I can obviously commit myself if we decide this is right.

This is my reaction to #474 and #475 - both of these are because the SET code doesn't check the incoming type at all, and assume that the integer member of the union is set.  But for a NULL type, the pointer is NULL.

There are still problems with MIB module implementations that do not check the varbind type - what does it mean to set the ipDefaultTTL to an OBJECT-IDENTIFIER?  So there are still opportunities for cleanup; every SET_RESERVE1 should call `netsnmp_check_vb_type()` - but NULL is the only case where the pointer will be invalid, so this patch eliminates the possibility that a module implementation will naively dereference a NULL pointer.
