### PR TITLE
Fix use of AC_EGREP_CPP or avoid it entirely.

### DIFF
--- a/configure
+++ b/configure
@@ -16374,7 +16374,7 @@ yes
     ]
 _ACEOF
 if (eval "$ac_cpp conftest.$ac_ext") 2>&5 |
-  $EGREP "yes" >/dev/null 2>&1; then :
+  $EGREP "^yes$" >/dev/null 2>&1; then :
     PARTIALTARGETFLAGS="-U$PARTIALTARGETOS -D$PARTIALTARGETOS=$PARTIALTARGETOS"
        { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }
@@ -30582,20 +30582,13 @@ $as_echo_n "checking for struct rtentry... " >&6; }
 if ${ac_cv_struct_rtentry+:} false; then :
   $as_echo_n "(cached) " >&6
 else
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-#define KERNEL
-#include <net/route.h>
-
-_ACEOF
-if (eval "$ac_cpp conftest.$ac_ext") 2>&5 |
-  $EGREP "ortentry" >/dev/null 2>&1; then :
+  ac_fn_c_check_type "$LINENO" "struct ortentry" "ac_cv_type_struct_ortentry" "#include <net/route.h>
+"
+if test "x$ac_cv_type_struct_ortentry" = xyes; then :
   ac_cv_struct_rtentry=ortentry
 else
   ac_cv_struct_rtentry=rtentry
 fi
-rm -f conftest*
 
         if test "x$ac_cv_struct_rtentry" = "xrtentry" ; then
              ac_cv_struct_rtentry="rtentry"
@@ -31022,7 +31015,7 @@ TCPTV_REXMTMAX
 
 _ACEOF
 if (eval "$ac_cpp conftest.$ac_ext") 2>&5 |
-  $EGREP "hz" >/dev/null 2>&1; then :
+  $EGREP "\<hz\>" >/dev/null 2>&1; then :
   ac_cv_TCPTV_NEEDS_HZ=yes
 else
   ac_cv_TCPTV_NEEDS_HZ=no

--- a/configure.d/config_os_misc4
+++ b/configure.d/config_os_misc4
@@ -224,7 +224,7 @@ fi
 #
 AC_CACHE_CHECK([whether TCP timers depend on 'hz'],
     ac_cv_TCPTV_NEEDS_HZ,
-   [AC_EGREP_CPP(hz,
+   [AC_EGREP_CPP([\<hz\>],
         [
 #include <netinet/tcp_timer.h>
 TCPTV_MIN

--- a/configure.d/config_os_progs
+++ b/configure.d/config_os_progs
@@ -231,7 +231,7 @@ AC_MSG_CHECKING([whether to un-define target system token (before redefining)])
 OLD_CPPFLAGS="$CPPFLAGS"
 CPPFLAGS="-U$PARTIALTARGETOS -D$PARTIALTARGETOS=$PARTIALTARGETOS"
 
-AC_EGREP_CPP(yes,
+AC_EGREP_CPP([^yes$],
     [[
 #ifdef $PARTIALTARGETOS
 yes

--- a/configure.d/config_os_struct_members
+++ b/configure.d/config_os_struct_members
@@ -696,13 +696,10 @@ fi
 if test "x$ac_cv_RTENTRY_TYPE" = "xunknown"; then
     AC_CACHE_CHECK([for struct rtentry],
         [ac_cv_struct_rtentry],
-        [AC_EGREP_CPP(ortentry,
-            [
-#define KERNEL
-#include <net/route.h>
-            ],
+	[AC_CHECK_TYPE([struct ortentry],
             [ac_cv_struct_rtentry=ortentry],
-            [ac_cv_struct_rtentry=rtentry ])
+	    [ac_cv_struct_rtentry=rtentry],
+	    [[#include <net/route.h>]])
         if test "x$ac_cv_struct_rtentry" = "xrtentry" ; then
              ac_cv_struct_rtentry="rtentry"
         else

--- a/configure.d/config_project_ipv6_types
+++ b/configure.d/config_project_ipv6_types
@@ -65,7 +65,7 @@ if test "x$enable_ipv6" = "xyes"; then
 	for v6type in v6d toshiba kame zeta generic; do
 		case $v6type in
 		v6d)
-			AC_EGREP_CPP(^yes$, [
+			AC_EGREP_CPP([^yes$], [
 #include </usr/local/v6/include/sys/types.h>
 #ifdef __V6D__
 yes
@@ -75,7 +75,7 @@ yes
 				CFLAGS="-I/usr/local/v6/include $CFLAGS"])
 			;;
 		toshiba)
-			AC_EGREP_CPP(^yes$, [
+			AC_EGREP_CPP([^yes$], [
 #include <sys/param.h>
 #ifdef _TOSHIBA_INET6
 yes
@@ -85,7 +85,7 @@ yes
 				CFLAGS="-DNETSNMP_ENABLE_IPV6 $CFLAGS"])
 			;;
 		kame)
-			AC_EGREP_CPP(^yes$, [
+			AC_EGREP_CPP([^yes$], [
 #include <netinet/in.h>
 #ifdef __KAME__
 yes
@@ -96,7 +96,7 @@ yes
 				CFLAGS="-DNETSNMP_ENABLE_IPV6 $CFLAGS"])
 			;;
 		zeta)
-			AC_EGREP_CPP(^yes$, [
+			AC_EGREP_CPP([^yes$], [
 #include <sys/param.h>
 #ifdef _ZETA_MINAMI_INET6
 yes


### PR DESCRIPTION
Using AC_EGREP_CPP is prone to false positives if not used carefully.

Use AC_CHECK_TYPE when looking for struct ortentry instead.

Otherwise, quote the first argument to AC_EGREP_CPP, for more readability and consistency.