### PR TITLE
Restore using libtool's -no-undefined flag on Cygwin

### DIFF
--- a/configure
+++ b/configure
@@ -16302,11 +16302,16 @@ esac
 
 
 #
-#    Whether the linker supports the flag -Wl,-no-undefined. Do not use
-#    -Wl,-no-undefined on OpenBSD because it breaks linking of shared
-#    libraries. Use -Wl,-no-undefined on all other platforms such that
-#    undefined symbols are detected at compile time instead of at runtime.
+#    Whether the linker supports the flag -Wl,-no-undefined.
 #
+#    Do not use -Wl,-no-undefined on OpenBSD because it breaks linking of shared
+#    libraries. Use -Wl,-no-undefined on all other platforms such that undefined
+#    symbols are detected at compile time instead of at runtime.
+#
+#    On Windows targets, due to limitations of the PE executable format, the
+#    linker will always operate as if -Wl,-no-undefined was supplied.  Also
+#    supply the libtool flag -no-undefined to authorize it to build shared
+#    libraries.
 
 case x$target_os in
   xopenbsd*)
@@ -16330,7 +16335,7 @@ main ()
 _ACEOF
 if ac_fn_c_try_link "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }; 		      LD_NO_UNDEFINED=-Wl,-no-undefined
+$as_echo "yes" >&6; }; 		      LD_NO_UNDEFINED="-no-undefined -Wl,-no-undefined"
 else
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
 $as_echo "no" >&6; }

--- a/configure.d/config_os_progs
+++ b/configure.d/config_os_progs
@@ -186,11 +186,16 @@ esac
 
 
 #
-#    Whether the linker supports the flag -Wl,-no-undefined. Do not use
-#    -Wl,-no-undefined on OpenBSD because it breaks linking of shared
-#    libraries. Use -Wl,-no-undefined on all other platforms such that
-#    undefined symbols are detected at compile time instead of at runtime.
+#    Whether the linker supports the flag -Wl,-no-undefined.
 #
+#    Do not use -Wl,-no-undefined on OpenBSD because it breaks linking of shared
+#    libraries. Use -Wl,-no-undefined on all other platforms such that undefined
+#    symbols are detected at compile time instead of at runtime.
+#
+#    On Windows targets, due to limitations of the PE executable format, the
+#    linker will always operate as if -Wl,-no-undefined was supplied.  Also
+#    supply the libtool flag -no-undefined to authorize it to build shared
+#    libraries.
 
 case x$target_os in
   xopenbsd*)
@@ -202,7 +207,7 @@ case x$target_os in
       LDFLAGS="$saved_LDFLAGS -Wl,-no-undefined"
       AC_LINK_IFELSE([AC_LANG_PROGRAM([],[])],
 		     [AC_MSG_RESULT([yes]); dnl
-		      LD_NO_UNDEFINED=-Wl,-no-undefined],
+		      LD_NO_UNDEFINED="-no-undefined -Wl,-no-undefined"],
 		     [AC_MSG_RESULT([no])])
       LDFLAGS="$saved_LDFLAGS"
       AC_SUBST(LD_NO_UNDEFINED)


### PR DESCRIPTION
Commit cb9b87d9b6e2 ("Always use -Wl,-no-undefined when linking a shared library") swaps the libtool flag -no-undefined for the linker flag -Wl,-no-undefined on Cygwin.

These two aren't the same: ld's -no-undefined flag [1] makes unresolved references an error [1], whereas libtool's -no-undefined flag [2] assures it that there are no undefined references and therefore it may try to build a shared library on platforms where that is required to build a shared library.

[1] https://sourceware.org/binutils/docs-2.40/ld/Options.html
[2] https://www.gnu.org/software/libtool/manual/html_node/Link-mode.html#Link-mode

This flag possibly should also be used for MinGW builds, if shared libraries are wanted there.