### PR TITLE
Added option to exclude *md* devices in diskio.

### DIFF
--- a/agent/mibgroup/ucd-snmp/diskio_linux.c
+++ b/agent/mibgroup/ucd-snmp/diskio_linux.c
@@ -94,6 +94,8 @@ diskio_free_config(void)
                            NETSNMP_DS_AGENT_DISKIO_NO_LOOP, 0);
     netsnmp_ds_set_boolean(NETSNMP_DS_APPLICATION_ID,
                            NETSNMP_DS_AGENT_DISKIO_NO_RAM, 0);
+    netsnmp_ds_set_boolean(NETSNMP_DS_APPLICATION_ID,
+                           NETSNMP_DS_AGENT_DISKIO_NO_MD, 0);
 
     if (la_head.length) {
         /*
@@ -253,6 +255,9 @@ void init_diskio_linux(void)
     netsnmp_ds_register_config(ASN_BOOLEAN, app, "diskio_exclude_ram",
                                NETSNMP_DS_APPLICATION_ID,
                                NETSNMP_DS_AGENT_DISKIO_NO_RAM);
+    netsnmp_ds_register_config(ASN_BOOLEAN, app, "diskio_exclude_md",
+                               NETSNMP_DS_APPLICATION_ID,
+                               NETSNMP_DS_AGENT_DISKIO_NO_MD);
 
     snmpd_register_config_handler("diskio", diskio_parse_config_disks,
         diskio_free_config, "path | device");
@@ -326,6 +331,10 @@ is_excluded(const char *name)
     if (netsnmp_ds_get_boolean(NETSNMP_DS_APPLICATION_ID,
                                NETSNMP_DS_AGENT_DISKIO_NO_RAM)
         && !(strncmp(name, "ram", 3)))
+        return 1;
+    if (netsnmp_ds_get_boolean(NETSNMP_DS_APPLICATION_ID,
+                               NETSNMP_DS_AGENT_DISKIO_NO_MD)
+        && !(strncmp(name, "md", 2)))
         return 1;
     return 0;
 }

--- a/include/net-snmp/agent/ds_agent.h
+++ b/include/net-snmp/agent/ds_agent.h
@@ -40,6 +40,7 @@
 #define NETSNMP_DS_AGENT_DISKIO_NO_FD   18      /* 1 = don't report /dev/fd*   entries in diskIOTable */
 #define NETSNMP_DS_AGENT_DISKIO_NO_LOOP 19      /* 1 = don't report /dev/loop* entries in diskIOTable */
 #define NETSNMP_DS_AGENT_DISKIO_NO_RAM  20      /* 1 = don't report /dev/ram*  entries in diskIOTable */
+#define NETSNMP_DS_AGENT_DISKIO_NO_MD   21      /* 1 = don't report /dev/md*   entries in diskIOTable */
 
 /* WARNING: The trap receiver also uses DS flags and must not conflict with these!
  * If you define additional boolean entries, check in "apps/snmptrapd_ds.h" first */


### PR DESCRIPTION
In many cases, on systems which have md raid, net-snmp reports each single disk plus the /dev/md* device in the diskIOTable. Sometimes this is not needed. This code change adds an option to exclude md entries in the diskIOTable.