### PR TITLE
Cygwin uses ':' for the path separator

### DIFF
--- a/configure.d/config_modules_agent
+++ b/configure.d/config_modules_agent
@@ -792,8 +792,8 @@ if test "x$NETSNMP_DEFAULT_MIBS" = "x"; then
 fi
 if test "x$ENV_SEPARATOR" != "x"; then
   :
-elif test "x$PARTIALTARGETOS" = "xmingw32" -o "x$PARTIALTARGETOS" = "xmingw32msvc" -o "x$PARTIALTARGETOS" = "xcygwin"; then
-  # mingw32 and cygwin use ';' as the default environment variable separator
+elif test "x$PARTIALTARGETOS" = "xmingw32" -o "x$PARTIALTARGETOS" = "xmingw32msvc"; then
+  # mingw32 uses ';' as the default environment variable separator
   ENV_SEPARATOR=";"
   NETSNMP_DEFAULT_MIBS=`echo "$NETSNMP_DEFAULT_MIBS" | $SED 's/:/;/g'`
   default_mibs=`echo "$default_mibs" | $SED 's/:/;/g'`

--- a/configure.d/config_project_paths
+++ b/configure.d/config_project_paths
@@ -80,7 +80,7 @@ AC_SUBST(SNMPSHAREPATH)
 #
 if test "x$NETSNMP_DEFAULT_MIBDIRS" = "x"; then
     NETSNMP_DEFAULT_MIBDIRS="\$HOME/.snmp/mibs:$SNMPSHAREPATH/mibs"
-    if test "x$PARTIALTARGETOS" = "xmingw32" -o "x$PARTIALTARGETOS" = "xmingw32msvc" -o "x$PARTIALTARGETOS" = "xcygwin"; then
+    if test "x$PARTIALTARGETOS" = "xmingw32" -o "x$PARTIALTARGETOS" = "xmingw32msvc"; then
         #
         #    USe Windows-style path separator
         NETSNMP_DEFAULT_MIBDIRS=`echo "$NETSNMP_DEFAULT_MIBDIRS" | $SED 's/:/;/g'`


### PR DESCRIPTION
Cygwin uses a UNIX-style ':' separator  for paths in environment variables.

This is a patch (originally by David Rothenberger), which we've been shipping in the Cygwin net-snmp package since at least 2013. 
