### PR TITLE
[5.9.3]: Ipaddress linux unbreak without rtnetlink

### DIFF
--- a/agent/mibgroup/ip-mib/data_access/ipaddress_ioctl.c
+++ b/agent/mibgroup/ip-mib/data_access/ipaddress_ioctl.c
@@ -244,7 +244,7 @@ _netsnmp_ioctl_ipaddress_container_load_v4(netsnmp_container *container,
          * get broadcast
          */
         memset(&addr_info, 0, sizeof(struct address_flag_info));
-#if defined (NETSNMP_ENABLE_IPV6)
+#if defined (NETSNMP_ENABLE_IPV6) && defined(HAVE_LINUX_RTNETLINK_H)
         addr_info = netsnmp_access_other_info_get(entry->if_index, AF_INET);
         if(addr_info.bcastflg) {
            bcastentry = netsnmp_access_ipaddress_entry_create();

--- a/agent/mibgroup/ip-mib/data_access/ipaddress_linux.c
+++ b/agent/mibgroup/ip-mib/data_access/ipaddress_linux.c
@@ -430,8 +430,8 @@ _load_v6(netsnmp_container *container, int idx_offset)
     return idx_offset;
 #endif /* HAVE_LINUX_RTNETLINK_H */
 }
-#endif /* NETSNMP_ENABLE_IPV6 */
 
+#ifdef HAVE_LINUX_RTNETLINK_H
 struct address_flag_info
 netsnmp_access_other_info_get(int index, int family)
 {
@@ -521,8 +521,6 @@ out:
     return addr;
 }
 
-#if defined (NETSNMP_ENABLE_IPV6)
-#ifdef HAVE_LINUX_RTNETLINK_H
 int
 netsnmp_access_ipaddress_extra_prefix_info(int index, u_long *preferedlt,
                                            ulong *validlt, char *addr)


### PR DESCRIPTION
Commit 89a7860829fdc618ef (IP-MIB: Fix the --disable-ipv6 build) moved defines around to fix builds without IPv6 support, but accidently caused netsnmp_access_other_info_get() to be visible even if HAVE_LINUX_RTNETLINK_H isn't defined, leading to build issues:

mibgroup/ip-mib/data_access/ipaddress_linux.c: In function ‘netsnmp_access_other_info_get’: mibgroup/ip-mib/data_access/ipaddress_linux.c:439:28: error: field ‘n’ has incomplete type
            struct nlmsghdr n;
                            ^
mibgroup/ip-mib/data_access/ipaddress_linux.c:440:29: error: field ‘r’ has incomplete type
            struct ifaddrmsg r;
                             ^
mibgroup/ip-mib/data_access/ipaddress_linux.c:454:40: error: ‘NETLINK_ROUTE’ undeclared (first use in this function)
    sd = socket(PF_NETLINK, SOCK_DGRAM, NETLINK_ROUTE);
                                        ^~~~~~~~~~~~~
mibgroup/ip-mib/data_access/ipaddress_linux.c:454:40: note: each undeclared identifier is reported only once for each function it appears in mibgroup/ip-mib/data_access/ipaddress_linux.c:461:22: warning: implicit declaration of function ‘NLMSG_LENGTH’; did you mean ‘CMSG_LEN’? [-Wimplicit-function-declaration]
    req.n.nlmsg_len = NLMSG_LENGTH(sizeof(struct ifaddrmsg));
                      ^~~~~~~~~~~~
                      CMSG_LEN
mibgroup/ip-mib/data_access/ipaddress_linux.c:461:42: error: invalid application of ‘sizeof’ to incomplete type ‘struct ifaddrmsg’
    req.n.nlmsg_len = NLMSG_LENGTH(sizeof(struct ifaddrmsg));
                                          ^~~~~~

Fix it by also enclosing it within the RTNETLINK and IPV6 guards, similar to netsnmp_access_ipaddress_extra_prefix_info().  Given that are already inside an IPV6 conditional just above and below, simply reuse that for simplicity.

Signed-off-by: Peter Korsgaard <peter@korsgaard.com>