### PR TITLE
configure: Fix false positive when build dir contains "yes"

### DIFF
--- a/configure.d/config_project_ipv6_types
+++ b/configure.d/config_project_ipv6_types
@@ -65,7 +65,7 @@ if test "x$enable_ipv6" = "xyes"; then
 	for v6type in v6d toshiba kame zeta generic; do
 		case $v6type in
 		v6d)
-			AC_EGREP_CPP(yes, [
+			AC_EGREP_CPP(^yes$, [
 #include </usr/local/v6/include/sys/types.h>
 #ifdef __V6D__
 yes
@@ -75,7 +75,7 @@ yes
 				CFLAGS="-I/usr/local/v6/include $CFLAGS"])
 			;;
 		toshiba)
-			AC_EGREP_CPP(yes, [
+			AC_EGREP_CPP(^yes$, [
 #include <sys/param.h>
 #ifdef _TOSHIBA_INET6
 yes
@@ -85,7 +85,7 @@ yes
 				CFLAGS="-DNETSNMP_ENABLE_IPV6 $CFLAGS"])
 			;;
 		kame)
-			AC_EGREP_CPP(yes, [
+			AC_EGREP_CPP(^yes$, [
 #include <netinet/in.h>
 #ifdef __KAME__
 yes
@@ -96,7 +96,7 @@ yes
 				CFLAGS="-DNETSNMP_ENABLE_IPV6 $CFLAGS"])
 			;;
 		zeta)
-			AC_EGREP_CPP(yes, [
+			AC_EGREP_CPP(^yes$, [
 #include <sys/param.h>
 #ifdef _ZETA_MINAMI_INET6
 yes


### PR DESCRIPTION
The checks for various IPv6 libraries succeed when the word "yes" appears anywhere in the CPP output. That's prone to false positives, e.g. when the build environment path contains that string.

Make the check more robust by anchoring the pattern so the word must appear on a line of its own.