### PR TITLE
Fix order of evaluation during init

### DIFF
--- a/snmplib/snmpv3.c
+++ b/snmplib/snmpv3.c
@@ -1052,6 +1052,8 @@ init_snmpv3_post_config(int majorid, int minorid, void *serverarg,
 
     size_t          engineIDLen;
     u_char         *c_engineID;
+    u_long          localEngineTime;
+    u_long          localEngineBoots;
 
     c_engineID = snmpv3_generate_engineID(&engineIDLen);
 
@@ -1076,9 +1078,11 @@ init_snmpv3_post_config(int majorid, int minorid, void *serverarg,
     /*
      * for USM set our local engineTime in the LCD timing cache 
      */
+    localEngineTime = snmpv3_local_snmpEngineTime();
+    localEngineBoots = snmpv3_local_snmpEngineBoots();
     set_enginetime(c_engineID, engineIDLen,
-                   snmpv3_local_snmpEngineBoots(),
-                   snmpv3_local_snmpEngineTime(), TRUE);
+                   localEngineBoots,
+                   localEngineTime, TRUE);
 #endif /* NETSNMP_SECMOD_USM */
 
     SNMP_FREE(c_engineID);


### PR DESCRIPTION
As per order of [function evaluation](https://en.cppreference.com/w/c/language/eval_order) it is up to the compiler to decide which function is executed first. As  `snmpv3_local_snmpEngineTime()` can increase engineBoot which is later taken from `snmpv3_local_snmpEngineBoots` there can be some issues during restart.
Please note that `set_enginetime()` function saves engineBoot taken as an argument and saves it in Enginetime list which is later used to generate response message and fill fields like engineBoots and engineTime. As per below code we can have two possibilites after restart.

1. `snmpv3_local_snmpEngineTime()` is executed first. EngineBoot is increased to 2 and then `snmpv3_local_snmpEngineBoots` returns 2 and everything works correctly.
2. `snmpv3_local_snmpEngineBoots` is executed first and returns 1. Then `snmpv3_local_snmpEngineTime()` is executed and EngineBoot is increased to 2. This behaviour causes ""USM not in time window" error for incoming requests and the communication with agent is broke.  

This behaviour was seen when using net-snmp code for VxWorks7 and the scenario no.2 was observed