### PR TITLE
libsnmp: Export netsnmp_set_mib_directory so it can be used inside a custom application.

### DIFF
--- a/include/net-snmp/library/mib.h
+++ b/include/net-snmp/library/mib.h
@@ -120,6 +120,7 @@ SOFTWARE.
     NETSNMP_IMPORT
     void            print_ascii_dump(FILE *);
     void            register_mib_handlers(void);
+    NETSNMP_IMPORT
     void            netsnmp_set_mib_directory(const char *dir);
     NETSNMP_IMPORT
     char            *netsnmp_get_mib_directory(void);


### PR DESCRIPTION
netsnmp_get_mib_directory was already exported, but netsnmp_set_mib_directory was not.

Now any external application can set its MIB dirs without reimplementing the netsnmp_set_mib_directory function.

closes #530