### PR TITLE
snmplib: fix memory leak

### DIFF
--- a/snmplib/parse.c
+++ b/snmplib/parse.c
@@ -2215,8 +2215,12 @@ parse_enumlist(FILE * fp, struct enum_list **retp)
     *retp = ep;
     return ep;
     out_err:
-        free(epp);
-        return NULL;
+        if((*epp)->label) { 
+            free((*epp)->label); 
+        }
+        free(*epp);
+        *epp = NULL;
+        return *epp;
 }
 
 static struct range_list *

--- a/snmplib/parse.c
+++ b/snmplib/parse.c
@@ -2192,28 +2192,31 @@ parse_enumlist(FILE * fp, struct enum_list **retp)
             type = get_token(fp, token, MAXTOKEN);
             if (type != LEFTPAREN) {
                 print_error("Expected \"(\"", token, type);
-                return NULL;
+                goto out_err;
             }
             type = get_token(fp, token, MAXTOKEN);
             if (type != NUMBER) {
                 print_error("Expected integer", token, type);
-                return NULL;
+                goto out_err;
             }
             (*epp)->value = strtol(token, NULL, 10);
             type = get_token(fp, token, MAXTOKEN);
             if (type != RIGHTPAREN) {
                 print_error("Expected \")\"", token, type);
-                return NULL;
+                goto out_err;
             }
             epp = &(*epp)->next;
         }
     }
     if (type == ENDOFFILE) {
         print_error("Expected \"}\"", token, type);
-        return NULL;
+        goto out_err;
     }
     *retp = ep;
     return ep;
+    out_err:
+        free(epp);
+        return NULL;
 }
 
 static struct range_list *


### PR DESCRIPTION
Fixed the incorrect error handling that was the cause of memory leak

Found by RASU JSC with ISP RAS Svace
Signed-off-by: Maxim Korotkov <maskorotkov@rasu.ru>