### PR TITLE
apps: fix handle leak

### DIFF
--- a/apps/snmpping.c
+++ b/apps/snmpping.c
@@ -334,6 +334,7 @@ start_ping(netsnmp_session *ss, oid * index, size_t indexlen, char *pingDest)
           break;
 #endif
        default:
+          freeaddrinfo(dest);
           fprintf(stderr, "Unsupported address family\n");
           return 3;
     }


### PR DESCRIPTION
In default case dest wasn't freed, although in the current code this is hardly possible, here is potential problem