### PR TITLE
Add '@' netgroup functionality

### DIFF
--- a/configure.d/config_os_functions
+++ b/configure.d/config_os_functions
@@ -25,12 +25,14 @@ AC_TYPE_SIGNAL
 AC_CHECK_FUNCS([rand   random srand srandom lrand48 srand48])
 
 #  Library:
-AC_CHECK_FUNCS([asprintf        closedir        fgetc_unlocked   ] dnl
+AC_CHECK_FUNCS([asprintf        closedir        endnetgrent      ] dnl
+               [fgetc_unlocked                                   ] dnl
                [flockfile       funlockfile     getipnodebyname  ] dnl
-               [gettimeofday    getlogin                         ] dnl
+               [gettimeofday    getlogin        getnetgrent      ] dnl
                [if_nametoindex  mkstemp                          ] dnl
                [opendir         readdir         regcomp          ] dnl
                [setenv          setitimer       setlocale        ] dnl
+               [setnetgrent                                      ] dnl
                [setsid          snprintf        strcasestr       ] dnl
                [strdup          strerror        strncasecmp      ] dnl
                [sysconf         times           vsnprintf        ] )

--- a/man/snmpd.conf.5.def
+++ b/man/snmpd.conf.5.def
@@ -434,6 +434,14 @@ com2sec sec1 10.0.0.0/8 public
 .IP
 Access from outside of 10.0.0.0/8 would still be denied.
 .IP
+It is also possible to reference a specific \fInetgroup\fR starting with an
+'@' character (e.g.  @adminhosts). The \fInetgroup\fR lookup is running
+through the NSS (Name Services Switch) making it possible to define the
+group locally or via NIS/LDAP.
+.IP
+Note: The hostname DNS lookup and \fInetgroup\fR resolution is done only
+during snmpd start or reload.
+.IP
 The same community string can be specified in several separate directives
 (presumably with different source tokens), and the first source/community
 combination that matches the incoming request will be selected.

--- a/snmplib/transports/snmpUDPDomain.c
+++ b/snmplib/transports/snmpUDPDomain.c
@@ -347,6 +347,33 @@ netsnmp_udp_com2SecEntry_create(com2SecEntry **entryp, const char *community,
 }
 
 void
+netsnmp_udp_com2SecEntry_check_return_code(int rc)
+{
+    /*
+     * Check return code of the newly created com2Sec entry.
+     */
+    switch(rc) {
+        case C2SE_ERR_SUCCESS:
+            break;
+        case C2SE_ERR_CONTEXT_TOO_LONG:
+            config_perror("context name too long");
+            break;
+        case C2SE_ERR_COMMUNITY_TOO_LONG:
+            config_perror("community name too long");
+            break;
+        case C2SE_ERR_SECNAME_TOO_LONG:
+            config_perror("security name too long");
+            break;
+        case C2SE_ERR_MASK_MISMATCH:
+            config_perror("source/mask mismatch");
+            break;
+        case C2SE_ERR_MISSING_ARG:
+        default:
+            config_perror("unexpected error; could not create com2SecEntry");
+    }
+}
+
+void
 netsnmp_udp_parse_security(const char *token, char *param)
 {
     /** copy_nword does null term, so we need vars of max size + 2. */
@@ -440,25 +467,7 @@ netsnmp_udp_parse_security(const char *token, char *param)
      */
     rc = netsnmp_udp_com2SecEntry_create(NULL, community, secName, contextName,
                                          &network, &mask, negate);
-    switch(rc) {
-        case C2SE_ERR_SUCCESS:
-            break;
-        case C2SE_ERR_CONTEXT_TOO_LONG:
-            config_perror("context name too long");
-            break;
-        case C2SE_ERR_COMMUNITY_TOO_LONG:
-            config_perror("community name too long");
-            break;
-        case C2SE_ERR_SECNAME_TOO_LONG:
-            config_perror("security name too long");
-            break;
-        case C2SE_ERR_MASK_MISMATCH:
-            config_perror("source/mask mismatch");
-            break;
-        case C2SE_ERR_MISSING_ARG:
-        default:
-            config_perror("unexpected error; could not create com2SecEntry");
-    }
+    netsnmp_udp_com2SecEntry_check_return_code(rc);
 }
 
 void


### PR DESCRIPTION


The openSUSE/SUSE net-snmp v5.7 package had a feature to use netgroups defined in `/etc/netgroup` or NIS/LDAP to gain access to a SNMP host. This feature was ported to our v5.9 and I would like to get it into the master branch.

How this feature works:
```
/etc/netgroup
nodes (node1,,) (node2,,) (node3,,)

/etc/snmp/snmpd.conf
rocommunity public @nodes
```

This makes it easier to define host groups that should have access to the SNMP host.
