### PR TITLE
mibgroup: fix NULL dereference in write_snmpNotifyFilterProfileRowStatus()

### DIFF
--- a/agent/mibgroup/notification/snmpNotifyFilterProfileTable.c
+++ b/agent/mibgroup/notification/snmpNotifyFilterProfileTable.c
@@ -395,6 +395,7 @@ write_snmpNotifyFilterProfileRowStatus(int action,
     static struct snmpNotifyFilterProfileTable_data *StorageDel;
     size_t          newlen = name_len - table_offset;
     static int      old_value;
+    if (!var_val) return SNMP_ERR_WRONGTYPE; 
     int             set_value = *((long *) var_val);
     netsnmp_variable_list *vars;
 

--- a/agent/mibgroup/notification/snmpNotifyFilterProfileTable.c
+++ b/agent/mibgroup/notification/snmpNotifyFilterProfileTable.c
@@ -395,9 +395,14 @@ write_snmpNotifyFilterProfileRowStatus(int action,
     static struct snmpNotifyFilterProfileTable_data *StorageDel;
     size_t          newlen = name_len - table_offset;
     static int      old_value;
-    if (!var_val) return SNMP_ERR_WRONGTYPE; 
-    int             set_value = *((long *) var_val);
+    int             set_value;
     netsnmp_variable_list *vars;
+    
+    if (!var_val) {
+        return SNMP_ERR_WRONGTYPE;
+    }
+    
+    set_value= *((long *) var_val)
 
 
     DEBUGMSGTL(("snmpNotifyFilterProfileTable",

--- a/agent/mibgroup/notification/snmpNotifyTable.c
+++ b/agent/mibgroup/notification/snmpNotifyTable.c
@@ -523,9 +523,15 @@ write_snmpNotifyRowStatus(int action,
     static struct snmpNotifyTable_data *StorageDel;
     size_t          newlen = name_len - snmpNotifyTable_offset;
     static int      old_value;
-    int             set_value = *((long *) var_val);
+    int             set_value;
     static netsnmp_variable_list *vars, *vp;
 
+    if (!var_val) {
+        return SNMP_ERR_WRONGTYPE; 
+    }
+
+    set_value = *((long *) var_val)
+    
     DEBUGMSGTL(("snmpNotifyTable",
                 "write_snmpNotifyRowStatus entering action=%d...  \n",
                 action));


### PR DESCRIPTION
In case RESERVE_1 pointer var_val was checked against NULL, although it was dereferenced for assignment set_value before check
Found by RASU JSC
