### PR TITLE
Added fix for TSM/TLS segfault.

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -127,7 +127,7 @@ Installing the Perl/SNMP Module
 (which includes other Net-SNMP specific modules as well), all of which
 are located in the net-snmp/perl directory. The Perl package provides
 a high level abstract interface to the functionality found in the
-Net-SNMP libraries and demon applications.
+Net-SNMP libraries and daemon applications.
 
    It is recommended you install the perl modules as you build the
    Net-SNMP package.  The configure script can be run as follows to

--- a/NEWS
+++ b/NEWS
@@ -1144,7 +1144,7 @@ UCD-SNMP NEWS:
  Ports:
     - HPUX 11
     - Dynix/PTX 4.4
-    - The snmpd demon can properly run as a windows service
+    - The snmpd daemon can properly run as a windows service
 
 *4.2.3*
  New:

--- a/agent/helpers/debug_handler.c
+++ b/agent/helpers/debug_handler.c
@@ -26,7 +26,7 @@
  *  All debugging output is done via the standard debugging routines
  *  with a token name of "helper:debug", so use the -Dhelper:debug
  *  command line flag to see the output when running the snmpd
- *  demon. It's not recommended you compile this into a handler chain
+ *  daemon. It's not recommended you compile this into a handler chain
  *  during compile time, but instead use the "injectHandler" token in
  *  the snmpd.conf file (or similar) to add it to the chain later:
  *

--- a/agent/mibgroup/disman/nslookup/lookupCtlTable.h
+++ b/agent/mibgroup/disman/nslookup/lookupCtlTable.h
@@ -19,7 +19,7 @@
  */
 
 
-config_require(header_complex);
+config_require(header_complex)
 
     /*
      * our storage structure(s) 

--- a/agent/mibgroup/examples/notification.c
+++ b/agent/mibgroup/examples/notification.c
@@ -11,7 +11,7 @@
  *
  *  When this module is compiled into the agent (run configure with
  *  --with-mib-modules="examples/notification") then it should send
- *  out traps, which when received by the snmptrapd demon will look
+ *  out traps, which when received by the snmptrapd daemon will look
  *  roughly like:
  *
  *  2002-05-08 08:57:05 localhost.localdomain [udp:127.0.0.1:32865]:

--- a/agent/mibgroup/hardware/fsys/fsys_mntent.c
+++ b/agent/mibgroup/hardware/fsys/fsys_mntent.c
@@ -86,6 +86,7 @@ static const char *other_fs[] = {
     "nssvol",
     "nvmfs",
     "ocfs2",
+    "overlay",
     "reiserfs",
     "simfs",
     "tmpfs",

--- a/agent/mibgroup/ip-mib/data_access/systemstats_sysctl.c
+++ b/agent/mibgroup/ip-mib/data_access/systemstats_sysctl.c
@@ -25,7 +25,7 @@
 #define _KERNEL 1
 #define _I_DEFINED_KERNEL
 #endif
-#if NETSNMP_IFNET_NEEDS_KERNEL_STRUCTURES
+#ifdef NETSNMP_IFNET_NEEDS_KERNEL_STRUCTURES
 #define _KERNEL_STRUCTURES
 #endif
 #include <net/if.h>

--- a/agent/mibgroup/mibII/data_access/at_hpux.c
+++ b/agent/mibgroup/mibII/data_access/at_hpux.c
@@ -79,7 +79,7 @@
 #include <sys/net/if_dl.h>
 #endif
 #endif
-#if HAVE_SYS_STREAM_H
+#ifdef HAVE_SYS_STREAM_H
 #include <sys/stream.h>
 #endif
 #if HAVE_NET_ROUTE_H

--- a/agent/mibgroup/mibII/interfaces.c
+++ b/agent/mibgroup/mibII/interfaces.c
@@ -53,7 +53,7 @@ netsnmp_feature_provide(interface_legacy);
 #include <sys/socket.h>
 #endif
 #ifndef STREAM_NEEDS_KERNEL_ISLANDS
-#if HAVE_SYS_STREAM_H
+#ifdef HAVE_SYS_STREAM_H
 #include <sys/stream.h>
 #endif
 #endif
@@ -96,7 +96,7 @@ netsnmp_feature_provide(interface_legacy);
 #undef _KERNEL
 #endif
 #ifdef STREAM_NEEDS_KERNEL_ISLANDS
-#if HAVE_SYS_STREAM_H
+#ifdef HAVE_SYS_STREAM_H
 #include <sys/stream.h>
 #endif
 #endif

--- a/agent/mibgroup/mibII/ip.c
+++ b/agent/mibgroup/mibII/ip.c
@@ -248,6 +248,13 @@ long            ipTTL, oldipTTL;
 #define	USES_TRADITIONAL_IPSTAT
 #endif
 
+#ifdef IP_NSTATS
+typedef struct ipstat {
+        uint64_t st[IP_NSTATS];
+};
+#define IP_STAT_STRUCTURE      struct ipstat
+#endif
+
 #ifdef dragonfly
 #define IP_STAT_STRUCTURE	struct ip_stats
 #define	USES_TRADITIONAL_IPSTAT

--- a/agent/mibgroup/mibII/route_headers.h
+++ b/agent/mibgroup/mibII/route_headers.h
@@ -15,7 +15,7 @@
 #endif
 
 #include <net/if_dl.h>
-#if HAVE_SYS_STREAM_H
+#ifdef HAVE_SYS_STREAM_H
 #include <sys/stream.h>
 #endif
 #include <net/route.h>

--- a/agent/mibgroup/mibII/tcp.c
+++ b/agent/mibgroup/mibII/tcp.c
@@ -189,6 +189,11 @@ init_tcp(void)
 #define USES_TRADITIONAL_TCPSTAT
 #endif
 
+#ifdef TCP_NSTATS
+typedef uint32_t tcp_stats[TCP_NSTATS];
+#define TCP_STAT_STRUCTURE	tcp_stats
+#endif
+
 #ifdef dragonfly
 #define TCP_STAT_STRUCTURE	struct tcp_stats
 #define USES_TRADITIONAL_TCPSTAT
@@ -324,6 +329,75 @@ tcp_handler(netsnmp_mib_handler          *handler,
 #endif			/* linux */
         netsnmp_set_request_error(reqinfo, request, SNMP_NOSUCHOBJECT);
         continue;
+#elif defined(TCP_NSTAT)
+    case TCPRTOALGORITHM:      /* Assume Van Jacobsen's algorithm */
+        ret_value = 4;
+        type = ASN_INTEGER;
+        break;
+    case TCPRTOMIN:
+#ifdef TCPTV_NEEDS_HZ
+        ret_value = TCPTV_MIN;
+#else
+        ret_value = TCPTV_MIN / PR_SLOWHZ * 1000;
+#endif
+        type = ASN_INTEGER;
+        break;
+    case TCPRTOMAX:
+#ifdef TCPTV_NEEDS_HZ
+        ret_value = TCPTV_REXMTMAX;
+#else
+        ret_value = TCPTV_REXMTMAX / PR_SLOWHZ * 1000;
+#endif
+        type = ASN_INTEGER;
+        break;
+    case TCPMAXCONN:
+        ret_value = -1;		/* Dynamic maximum */
+        type = ASN_INTEGER;
+        break;
+    case TCPACTIVEOPENS:
+        ret_value = tcpstat[TCP_STAT_CONNATTEMPT];
+        break;
+    case TCPPASSIVEOPENS:
+        ret_value = tcpstat[TCP_STAT_ACCEPTS];
+        break;
+        /*
+         * NB:  tcps_drops is actually the sum of the two MIB
+         *      counters tcpAttemptFails and tcpEstabResets.
+         */
+    case TCPATTEMPTFAILS:
+        ret_value = tcpstat[TCP_STAT_CONNDROPS];
+        break;
+    case TCPESTABRESETS:
+        ret_value = tcpstat[TCP_STAT_DROPS];
+        break;
+    case TCPCURRESTAB:
+#ifdef USING_MIBII_TCPTABLE_MODULE
+        ret_value = TCP_Count_Connections();
+#else
+        ret_value = 0;
+#endif
+        type = ASN_GAUGE;
+        break;
+    case TCPINSEGS:
+        ret_value = tcpstat[TCP_STAT_RCVTOTAL];
+        break;
+    case TCPOUTSEGS:
+        /*
+         * RFC 1213 defines this as the number of segments sent
+         * "excluding those containing only retransmitted octets"
+         */
+        ret_value = tcpstat[TCP_STAT_SNDTOTAL] - tcpstat[TCP_STAT_SNDREXMITPACK];
+        break;
+    case TCPRETRANSSEGS:
+        ret_value = tcpstat[TCP_STAT_SNDREXMITPACK];
+        break;
+    case TCPINERRS:
+        ret_value = tcpstat[TCP_STAT_RCVBADSUM] + tcpstat[TCP_STAT_RCVBADOFF]
+            + tcpstat[TCP_STAT_RCVMEMDROP] + tcpstat[TCP_STAT_RCVSHORT];
+        break;
+    case TCPOUTRSTS:
+        ret_value = tcpstat[TCP_STAT_SNDCTRL] - tcpstat[TCP_STAT_CLOSED];
+        break;
 #elif defined(USES_TRADITIONAL_TCPSTAT) && !defined(_USE_FIRST_PROTOCOL)
 #ifdef HAVE_SYS_TCPIPSTATS_H
     /*

--- a/agent/mibgroup/mibII/tcpTable.c
+++ b/agent/mibgroup/mibII/tcpTable.c
@@ -122,6 +122,8 @@ typedef struct netsnmp_inpcb_s netsnmp_inpcb;
 struct netsnmp_inpcb_s {
 #if __FreeBSD_version >= 1200026
     struct xinpcb   pcb;
+#elif defined(__NetBSD__) && __NetBSD_Version__ >= 999010400
+    struct in4pcb    pcb;
 #else
     struct inpcb    pcb;
 #endif
@@ -132,11 +134,21 @@ struct netsnmp_inpcb_s {
 #define INP_NEXT_SYMBOL		inp_next
 #define	TCPTABLE_ENTRY_TYPE	netsnmp_inpcb 
 #define	TCPTABLE_STATE		state 
+#define	TCPTABLE_IS_LINKED_LIST
+#define INP_NEXT_SYMBOL		inp_next
+#if defined(__NetBSD__) && __NetBSD_Version__ >= 999010400
+#define	TCPTABLE_LOCALADDRESS	pcb.in4p_ip.ip_src.s_addr 
+#define	TCPTABLE_LOCALPORT	pcb.in4p_pcb.inp_lport
+#define	TCPTABLE_REMOTEADDRESS	pcb.in4p_ip.ip_dst.s_addr 
+#define	TCPTABLE_REMOTEPORT	pcb.in4p_pcb.inp_fport
+#define	TCPTABLE_TCPCB          pcb.in4p_pcb.inp_ppcb
+#else
 #define	TCPTABLE_LOCALADDRESS	pcb.inp_laddr.s_addr 
 #define	TCPTABLE_LOCALPORT	pcb.inp_lport
 #define	TCPTABLE_REMOTEADDRESS	pcb.inp_faddr.s_addr 
 #define	TCPTABLE_REMOTEPORT	pcb.inp_fport
-#define	TCPTABLE_IS_LINKED_LIST
+#define TCPTABLE_TCPCB		pcb.inp_ppcb
+#endif
 
 #endif                          /* hpux11 */
 
@@ -1057,18 +1069,22 @@ tcpTable_load(netsnmp_cache *cache, void *vmagic)
     /*
      *  Set up a linked list
      */
+#if defined(__NetBSD__) && __NetBSD_Version__ >= 699002800
+    entry  = TAILQ_FIRST(&table.inpt_queue);
+#else
     entry  = table.INP_FIRST_SYMBOL;
+#endif
     while (entry) {
    
         nnew = SNMP_MALLOC_TYPEDEF(netsnmp_inpcb);
         if (!nnew)
             break;
-        if (!NETSNMP_KLOOKUP(entry, (char *)&(nnew->pcb), sizeof(struct inpcb))) {
+        if (!NETSNMP_KLOOKUP(entry, (char *)&(nnew->pcb), sizeof(nnew->pcb))) {
             DEBUGMSGTL(("mibII/tcpTable:TcpTable_load", "klookup failed\n"));
             break;
         }
 
-        if (!NETSNMP_KLOOKUP(nnew->pcb.inp_ppcb, (char *)&tcpcb, sizeof(struct tcpcb))) {
+        if (!NETSNMP_KLOOKUP(nnew->TCPTABLE_TCPCB, (char *)&tcpcb, sizeof(struct tcpcb))) {
             DEBUGMSGTL(("mibII/tcpTable:TcpTable_load", "klookup failed\n"));
             break;
         }
@@ -1081,7 +1097,11 @@ tcpTable_load(netsnmp_cache *cache, void *vmagic)
 	nnew->inp_next = tcp_head;
 	tcp_head   = nnew;
 
+#if defined(__NetBSD__) && __NetBSD_Version__ >= 699002800
+        if (entry == TAILQ_FIRST(&table.inpt_queue))
+#else
         if (entry == table.INP_FIRST_SYMBOL)
+#endif
             break;
     }
 

--- a/agent/mibgroup/mibII/udp.c
+++ b/agent/mibgroup/mibII/udp.c
@@ -151,6 +151,12 @@ init_udp(void)
 #define USES_TRADITIONAL_UDPSTAT
 #endif
 
+#ifdef UDP_NSTATS
+typedef struct udpstat {
+	uint64_t st[UDP_NSTATS];
+};
+#define UDP_STAT_STRUCTURE	struct udpstat
+#endif
 
 #if !defined(UDP_STAT_STRUCTURE)
 #define UDP_STAT_STRUCTURE	struct udpstat

--- a/agent/mibgroup/mibII/udpTable.c
+++ b/agent/mibgroup/mibII/udpTable.c
@@ -108,6 +108,10 @@ struct netsnmp_inpcb_s {
 #define	UDPTABLE_ENTRY_TYPE	netsnmp_inpcb 
 #define	UDPTABLE_LOCALADDRESS	pcb.inp_laddr.s_addr 
 #define	UDPTABLE_LOCALPORT	pcb.inp_lport
+#elif defined(__NetBSD__) && __NetBSD_Version__ >= 999010400
+#define	UDPTABLE_ENTRY_TYPE	struct in4pcb 
+#define	UDPTABLE_LOCALADDRESS	in4p_ip.ip_src.s_addr
+#define	UDPTABLE_LOCALPORT	in4p_pcb.inp_lport
 #else
 #define	UDPTABLE_ENTRY_TYPE	struct inpcb 
 #define	UDPTABLE_LOCALADDRESS	inp_laddr.s_addr 
@@ -430,7 +434,13 @@ udpTable_next_entry( void **loop_context,
      * and update the loop context ready for the next one.
      */
     *data_context = (void*)entry;
+#if defined(__NetBSD__) && __NetBSD_Version__ >= 999010400
+    *loop_context = (void*)TAILQ_NEXT(entry, in4p_pcb.inp_queue);
+#elif defined(__NetBSD__) && __NetBSD_Version__ >= 699002800
+    *loop_context = (void*)TAILQ_NEXT(entry, inp_queue);
+#else
     *loop_context = (void*)entry->INP_NEXT_SYMBOL;
+#endif
     return index;
 }
 
@@ -440,7 +450,13 @@ udpTable_free(netsnmp_cache *cache, void *magic)
     UDPTABLE_ENTRY_TYPE	 *p;
     while (udp_head) {
         p = udp_head;
+#if defined(__NetBSD__) && __NetBSD_Version__ >= 999010400
+        udp_head = TAILQ_NEXT(udp_head, in4p_pcb.inp_queue);
+#elif defined(__NetBSD__) && __NetBSD_Version__ >= 699002800
+        udp_head = TAILQ_NEXT(udp_head, inp_queue);
+#else
         udp_head = udp_head->INP_NEXT_SYMBOL;
+#endif
         free(p);
     }
 
@@ -752,7 +768,11 @@ udpTable_load(netsnmp_cache *cache, void *vmagic)
     /*
      *  Set up a linked list
      */
+#if defined(__NetBSD__) && __NetBSD_Version__ >= 699002800
+    entry  = TAILQ_FIRST(&table.inpt_queue);
+#else
     entry  = table.INP_FIRST_SYMBOL;
+#endif
     while (entry) {
    
         nnew = SNMP_MALLOC_TYPEDEF(struct inpcb);
@@ -768,7 +788,11 @@ udpTable_load(netsnmp_cache *cache, void *vmagic)
 	nnew->INP_NEXT_SYMBOL = udp_head;
 	udp_head = nnew;
 
+#if defined(__NetBSD__) && __NetBSD_Version__ >= 699002800
+        if (entry == TAILQ_FIRST(&table.inpt_queue))
+#else
         if (entry == table.INP_FIRST_SYMBOL)
+#endif
             break;
     }
 
@@ -809,11 +833,20 @@ udpTable_load(netsnmp_cache *cache, void *vmagic)
             break;
         }
 
+#if defined(__NetBSD__) && __NetBSD_Version__ >= 699002800
+        entry    = TAILQ_NEXT(nnew, inp_queue);        /* Next kernel entry */
+       TAILQ_NEXT(nnew, inp_queue) = udp_head;
+#else
         entry    = nnew->INP_NEXT_SYMBOL;		/* Next kernel entry */
 	nnew->INP_NEXT_SYMBOL = udp_head;
+#endif
 	udp_head = nnew;
 
+#if defined(__NetBSD__) && __NetBSD_Version__ >= 699002800
+        if (entry == TAILQ_FIRST(&table.inpt_queue))
+#else
         if (entry == udp_inpcb.INP_NEXT_SYMBOL)
+#endif
             break;
     }
 

--- a/agent/mibgroup/mibII/vacm_conf.c
+++ b/agent/mibgroup/mibII/vacm_conf.c
@@ -30,7 +30,7 @@
 #else
 #include <strings.h>
 #endif
-#if HAVE_MALLOC_H
+#ifdef HAVE_MALLOC_H
 #include <malloc.h>
 #endif
 #include <ctype.h>

--- a/agent/mibgroup/mibII/vacm_vars.c
+++ b/agent/mibgroup/mibII/vacm_vars.c
@@ -30,7 +30,7 @@
 #else
 #include <strings.h>
 #endif
-#if HAVE_MALLOC_H
+#ifdef HAVE_MALLOC_H
 #include <malloc.h>
 #endif
 #include <ctype.h>

--- a/agent/mibgroup/mibincl.h
+++ b/agent/mibgroup/mibincl.h
@@ -8,7 +8,7 @@
 #if HAVE_STDLIB_H
 #include <stdlib.h>
 #endif
-#if HAVE_MALLOC_H
+#ifdef HAVE_MALLOC_H
 #include <malloc.h>
 #endif
 #if TIME_WITH_SYS_TIME

--- a/agent/mibgroup/ucd-snmp/errormib.c
+++ b/agent/mibgroup/ucd-snmp/errormib.c
@@ -102,7 +102,7 @@
 #ifdef HAVE_SYS_FIXPOINT_H
 #include <sys/fixpoint.h>
 #endif
-#if HAVE_MALLOC_H
+#ifdef HAVE_MALLOC_H
 #include <malloc.h>
 #endif
 #if HAVE_STRING_H

--- a/agent/mibgroup/ucd-snmp/extensible.c
+++ b/agent/mibgroup/ucd-snmp/extensible.c
@@ -90,7 +90,7 @@
 #ifdef HAVE_SYS_FIXPOINT_H
 #include <sys/fixpoint.h>
 #endif
-#if HAVE_MALLOC_H
+#ifdef HAVE_MALLOC_H
 #include <malloc.h>
 #endif
 #if HAVE_STRING_H

--- a/agent/mibgroup/ucd-snmp/loadave.c
+++ b/agent/mibgroup/ucd-snmp/loadave.c
@@ -92,7 +92,7 @@
 #ifdef HAVE_SYS_LOADAVG_H
 #include <sys/loadavg.h>
 #endif
-#if HAVE_MALLOC_H
+#ifdef HAVE_MALLOC_H
 #include <malloc.h>
 #endif
 #if HAVE_STRING_H

--- a/agent/mibgroup/ucd-snmp/memory_netbsd1.c
+++ b/agent/mibgroup/ucd-snmp/memory_netbsd1.c
@@ -165,7 +165,7 @@ var_extensible_mem(struct variable *vp,
     static char     errmsg[1024];
 
     static struct uvmexp uvmexp;
-    int             uvmexp_size = sizeof(uvmexp);
+    size_t          uvmexp_size = sizeof(uvmexp);
     int             uvmexp_mib[] = { CTL_VM, VM_UVMEXP };
     static struct vmtotal total;
     size_t          total_size = sizeof(total);
@@ -181,13 +181,22 @@ var_extensible_mem(struct variable *vp,
     /*
      * Memory info 
      */
-    sysctl(uvmexp_mib, 2, &uvmexp, &uvmexp_size, NULL, 0);
-    sysctl(total_mib, 2, &total, &total_size, NULL, 0);
+    if (sysctl(uvmexp_mib, 2, &uvmexp, &uvmexp_size, NULL, 0) == -1) {
+        snmp_log(LOG_ERR, "sysctl VM_UVMEXP failed (errno %d)\n", errno);
+        return NULL;
+    }
+    if (sysctl(total_mib, 2, &total, &total_size, NULL, 0) == -1) {
+        snmp_log(LOG_ERR, "sysctl VM_METER failed (errno %d)\n", errno);
+        return NULL;
+    }
 
     /*
      * Physical memory 
      */
-    sysctl(phys_mem_mib, 2, &phys_mem, &phys_mem_size, NULL, 0);
+    if (sysctl(phys_mem_mib, 2, &phys_mem, &phys_mem_size, NULL, 0) == -1) {
+        snmp_log(LOG_ERR, "sysctl HW_USERMEM failed (errno %d)\n", errno);
+        return NULL;
+    }
 
     long_ret = 0;               /* set to 0 as default */
 

--- a/agent/mibgroup/ucd-snmp/proc.c
+++ b/agent/mibgroup/ucd-snmp/proc.c
@@ -20,7 +20,7 @@
 #else
 #include <strings.h>
 #endif
-#if HAVE_MALLOC_H
+#ifdef HAVE_MALLOC_H
 #include <malloc.h>
 #endif
 #include <math.h>

--- a/agent/mibgroup/ucd-snmp/vmstat_linux.c
+++ b/agent/mibgroup/ucd-snmp/vmstat_linux.c
@@ -81,7 +81,7 @@
 #if HAVE_SYS_FIXPOINT_H
 #include <sys/fixpoint.h>
 #endif
-#if HAVE_MALLOC_H
+#ifdef HAVE_MALLOC_H
 #include <malloc.h>
 #endif
 #if HAVE_STRING_H

--- a/agent/mibgroup/util_funcs.c
+++ b/agent/mibgroup/util_funcs.c
@@ -27,7 +27,7 @@
 #if HAVE_STDLIB_H
 #include <stdlib.h>
 #endif
-#if HAVE_MALLOC_H
+#ifdef HAVE_MALLOC_H
 #include <malloc.h>
 #endif
 #ifdef __alpha

--- a/agent/mibgroup/utilities/execute.c
+++ b/agent/mibgroup/utilities/execute.c
@@ -14,7 +14,7 @@
 #if HAVE_UNISTD_H
 #include <unistd.h>
 #endif
-#if HAVE_MALLOC_H
+#ifdef HAVE_MALLOC_H
 #include <malloc.h>
 #endif
 #include <sys/types.h>

--- a/ci/net-snmp-configure
+++ b/ci/net-snmp-configure
@@ -199,11 +199,7 @@ case "$(uname)" in
 	      mibs+=(rmon-mib)
               ;;
       esac
-      # Disable MySQL support because of the following Perl test failure on
-      # Travis:
-      # t/1.t .. Can't load '/home/travis/build/bvanassche/net-snmp/perl/TrapReceiver/../blib/arch/auto/NetSNMP/TrapReceiver/TrapReceiver.so' for module NetSNMP::TrapReceiver: /home/travis/build/bvanassche/net-snmp/apps/.libs/libnetsnmptrapd.so.35: undefined symbol: mysql_sqlstate at /usr/lib/x86_64-linux-gnu/perl/5.22/DynaLoader.pm line 187.
-      # at t/1.t line 16.
-      if [ -n "${TRAVIS_OS_NAME}" ] && [ -n "$libmysqlver" ]; then
+      if [ -n "$libmysqlver" ]; then
 	  options+=(--with-mysql)
       fi
       if [ -n "$perldevver" ] && [ "$perlcc" = "$(compiler_type "${CC:-cc}")" ];
@@ -243,11 +239,6 @@ case "$(uname)" in
               ;;
       esac
       options+=("--with-openssl=$(brew --prefix openssl)")
-      if [ "${TRAVIS_OS_NAME}" == "osx" ]; then
-          # On Travis OS/X linking the Perl modules fails with "undefined symbol
-          # _BN_bin2bn" etc.
-          options+=(--disable-embedded-perl --without-perl-modules)
-      fi
     ;;
   FreeBSD*)
       case "$MODE" in

--- a/ci/net-snmp-run-tests
+++ b/ci/net-snmp-run-tests
@@ -39,12 +39,7 @@ make -s &&
           "$scriptdir/net-snmp-run-perl-tests"
       fi
 ) &&
-# Running the Python tests fails as follows on OS/X:
-# ImportError: dlopen(/Users/travis/build/bvanassche/net-snmp/python/netsnmp/client_intf.so, 2): Library not loaded: /usr/local/net-snmp-master/lib/libnetsnmp.35.dylib
-# Referenced from: /Users/travis/build/bvanassche/net-snmp/python/netsnmp/client_intf.so
-# Reason: image not found
 # Disable the Python tests because these fail sporadically.
-if false && grep -q with-python-modules config.log &&
-	[ "${TRAVIS_OS_NAME}" != "osx" ]; then
+if false && grep -q with-python-modules config.log; then
     "$scriptdir/net-snmp-run-python-tests"
 fi

--- a/ci/openssl.bat
+++ b/ci/openssl.bat
@@ -3,6 +3,6 @@ rmdir /s /q C:\OpenSSL-Win32
 rmdir /s /q C:\OpenSSL-v11-Win32
 rmdir /s /q C:\OpenSSL-Win64
 rmdir /s /q C:\OpenSSL-v11-Win64
-curl https://slproweb.com/download/Win64OpenSSL-3_0_7.exe -o openssl.exe
+curl https://slproweb.com/download/Win64OpenSSL-3_0_8.exe -o openssl.exe
 .\openssl.exe /suppressmsgboxes /silent /norestart /nocloseapplications /log=openssl-installation-log.txt /dir=C:\OpenSSL-Win64
 rem type openssl-installation-log.txt

--- a/configure
+++ b/configure
@@ -16338,10 +16338,21 @@ fi
 rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
       LDFLAGS="$saved_LDFLAGS"
-
     fi
     ;;
 esac
+
+# On Windows targets, due to limitations of the PE executable format, the
+# linker will always operate as if -Wl,-no-undefined was supplied. Supply the
+# libtool flag -no-undefined to authorize libtool to build shared libraries.
+# To do: enable the libtool flag -no-undefined on more platforms.
+case x$target_os in
+  xlinux*|xcygwin*)
+    LD_NO_UNDEFINED="-no-undefined $LD_NO_UNDEFINED"
+    ;;
+esac
+
+
 
 
 #

--- a/configure
+++ b/configure
@@ -16302,16 +16302,11 @@ esac
 
 
 #
-#    Whether the linker supports the flag -Wl,-no-undefined.
+#    Whether the linker supports the flag -Wl,-no-undefined. Do not use
+#    -Wl,-no-undefined on OpenBSD because it breaks linking of shared
+#    libraries. Use -Wl,-no-undefined on all other platforms such that
+#    undefined symbols are detected at compile time instead of at runtime.
 #
-#    Do not use -Wl,-no-undefined on OpenBSD because it breaks linking of shared
-#    libraries. Use -Wl,-no-undefined on all other platforms such that undefined
-#    symbols are detected at compile time instead of at runtime.
-#
-#    On Windows targets, due to limitations of the PE executable format, the
-#    linker will always operate as if -Wl,-no-undefined was supplied.  Also
-#    supply the libtool flag -no-undefined to authorize it to build shared
-#    libraries.
 
 case x$target_os in
   xopenbsd*)
@@ -16335,7 +16330,7 @@ main ()
 _ACEOF
 if ac_fn_c_try_link "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }; 		      LD_NO_UNDEFINED="-no-undefined -Wl,-no-undefined"
+$as_echo "yes" >&6; }; 		      LD_NO_UNDEFINED=-Wl,-no-undefined
 else
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
 $as_echo "no" >&6; }

--- a/configure
+++ b/configure
@@ -16157,7 +16157,7 @@ $as_echo "$as_me: Checking for developer compiler flags" >&6;}
         -Wimplicit-fallthrough -Wlogical-op -Wundef                          \
         -Wno-format-truncation -Wno-missing-field-initializers               \
         -Wno-sign-compare -Wno-unused-parameter                              \
-        -Wno-deprecated-declarations
+        -Wno-deprecated-declarations -Wextra-semi
     do
       { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether the compiler supports $opt" >&5
 $as_echo_n "checking whether the compiler supports $opt... " >&6; }

--- a/configure
+++ b/configure
@@ -16302,11 +16302,16 @@ esac
 
 
 #
-#    Whether the linker supports the flag -Wl,-no-undefined. Do not use
-#    -Wl,-no-undefined on OpenBSD because it breaks linking of shared
-#    libraries. Use -Wl,-no-undefined on all other platforms such that
-#    undefined symbols are detected at compile time instead of at runtime.
+#    Whether the linker supports the flag -Wl,-no-undefined.
 #
+#    Do not use -Wl,-no-undefined on OpenBSD because it breaks linking of shared
+#    libraries. Use -Wl,-no-undefined on all other platforms such that undefined
+#    symbols are detected at compile time instead of at runtime.
+#
+#    On Windows targets, due to limitations of the PE executable format, the
+#    linker will always operate as if -Wl,-no-undefined was supplied.  Also
+#    supply the libtool flag -no-undefined to authorize it to build shared
+#    libraries.
 
 case x$target_os in
   xopenbsd*)
@@ -16330,7 +16335,7 @@ main ()
 _ACEOF
 if ac_fn_c_try_link "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }; 		      LD_NO_UNDEFINED=-Wl,-no-undefined
+$as_echo "yes" >&6; }; 		      LD_NO_UNDEFINED="-no-undefined -Wl,-no-undefined"
 else
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
 $as_echo "no" >&6; }

--- a/configure
+++ b/configure
@@ -30860,27 +30860,26 @@ if ${ac_cv_ps_flags+:} false; then :
   $as_echo_n "(cached) " >&6
 else
 
-if test "`($PSPROG -e 2>&1) | $EGREP ' (ps) *$' | awk '{print $NF}'`" = "ps" ; then
-    ac_cv_ps_flags="-e"
-elif test "`($PSPROG -el 2>&1) | $EGREP ' (ps) *$' | awk '{print $NF}'`" = "ps" ; then
-    ac_cv_ps_flags="-el"
-elif test "`($PSPROG acx 2>&1) | $EGREP ' (ps) *$' | awk '{print $NF}'`" = "ps" ; then
-    ac_cv_ps_flags="acx"
-elif test "`($PSPROG -acx 2>&1) | $EGREP ' (ps) *$' | awk '{print $NF}'`" = "ps" ; then
-    ac_cv_ps_flags="-acx"
-elif test "`($PSPROG -o pid,tt,state,time,ucomm 2>&1) | $EGREP ' ps *$' | awk '{print $NF}'`" = "ps" ; then
-    ac_cv_ps_flags="-o pid,tt,state,time,ucomm"
-elif test "`($PSPROG ax 2>&1) | $EGREP ' (ps) *$' | awk '{print $NF}'`" = "ps" ; then
-    ac_cv_ps_flags="ax"
-elif test "x$PARTIALTARGETOS" = "xcygwin"; then
-    ac_cv_ps_flags="-e"
-elif test "x$PARTIALTARGETOS" = "xmingw32" -o "x$PARTIALTARGETOS" = "xmingw32msvc"; then
-    ac_cv_ps_flags="-e"
-else
-    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: Unable to determine valid ps flags...  defaulting..." >&5
+case "x$PARTIALTARGETOS" in
+    xcygwin|xmingw32*)
+	ac_cv_ps_flags="-e";;
+    *)
+	ac_cv_ps_flags=""
+	for args in -e -el acx -acx "-o pid,tt,state,time,ucomm" ax; do
+	    if test "`($PSPROG $args 2>&1) | $EGREP ' (ps) *$' | awk '{print $NF}'`" = "ps"; then
+		ac_cv_ps_flags=$args
+		break
+	    fi
+	done
+	if test "x${ac_cv_ps_flags}" = x; then
+	    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: Unable to determine valid ps flags...  defaulting..." >&5
 $as_echo "$as_me: WARNING: Unable to determine valid ps flags...  defaulting..." >&2;}
-    ac_cv_ps_flags="-acx"
-fi
+	    ac_cv_ps_flags="-acx"
+	elif $PSPROG $ac_cv_ps_flags -J 0 >/dev/null 2>&1; then
+	    ac_cv_ps_flags="$ac_cv_ps_flags -J 0"
+	fi
+	;;
+esac
 
 fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_ps_flags" >&5

--- a/configure
+++ b/configure
@@ -16157,7 +16157,7 @@ $as_echo "$as_me: Checking for developer compiler flags" >&6;}
         -Wimplicit-fallthrough -Wlogical-op -Wundef                          \
         -Wno-format-truncation -Wno-missing-field-initializers               \
         -Wno-sign-compare -Wno-unused-parameter                              \
-        $(test "x${TRAVIS_OS_NAME}" != x && echo -Wno-deprecated-declarations)
+        -Wno-deprecated-declarations
     do
       { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether the compiler supports $opt" >&5
 $as_echo_n "checking whether the compiler supports $opt... " >&6; }

--- a/configure
+++ b/configure
@@ -16819,7 +16819,7 @@ _ACEOF
 #
 if test "x$NETSNMP_DEFAULT_MIBDIRS" = "x"; then
     NETSNMP_DEFAULT_MIBDIRS="\$HOME/.snmp/mibs:$SNMPSHAREPATH/mibs"
-    if test "x$PARTIALTARGETOS" = "xmingw32" -o "x$PARTIALTARGETOS" = "xmingw32msvc" -o "x$PARTIALTARGETOS" = "xcygwin"; then
+    if test "x$PARTIALTARGETOS" = "xmingw32" -o "x$PARTIALTARGETOS" = "xmingw32msvc"; then
         #
         #    USe Windows-style path separator
         NETSNMP_DEFAULT_MIBDIRS=`echo "$NETSNMP_DEFAULT_MIBDIRS" | $SED 's/:/;/g'`
@@ -22235,8 +22235,8 @@ if test "x$NETSNMP_DEFAULT_MIBS" = "x"; then
 fi
 if test "x$ENV_SEPARATOR" != "x"; then
   :
-elif test "x$PARTIALTARGETOS" = "xmingw32" -o "x$PARTIALTARGETOS" = "xmingw32msvc" -o "x$PARTIALTARGETOS" = "xcygwin"; then
-  # mingw32 and cygwin use ';' as the default environment variable separator
+elif test "x$PARTIALTARGETOS" = "xmingw32" -o "x$PARTIALTARGETOS" = "xmingw32msvc"; then
+  # mingw32 uses ';' as the default environment variable separator
   ENV_SEPARATOR=";"
   NETSNMP_DEFAULT_MIBS=`echo "$NETSNMP_DEFAULT_MIBS" | $SED 's/:/;/g'`
   default_mibs=`echo "$default_mibs" | $SED 's/:/;/g'`

--- a/configure
+++ b/configure
@@ -31059,7 +31059,7 @@ done
 do :
   ac_fn_c_check_header_compile "$LINENO" "inet/ip.h" "ac_cv_header_inet_ip_h" "$ac_includes_default
 
-#if HAVE_SYS_STREAM_H
+#ifdef HAVE_SYS_STREAM_H
 #include <sys/stream.h>
 #endif
 #if HAVE_INET_COMMON_H

--- a/configure.d/config_modules_agent
+++ b/configure.d/config_modules_agent
@@ -792,8 +792,8 @@ if test "x$NETSNMP_DEFAULT_MIBS" = "x"; then
 fi
 if test "x$ENV_SEPARATOR" != "x"; then
   :
-elif test "x$PARTIALTARGETOS" = "xmingw32" -o "x$PARTIALTARGETOS" = "xmingw32msvc" -o "x$PARTIALTARGETOS" = "xcygwin"; then
-  # mingw32 and cygwin use ';' as the default environment variable separator
+elif test "x$PARTIALTARGETOS" = "xmingw32" -o "x$PARTIALTARGETOS" = "xmingw32msvc"; then
+  # mingw32 uses ';' as the default environment variable separator
   ENV_SEPARATOR=";"
   NETSNMP_DEFAULT_MIBS=`echo "$NETSNMP_DEFAULT_MIBS" | $SED 's/:/;/g'`
   default_mibs=`echo "$default_mibs" | $SED 's/:/;/g'`

--- a/configure.d/config_net_snmp_config_h
+++ b/configure.d/config_net_snmp_config_h
@@ -502,10 +502,13 @@ NETSNMP_STATIC_INLINE int netsnmp_bigendian(void)
 # define NETSNMP_BIGENDIAN netsnmp_bigendian()
 #endif
 
-#if defined(__has_attribute) && __has_attribute(__fallthrough__)
-# define NETSNMP_FALLTHROUGH __attribute__((__fallthrough__))
-#else
-# define NETSNMP_FALLTHROUGH do {} while (0) /* fallthrough */
+#if defined(__has_attribute)
+#  if __has_attribute(__fallthrough__)
+#    define NETSNMP_FALLTHROUGH __attribute__((__fallthrough__))
+#  endif
+#endif
+#if !defined NETSNMP_FALLTHROUGH
+#  define NETSNMP_FALLTHROUGH do {} while (0) /* fallthrough */
 #endif
 
 /* ********* NETSNMP_MARK_BEGIN_LEGACY_DEFINITIONS *********/

--- a/configure.d/config_os_misc4
+++ b/configure.d/config_os_misc4
@@ -110,26 +110,25 @@ fi
 AC_CACHE_CHECK([for correct flags to ps],
      ac_cv_ps_flags,
      [
-if test "`($PSPROG -e 2>&1) | $EGREP ' (ps) *$' | awk '{print $NF}'`" = "ps" ; then
-    ac_cv_ps_flags="-e"
-elif test "`($PSPROG -el 2>&1) | $EGREP ' (ps) *$' | awk '{print $NF}'`" = "ps" ; then
-    ac_cv_ps_flags="-el"
-elif test "`($PSPROG acx 2>&1) | $EGREP ' (ps) *$' | awk '{print $NF}'`" = "ps" ; then
-    ac_cv_ps_flags="acx"
-elif test "`($PSPROG -acx 2>&1) | $EGREP ' (ps) *$' | awk '{print $NF}'`" = "ps" ; then
-    ac_cv_ps_flags="-acx"
-elif test "`($PSPROG -o pid,tt,state,time,ucomm 2>&1) | $EGREP ' ps *$' | awk '{print $NF}'`" = "ps" ; then
-    ac_cv_ps_flags="-o pid,tt,state,time,ucomm"
-elif test "`($PSPROG ax 2>&1) | $EGREP ' (ps) *$' | awk '{print $NF}'`" = "ps" ; then
-    ac_cv_ps_flags="ax"
-elif test "x$PARTIALTARGETOS" = "xcygwin"; then
-    ac_cv_ps_flags="-e"
-elif test "x$PARTIALTARGETOS" = "xmingw32" -o "x$PARTIALTARGETOS" = "xmingw32msvc"; then 
-    ac_cv_ps_flags="-e"
-else
-    AC_MSG_WARN([Unable to determine valid ps flags...  defaulting...])
-    ac_cv_ps_flags="-acx"
-fi
+case "x$PARTIALTARGETOS" in
+    xcygwin|xmingw32*)
+	ac_cv_ps_flags="-e";;
+    *)
+	ac_cv_ps_flags=""
+	for args in -e -el acx -acx "-o pid,tt,state,time,ucomm" ax; do
+	    if test "`($PSPROG $args 2>&1) | $EGREP ' (ps) *$' | awk '{print $NF}'`" = "ps"; then
+		ac_cv_ps_flags=$args
+		break
+	    fi
+	done
+	if test "x${ac_cv_ps_flags}" = x; then
+	    AC_MSG_WARN([Unable to determine valid ps flags...  defaulting...])
+	    ac_cv_ps_flags="-acx"
+	elif $PSPROG $ac_cv_ps_flags -J 0 >/dev/null 2>&1; then
+	    ac_cv_ps_flags="$ac_cv_ps_flags -J 0"
+	fi
+	;;
+esac
 ])
 
 PSCMD="$PSPROG $ac_cv_ps_flags"

--- a/configure.d/config_os_misc4
+++ b/configure.d/config_os_misc4
@@ -251,7 +251,7 @@ case $target_os in
     AC_CHECK_HEADERS(inet/ip.h,ac_inet_ip_h=yes,ac_inet_ip_h=no,
         AC_INCLUDES_DEFAULT([])
         [
-#if HAVE_SYS_STREAM_H
+#ifdef HAVE_SYS_STREAM_H
 #include <sys/stream.h>
 #endif
 #if HAVE_INET_COMMON_H

--- a/configure.d/config_os_progs
+++ b/configure.d/config_os_progs
@@ -104,7 +104,7 @@ if test "x$developer" = "xyes" -a "x$GCC" = "xyes"; then
         -Wimplicit-fallthrough -Wlogical-op -Wundef                          \
         -Wno-format-truncation -Wno-missing-field-initializers               \
         -Wno-sign-compare -Wno-unused-parameter                              \
-        $(test "x${TRAVIS_OS_NAME}" != x && echo -Wno-deprecated-declarations)
+        -Wno-deprecated-declarations
     do
       AC_MSG_CHECKING([whether the compiler supports $opt])
       if test x$opt != x-Wstrict-prototypes; then

--- a/configure.d/config_os_progs
+++ b/configure.d/config_os_progs
@@ -104,7 +104,7 @@ if test "x$developer" = "xyes" -a "x$GCC" = "xyes"; then
         -Wimplicit-fallthrough -Wlogical-op -Wundef                          \
         -Wno-format-truncation -Wno-missing-field-initializers               \
         -Wno-sign-compare -Wno-unused-parameter                              \
-        -Wno-deprecated-declarations
+        -Wno-deprecated-declarations -Wextra-semi
     do
       AC_MSG_CHECKING([whether the compiler supports $opt])
       if test x$opt != x-Wstrict-prototypes; then

--- a/configure.d/config_os_progs
+++ b/configure.d/config_os_progs
@@ -205,10 +205,21 @@ case x$target_os in
 		      LD_NO_UNDEFINED=-Wl,-no-undefined],
 		     [AC_MSG_RESULT([no])])
       LDFLAGS="$saved_LDFLAGS"
-      AC_SUBST(LD_NO_UNDEFINED)
     fi
     ;;
 esac
+
+# On Windows targets, due to limitations of the PE executable format, the
+# linker will always operate as if -Wl,-no-undefined was supplied. Supply the
+# libtool flag -no-undefined to authorize libtool to build shared libraries.
+# To do: enable the libtool flag -no-undefined on more platforms.
+case x$target_os in
+  xlinux*|xcygwin*)
+    LD_NO_UNDEFINED="-no-undefined $LD_NO_UNDEFINED"
+    ;;
+esac
+
+AC_SUBST(LD_NO_UNDEFINED)
 
 
 #

--- a/configure.d/config_os_progs
+++ b/configure.d/config_os_progs
@@ -186,16 +186,11 @@ esac
 
 
 #
-#    Whether the linker supports the flag -Wl,-no-undefined.
+#    Whether the linker supports the flag -Wl,-no-undefined. Do not use
+#    -Wl,-no-undefined on OpenBSD because it breaks linking of shared
+#    libraries. Use -Wl,-no-undefined on all other platforms such that
+#    undefined symbols are detected at compile time instead of at runtime.
 #
-#    Do not use -Wl,-no-undefined on OpenBSD because it breaks linking of shared
-#    libraries. Use -Wl,-no-undefined on all other platforms such that undefined
-#    symbols are detected at compile time instead of at runtime.
-#
-#    On Windows targets, due to limitations of the PE executable format, the
-#    linker will always operate as if -Wl,-no-undefined was supplied.  Also
-#    supply the libtool flag -no-undefined to authorize it to build shared
-#    libraries.
 
 case x$target_os in
   xopenbsd*)
@@ -207,7 +202,7 @@ case x$target_os in
       LDFLAGS="$saved_LDFLAGS -Wl,-no-undefined"
       AC_LINK_IFELSE([AC_LANG_PROGRAM([],[])],
 		     [AC_MSG_RESULT([yes]); dnl
-		      LD_NO_UNDEFINED="-no-undefined -Wl,-no-undefined"],
+		      LD_NO_UNDEFINED=-Wl,-no-undefined],
 		     [AC_MSG_RESULT([no])])
       LDFLAGS="$saved_LDFLAGS"
       AC_SUBST(LD_NO_UNDEFINED)

--- a/configure.d/config_os_progs
+++ b/configure.d/config_os_progs
@@ -186,11 +186,16 @@ esac
 
 
 #
-#    Whether the linker supports the flag -Wl,-no-undefined. Do not use
-#    -Wl,-no-undefined on OpenBSD because it breaks linking of shared
-#    libraries. Use -Wl,-no-undefined on all other platforms such that
-#    undefined symbols are detected at compile time instead of at runtime.
+#    Whether the linker supports the flag -Wl,-no-undefined.
 #
+#    Do not use -Wl,-no-undefined on OpenBSD because it breaks linking of shared
+#    libraries. Use -Wl,-no-undefined on all other platforms such that undefined
+#    symbols are detected at compile time instead of at runtime.
+#
+#    On Windows targets, due to limitations of the PE executable format, the
+#    linker will always operate as if -Wl,-no-undefined was supplied.  Also
+#    supply the libtool flag -no-undefined to authorize it to build shared
+#    libraries.
 
 case x$target_os in
   xopenbsd*)
@@ -202,7 +207,7 @@ case x$target_os in
       LDFLAGS="$saved_LDFLAGS -Wl,-no-undefined"
       AC_LINK_IFELSE([AC_LANG_PROGRAM([],[])],
 		     [AC_MSG_RESULT([yes]); dnl
-		      LD_NO_UNDEFINED=-Wl,-no-undefined],
+		      LD_NO_UNDEFINED="-no-undefined -Wl,-no-undefined"],
 		     [AC_MSG_RESULT([no])])
       LDFLAGS="$saved_LDFLAGS"
       AC_SUBST(LD_NO_UNDEFINED)

--- a/configure.d/config_project_paths
+++ b/configure.d/config_project_paths
@@ -80,7 +80,7 @@ AC_SUBST(SNMPSHAREPATH)
 #
 if test "x$NETSNMP_DEFAULT_MIBDIRS" = "x"; then
     NETSNMP_DEFAULT_MIBDIRS="\$HOME/.snmp/mibs:$SNMPSHAREPATH/mibs"
-    if test "x$PARTIALTARGETOS" = "xmingw32" -o "x$PARTIALTARGETOS" = "xmingw32msvc" -o "x$PARTIALTARGETOS" = "xcygwin"; then
+    if test "x$PARTIALTARGETOS" = "xmingw32" -o "x$PARTIALTARGETOS" = "xmingw32msvc"; then
         #
         #    USe Windows-style path separator
         NETSNMP_DEFAULT_MIBDIRS=`echo "$NETSNMP_DEFAULT_MIBDIRS" | $SED 's/:/;/g'`

--- a/include/net-snmp/library/mib.h
+++ b/include/net-snmp/library/mib.h
@@ -120,6 +120,7 @@ SOFTWARE.
     NETSNMP_IMPORT
     void            print_ascii_dump(FILE *);
     void            register_mib_handlers(void);
+    NETSNMP_IMPORT
     void            netsnmp_set_mib_directory(const char *dir);
     NETSNMP_IMPORT
     char            *netsnmp_get_mib_directory(void);

--- a/include/net-snmp/net-snmp-config.h.in
+++ b/include/net-snmp/net-snmp-config.h.in
@@ -2355,10 +2355,13 @@ NETSNMP_STATIC_INLINE int netsnmp_bigendian(void)
 # define NETSNMP_BIGENDIAN netsnmp_bigendian()
 #endif
 
-#if defined(__has_attribute) && __has_attribute(__fallthrough__)
-# define NETSNMP_FALLTHROUGH __attribute__((__fallthrough__))
-#else
-# define NETSNMP_FALLTHROUGH do {} while (0) /* fallthrough */
+#if defined(__has_attribute)
+#  if __has_attribute(__fallthrough__)
+#    define NETSNMP_FALLTHROUGH __attribute__((__fallthrough__))
+#  endif
+#endif
+#if !defined NETSNMP_FALLTHROUGH
+#  define NETSNMP_FALLTHROUGH do {} while (0) /* fallthrough */
 #endif
 
 /* ********* NETSNMP_MARK_BEGIN_LEGACY_DEFINITIONS *********/

--- a/include/net-snmp/system/netbsd.h
+++ b/include/net-snmp/system/netbsd.h
@@ -57,6 +57,9 @@
 #define netbsd3
 #endif
 
+#if defined(netbsd10) && !defined(netbsd9)
+#define netbsd9 netbsd9
+#endif
 #if defined(netbsd9) && !defined(netbsd8)
 #define netbsd8 netbsd8
 #endif

--- a/include/net-snmp/system/openbsd.h
+++ b/include/net-snmp/system/openbsd.h
@@ -1,3 +1,4 @@
+#define __NetBSD_Version__ 1
 #include "netbsd.h"
 
 #define netbsd1 netbsd1         /* we're really close to this */

--- a/include/net-snmp/system/openbsd7.h
+++ b/include/net-snmp/system/openbsd7.h
@@ -1,0 +1,3 @@
+/* openbsd7 is a superset of all since openbsd3 */
+#include "openbsd6.h"
+#define openbsd6 openbsd6

--- a/mibs/IANA-ADDRESS-FAMILY-NUMBERS-MIB.txt
+++ b/mibs/IANA-ADDRESS-FAMILY-NUMBERS-MIB.txt
@@ -6,7 +6,7 @@ IMPORTS
     TEXTUAL-CONVENTION                  FROM SNMPv2-TC;
 
 ianaAddressFamilyNumbers MODULE-IDENTITY
-    LAST-UPDATED "202009140000Z"  -- September 14, 2020
+    LAST-UPDATED "202110190000Z"  -- October 19, 2021
     ORGANIZATION "IANA"
     CONTACT-INFO
         "Postal:    Internet Assigned Numbers Authority
@@ -22,6 +22,12 @@ ianaAddressFamilyNumbers MODULE-IDENTITY
         textual convention."
 
     -- revision history
+
+    REVISION     "202110190000Z"  -- October 19, 2021
+    DESCRIPTION  "Assigned value 16399."
+
+    REVISION     "202105180000Z"  -- May 18, 2021
+    DESCRIPTION  "Assigned value 31."
 
     REVISION     "202009140000Z"  -- September 14, 2020
     DESCRIPTION  "Added missing value 16398."
@@ -119,6 +125,7 @@ AddressFamilyNumbers ::= TEXTUAL-CONVENTION
         mplsTpPseudowireEndpointIdentifier(28),  -- MPLS-TP Pseudowire Endpoint Identifier
         mtIpMultiTopologyIpVersion4 (29),  -- MT IP: Multi-Topology IP version 4
         mtIpv6MultiTopologyIpVersion6 (30),  -- MT IPv6: Multi-Topology IP version 6
+        bgpSfc (31),  -- BGP SFC
         eigrpCommonServiceFamily(16384),  -- EIGRP Common Service Family
         eigrpIpv4ServiceFamily(16385),  -- EIGRP IPv4 Service Family
         eigrpIpv6ServiceFamily(16386),  -- EIGRP IPv6 Service Family
@@ -134,6 +141,7 @@ AddressFamilyNumbers ::= TEXTUAL-CONVENTION
         trillNickname(16396),  -- TRILL Nickname
         universallyUniqueIdentifier(16397),  -- Universally Unique Identifier (UUID)
         routingPolicyAfi(16398),  -- Routing Policy AFI
+        mplsNamespaces(16399),  -- MPLS Namespaces
         reserved(65535)
 
         Requests for new values should be made to IANA via
@@ -170,6 +178,7 @@ AddressFamilyNumbers ::= TEXTUAL-CONVENTION
                 mplsTpPseudowireEndpointIdentifier(28),
                 mtipmultitopologyipversion4 (29),
                 mtipv6multitopologyipversion6 (30),
+                bgpSfc (31),
                 eigrpCommonServiceFamily(16384),
                 eigrpIpv4ServiceFamily(16385),
                 eigrpIpv6ServiceFamily(16386),
@@ -185,6 +194,7 @@ AddressFamilyNumbers ::= TEXTUAL-CONVENTION
                 trillNickname(16396),
                 universallyUniqueIdentifier(16397),
                 routingPolicyAfi(16398),
+                mplsNamespaces(16399),
                 reserved(65535)
             }
     END

--- a/mibs/IANAifType-MIB.txt
+++ b/mibs/IANAifType-MIB.txt
@@ -5,7 +5,7 @@
        TEXTUAL-CONVENTION          FROM SNMPv2-TC;
 
    ianaifType MODULE-IDENTITY
-       LAST-UPDATED "202104230000Z" -- April 23, 2021
+       LAST-UPDATED "202208170000Z" -- August 17, 2022
        ORGANIZATION "IANA"
        CONTACT-INFO "        Internet Assigned Numbers Authority
 
@@ -18,6 +18,12 @@
        DESCRIPTION  "This MIB module defines the IANAifType Textual
                      Convention, and thus the enumerated values of
                      the ifType object defined in MIB-II's ifTable."
+
+       REVISION     "202208170000Z"  -- August 17, 2022
+       DESCRIPTION  "Changed gpon description to refer to G.984."
+
+       REVISION     "202105170000Z"  -- May 17, 2021
+       DESCRIPTION  "Registration of new IANAifType 303."
 
        REVISION     "202104230000Z"  -- April 23, 2021
        DESCRIPTION  "Registration of new tunnelType 19 and
@@ -654,7 +660,7 @@
                    ilan (247), -- Internal LAN on a bridge per IEEE 802.1ap
                    pip (248), -- Provider Instance Port on a bridge per IEEE 802.1ah PBB
                    aluELP (249), -- Alcatel-Lucent Ethernet Link Protection
-                   gpon (250), -- Gigabit-capable passive optical networks (G-PON) as per ITU-T G.948
+                   gpon (250), -- Gigabit-capable passive optical networks (G-PON) as per ITU-T G.984
                    vdsl2 (251), -- Very high speed digital subscriber line Version 2 (as per ITU-T Recommendation G.993.2)
                    capwapDot11Profile (252), -- WLAN Profile Interface
                    capwapDot11Bss (253), -- WLAN BSS Interface
@@ -702,7 +708,8 @@
                    ieee19061nanocom (299), -- Nanoscale and Molecular Communication
                    cpri (300), -- Common Public Radio Interface
                    omni (301), -- Overlay Multilink Network Interface (OMNI)
-                   roe (302) -- Radio over Ethernet Interface
+                   roe (302), -- Radio over Ethernet Interface
+                   p2pOverLan (303) -- Point to Point over LAN interface
                    }
 
 IANAtunnelType ::= TEXTUAL-CONVENTION

--- a/mibs/UCD-SNMP-MIB.txt
+++ b/mibs/UCD-SNMP-MIB.txt
@@ -40,7 +40,7 @@ IMPORTS
 	FROM SNMPv2-TC;
 
 ucdavis MODULE-IDENTITY
-    LAST-UPDATED "201606100000Z"
+    LAST-UPDATED "202008210000Z"
     ORGANIZATION "University of California, Davis"
     CONTACT-INFO    
 	"This mib is no longer being maintained by the University of
@@ -58,6 +58,10 @@ ucdavis MODULE-IDENTITY
     DESCRIPTION
 	"This file defines the private UCD SNMP MIB extensions."
 
+    REVISION     "202008210000Z"
+    DESCRIPTION
+	"Add new memSysAvail object"
+
     REVISION     "201606100000Z"
     DESCRIPTION
 	"New 64-bit memory objects"
@@ -65,6 +69,7 @@ ucdavis MODULE-IDENTITY
     REVISION     "201407310000Z"
     DESCRIPTION
 	"New object for number of CPUs as counted by the agent"
+
     REVISION	 "201105140000Z"
     DESCRIPTION
 	"New objects for monitoring CPU Steal, Guest and Nice values"

--- a/net-snmp-create-v3-user.in
+++ b/net-snmp-create-v3-user.in
@@ -4,7 +4,7 @@
 # to Net-SNMP config file.
 
 if @PSCMD@ | @EGREP@ ' snmpd *$' > /dev/null 2>&1 ; then
-    echo "Apparently at least one snmpd demon is already running."
+    echo "Apparently at least one snmpd daemon is already running."
     echo "You must stop them in order to use this command."
     exit 1
 fi

--- a/perl/TrapReceiver/TrapReceiver.pm
+++ b/perl/TrapReceiver/TrapReceiver.pm
@@ -116,7 +116,7 @@ been configured using --enable-embedded-perl.  Registration of
 functions is then done through the snmptrapd.conf configuration
 file.  This module can NOT be used in a normal perl script to
 receive traps.  It is intended solely for embedded use within the
-snmptrapd demon.
+snmptrapd daemon.
 
 =head1 DESCRIPTION
 
@@ -144,18 +144,18 @@ Registered functions should return one of the following values:
 
 =item NETSNMPTRAPD_HANDLER_OK
 
-Handling the trap succeeded, but lets the snmptrapd demon check for
+Handling the trap succeeded, but lets the snmptrapd daemon check for
 further appropriate handlers.
 
 =item NETSNMPTRAPD_HANDLER_FAIL
 
-Handling the trap failed, but lets the snmptrapd demon check for
+Handling the trap failed, but lets the snmptrapd daemon check for
 further appropriate handlers.
 
 =item NETSNMPTRAPD_HANDLER_BREAK
 
 Stops evaluating the list of handlers for this specific trap, but lets
-the snmptrapd demon apply global handlers.
+the snmptrapd daemon apply global handlers.
 
 =item NETSNMPTRAPD_HANDLER_FINISH
 

--- a/perl/agent/agent.pm
+++ b/perl/agent/agent.pm
@@ -229,7 +229,7 @@ NetSNMP::agent - Perl extension for the net-snmp agent.
 
 This module implements an API set to make a SNMP agent act as a snmp
 agent, a snmp subagent (using the AgentX subagent protocol) and/or
-embedded perl-APIs directly within the traditional net-snmp agent demon.
+embedded perl-APIs directly within the traditional net-snmp agent daemon.
 
 Also see the tutorial about the genaral Net-SNMP C API, which this
 module implements in a perl-way, and a perl specific tutorial at:

--- a/snmplib/container_binary_array.c
+++ b/snmplib/container_binary_array.c
@@ -22,7 +22,7 @@
 #if HAVE_STDLIB_H
 #include <stdlib.h>
 #endif
-#if HAVE_MALLOC_H
+#ifdef HAVE_MALLOC_H
 #include <malloc.h>
 #endif
 #include <sys/types.h>

--- a/snmplib/container_iterator.c
+++ b/snmplib/container_iterator.c
@@ -10,7 +10,7 @@
 #if HAVE_STDLIB_H
 #include <stdlib.h>
 #endif
-#if HAVE_MALLOC_H
+#ifdef HAVE_MALLOC_H
 #include <malloc.h>
 #endif
 #include <sys/types.h>

--- a/snmplib/container_list_ssll.c
+++ b/snmplib/container_list_ssll.c
@@ -10,7 +10,7 @@
 #if HAVE_STDLIB_H
 #include <stdlib.h>
 #endif
-#if HAVE_MALLOC_H
+#ifdef HAVE_MALLOC_H
 #include <malloc.h>
 #endif
 #include <sys/types.h>

--- a/snmplib/container_null.c
+++ b/snmplib/container_null.c
@@ -16,7 +16,7 @@
 #if HAVE_STDLIB_H
 #include <stdlib.h>
 #endif
-#if HAVE_MALLOC_H
+#ifdef HAVE_MALLOC_H
 #include <malloc.h>
 #endif
 #include <sys/types.h>

--- a/snmplib/snmp_logging.c
+++ b/snmplib/snmp_logging.c
@@ -25,7 +25,7 @@
 #include <net-snmp/net-snmp-config.h>
 #include <net-snmp/net-snmp-features.h>
 #include <stdio.h>
-#if HAVE_MALLOC_H
+#ifdef HAVE_MALLOC_H
 #include <malloc.h>
 #endif
 #if HAVE_STRING_H

--- a/snmplib/snmp_openssl.c
+++ b/snmplib/snmp_openssl.c
@@ -736,7 +736,7 @@ netsnmp_openssl_get_cert_chain(SSL *ssl)
 
     /** check for a chain to a CA */
     ochain = SSL_get_peer_cert_chain(ssl);
-    sk_num_res = sk_num((const void *)ochain);
+    sk_num_res = sk_X509_num(ochain);
     if (!ochain || sk_num_res == 0) {
         DEBUGMSGT(("ssl:cert:chain", "peer has no cert chain\n"));
     }
@@ -745,9 +745,9 @@ netsnmp_openssl_get_cert_chain(SSL *ssl)
          * loop over chain, adding fingerprint / cert for each
          */
         DEBUGMSGT(("ssl:cert:chain", "examining cert chain\n"));
-        sk_num_res = sk_num((const void *)ochain);
+        sk_num_res = sk_X509_num(ochain);
         for(i = 0; i < sk_num_res; ++i) {
-            ocert_tmp = (X509*)sk_value((const void *)ochain,i);
+            ocert_tmp = sk_X509_value(ochain, i);
             fingerprint = netsnmp_openssl_cert_get_fingerprint(ocert_tmp, -1);
             if (NULL == fingerprint)
                 break;

--- a/snmplib/snmpv3.c
+++ b/snmplib/snmpv3.c
@@ -1052,6 +1052,8 @@ init_snmpv3_post_config(int majorid, int minorid, void *serverarg,
 
     size_t          engineIDLen;
     u_char         *c_engineID;
+    u_long          localEngineTime;
+    u_long          localEngineBoots;
 
     c_engineID = snmpv3_generate_engineID(&engineIDLen);
 
@@ -1076,9 +1078,11 @@ init_snmpv3_post_config(int majorid, int minorid, void *serverarg,
     /*
      * for USM set our local engineTime in the LCD timing cache 
      */
+    localEngineTime = snmpv3_local_snmpEngineTime();
+    localEngineBoots = snmpv3_local_snmpEngineBoots();
     set_enginetime(c_engineID, engineIDLen,
-                   snmpv3_local_snmpEngineBoots(),
-                   snmpv3_local_snmpEngineTime(), TRUE);
+                   localEngineBoots,
+                   localEngineTime, TRUE);
 #endif /* NETSNMP_SECMOD_USM */
 
     SNMP_FREE(c_engineID);

--- a/snmplib/transports/snmpSSHDomain.c
+++ b/snmplib/transports/snmpSSHDomain.c
@@ -626,7 +626,7 @@ netsnmp_ssh_transport(const struct sockaddr_in *addr, int local)
         /* XXX: get data from the transport def for it's location */
         unaddr->sun_family = AF_UNIX;
         if (NULL == sockpath) {
-            snprintf(tmpsockpath, sizeof(tmpsocketpath), "%s/%s",
+            snprintf(tmpsockpath, sizeof(tmpsockpath), "%s/%s",
                      get_persistent_directory(), DEFAULT_SOCK_NAME);
             sockpath = tmpsockpath;
         }

--- a/snmplib/transports/snmpTLSBaseDomain.c
+++ b/snmplib/transports/snmpTLSBaseDomain.c
@@ -574,6 +574,7 @@ SSL_CTX *
 sslctx_client_setup(const SSL_METHOD *method, _netsnmpTLSBaseData *tlsbase) {
     netsnmp_cert *id_cert, *peer_cert;
     SSL_CTX      *the_ctx;
+    X509         *ocert;
 
     /***********************************************************************
      * Set up the client context
@@ -623,8 +624,13 @@ sslctx_client_setup(const SSL_METHOD *method, _netsnmpTLSBaseData *tlsbase) {
 
     while (id_cert->issuer_cert) {
         id_cert = id_cert->issuer_cert;
-        if (!SSL_CTX_add_extra_chain_cert(the_ctx, id_cert->ocert))
-            LOGANDDIE("failed to add intermediate client certificate");
+        if (id_cert->ocert)
+        {
+            ocert = X509_dup(id_cert->ocert);
+            DEBUGMSGTL(("sslctx_client", "adding cert-chain certificate %p", ocert);
+            if (!ocert || !SSL_CTX_add_extra_chain_cert(the_ctx, ocert))
+                LOGANDDIE("failed to add intermediate client certificate");
+        }
     }
 
     if (tlsbase->their_identity)
@@ -655,6 +661,7 @@ sslctx_client_setup(const SSL_METHOD *method, _netsnmpTLSBaseData *tlsbase) {
 SSL_CTX *
 sslctx_server_setup(const SSL_METHOD *method) {
     netsnmp_cert *id_cert;
+    X509         *ocert;
 
     /***********************************************************************
      * Set up the server context
@@ -689,8 +696,13 @@ sslctx_server_setup(const SSL_METHOD *method) {
 
     while (id_cert->issuer_cert) {
         id_cert = id_cert->issuer_cert;
-        if (!SSL_CTX_add_extra_chain_cert(the_ctx, id_cert->ocert))
-            LOGANDDIE("failed to add intermediate server certificate");
+        if (id_cert->ocert)
+        {
+            ocert = X509_dup(id_cert->ocert);
+            DEBUGMSGTL(("sslctx_server", "adding cert-chain certificate %p", ocert);
+            if (!ocert || !SSL_CTX_add_extra_chain_cert(the_ctx, ocert))
+                LOGANDDIE("failed to add intermediate server certificate");
+        }
     }
 
     SSL_CTX_set_read_ahead(the_ctx, 1); /* XXX: DTLS only? */

--- a/snmplib/transports/snmpTLSBaseDomain.c
+++ b/snmplib/transports/snmpTLSBaseDomain.c
@@ -627,7 +627,7 @@ sslctx_client_setup(const SSL_METHOD *method, _netsnmpTLSBaseData *tlsbase) {
         if (id_cert->ocert)
         {
             ocert = X509_dup(id_cert->ocert);
-            DEBUGMSGTL(("sslctx_client", "adding cert-chain certificate %p", ocert);
+            DEBUGMSGTL(("sslctx_client", "adding cert-chain certificate %p", ocert));
             if (!ocert || !SSL_CTX_add_extra_chain_cert(the_ctx, ocert))
                 LOGANDDIE("failed to add intermediate client certificate");
         }
@@ -699,7 +699,7 @@ sslctx_server_setup(const SSL_METHOD *method) {
         if (id_cert->ocert)
         {
             ocert = X509_dup(id_cert->ocert);
-            DEBUGMSGTL(("sslctx_server", "adding cert-chain certificate %p", ocert);
+            DEBUGMSGTL(("sslctx_server", "adding cert-chain certificate %p", ocert));
             if (!ocert || !SSL_CTX_add_extra_chain_cert(the_ctx, ocert))
                 LOGANDDIE("failed to add intermediate server certificate");
         }

--- a/snmplib/transports/snmpTLSBaseDomain.c
+++ b/snmplib/transports/snmpTLSBaseDomain.c
@@ -472,9 +472,11 @@ SSL_CTX *
 _sslctx_common_setup(SSL_CTX *the_ctx, _netsnmpTLSBaseData *tlsbase) {
     char         *crlFile;
     char         *cipherList;
+#ifdef SSL_CTX_set_min_proto_version
     const char   *tlsMinVersion;
     const char   *tlsMaxVersion;
     int          tlsVersion;
+#endif
     X509_LOOKUP  *lookup;
     X509_STORE   *cert_store = NULL;
 

--- a/snmplib/transports/snmpTLSBaseDomain.c
+++ b/snmplib/transports/snmpTLSBaseDomain.c
@@ -627,7 +627,7 @@ sslctx_client_setup(const SSL_METHOD *method, _netsnmpTLSBaseData *tlsbase) {
         if (id_cert->ocert)
         {
             ocert = X509_dup(id_cert->ocert);
-            DEBUGMSGTL(("sslctx_client", "adding cert-chain certificate %p", ocert));
+            DEBUGMSGTL(("sslctx_client", "adding cert-chain certificate %p", ocert);
             if (!ocert || !SSL_CTX_add_extra_chain_cert(the_ctx, ocert))
                 LOGANDDIE("failed to add intermediate client certificate");
         }
@@ -699,7 +699,7 @@ sslctx_server_setup(const SSL_METHOD *method) {
         if (id_cert->ocert)
         {
             ocert = X509_dup(id_cert->ocert);
-            DEBUGMSGTL(("sslctx_server", "adding cert-chain certificate %p", ocert));
+            DEBUGMSGTL(("sslctx_server", "adding cert-chain certificate %p", ocert);
             if (!ocert || !SSL_CTX_add_extra_chain_cert(the_ctx, ocert))
                 LOGANDDIE("failed to add intermediate server certificate");
         }

--- a/testing/fulltests/default/T055agentv1mintrap_simple
+++ b/testing/fulltests/default/T055agentv1mintrap_simple
@@ -5,8 +5,6 @@
 HEADER snmpv1 traps are sent by snmpd without notification mib support
 
 SKIPIFNOT USING_EXAMPLES_EXAMPLE_MODULE
-# To do: figure out why this test fails with Xcode 12.
-[ "${TRAVIS_OS_NAME}" = "osx" ] && SKIP "Skipping T055 on OS/X"
 
 #
 # Begin test

--- a/testing/fulltests/default/T056agentv2cmintrap_simple
+++ b/testing/fulltests/default/T056agentv2cmintrap_simple
@@ -5,8 +5,6 @@
 HEADER snmpv2c traps are sent by snmpd without notification mib support
 
 SKIPIFNOT USING_EXAMPLES_EXAMPLE_MODULE
-# To do: figure out why this test fails with Xcode 12.
-[ "${TRAVIS_OS_NAME}" = "osx" ] && SKIP "Skipping T056 on OS/X"
 
 #
 # Begin test

--- a/testing/fulltests/default/T113agentxtrap_simple
+++ b/testing/fulltests/default/T113agentxtrap_simple
@@ -13,7 +13,7 @@ SKIPIFNOT NETSNMP_SECMOD_USM
 # Begin test
 #
 
-# start the trap demon
+# start the trap daemon
 CONFIGTRAPD authcommunity log public
 STARTTRAPD
 
@@ -72,7 +72,7 @@ fi
 # stop the master agent
 STOPAGENT
 
-# stop the trap demon
+# stop the trap daemon
 STOPTRAPD
 
 # all done (whew)

--- a/testing/fulltests/default/T114agentxagentxtrap_simple
+++ b/testing/fulltests/default/T114agentxagentxtrap_simple
@@ -10,7 +10,7 @@ SKIPIFNOT USING_AGENTX_MASTER_MODULE
 # Begin test
 #
 
-# start the trap demon
+# start the trap daemon
 CONFIGTRAPD disableAuthorization yes
 STARTTRAPD
 
@@ -33,7 +33,7 @@ CAPTURE "agentxtrap $AGENTX_SERVER 1.3.6.1.4.1.8072.9999.9999.0 0.0 s mostly_har
 # stop the master agent
 STOPAGENT
 
-# stop the trap demon
+# stop the trap daemon
 STOPTRAPD
 
 # Check that the trap was received

--- a/testing/fulltests/default/T200snmpv2cwalkall_simple
+++ b/testing/fulltests/default/T200snmpv2cwalkall_simple
@@ -4,8 +4,6 @@
 
 HEADER "full snmpwalk (SNMPv2c) against agent (may take time)"
 
-[ "${TRAVIS_OS_NAME}" = "osx" ] && SKIP "Skipping MIB walk on OS/X"
-
 if test `uname -s` = "HP-UX" ; then
     if test `id -u` != "0" ; then
         # The agent needs to be run as root - else force skip

--- a/testing/fulltests/support/simple_eval_tools.sh
+++ b/testing/fulltests/support/simple_eval_tools.sh
@@ -682,8 +682,7 @@ FINISHED() {
 	    rm -f core
 	fi
 	echo "$headerStr...FAIL" >> $SNMP_TMPDIR/invoked
-	if [ -n "${TRAVIS_OS_NAME}" ] || [ -n "$APPVEYOR" ] ||
-	   [ -n "$CIRRUS_CI" ]; then
+	if [ -n "$APPVEYOR" ] || [ -n "$CIRRUS_CI" ]; then
 	    {
 		find "$SNMP_TMPDIR" -type f |
 		    while read -r f; do

--- a/testing/fulltests/tls/T300TlsPerl.t
+++ b/testing/fulltests/tls/T300TlsPerl.t
@@ -5,11 +5,4 @@
 $agentaddress = "tlstcp:localhost:9875";
 $feature = "NETSNMP_TRANSPORT_TLSTCP_DOMAIN";
 
-if (!defined($ENV{'TRAVIS_OS_NAME'})) {
-    do "$ENV{'srcdir'}/testing/fulltests/tls/S300tlsperl.pl";
-} else {
-    # Skip this test on Travis CI
-    use Test;
-    plan(tests => 1);
-    ok(1);
-}
+do "$ENV{'srcdir'}/testing/fulltests/tls/S300tlsperl.pl";


### PR DESCRIPTION
The function `SSL_CTX_add_extra_chain_cert` frees the used X509 pointer after destroying the associated SSL_CTX according to https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_add_extra_chain_cert.html. This leads to the X509 pointer from the cert-map being freed, while still being potentially used in further sessions. This problem regularly occurs, when repeatedly opening and closing netsnmp-sessions in a TSM/TLS-configuration.

I added a fix, where I create a copy of the original X509 pointer using `X509_dup`, which is used in `SSL_CTX_add_extra_chain_cert` instead of the cached X509 pointer and autonomously cleaned up by openssl after destroying the SSL_CTX.
