### PR TITLE
Set flags in MakefileSubs.pm at configure time

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -140,6 +140,7 @@ AC_CONFIG_FILES([net-snmp-create-v3-user:net-snmp-create-v3-user.in],
 AC_CONFIG_FILES([netsnmp.pc:netsnmp.pc.in netsnmp-agent.pc:netsnmp-agent.pc.in])
 AC_CONFIG_FILES([dist/generation-scripts/gen-variables:dist/generation-scripts/gen-variables.in])
 AC_CONFIG_FILES([local/snmpconf])
+AC_CONFIG_FILES([perl/MakefileSubs.pm])
 
 AC_CONFIG_COMMANDS([default], echo timestamp > stamp-h)
 

--- a/perl/MakefileSubs.pm.in
+++ b/perl/MakefileSubs.pm.in
@@ -105,15 +105,10 @@ sub AddCommonParams {
     } else {
 	# Unix or MinGW.
 	append($Params->{'LDDLFLAGS'}, $Config{'lddlflags'});
-	my $ldflags = `$opts->{'nsconfig'} --ldflags` or
-	    die "net-snmp-config failed\n";
-	chomp($ldflags);
-	append($Params->{'LDDLFLAGS'}, $ldflags);
+	append($Params->{'LDDLFLAGS'}, '@LDFLAGS@');
 	append($Params->{'CCFLAGS'},
 	       "-I" . File::Spec->catdir($basedir, "include"));
-	my $cflags = `$opts->{'nsconfig'} --cflags` or
-	    die "net-snmp-config failed\n";
-	chomp($cflags);
+	my $cflags = '@CFLAGS@ @DEVFLAGS@ @CPPFLAGS@ -I. -I@includedir@';
 	# Remove -Wimplicit-fallthrough since it is not supported by older
 	# versions of gcc.
 	$cflags =~ s/-Wimplicit-fallthrough=[0-9]//g;


### PR DESCRIPTION
Setting the flags at configure time instead of runtime allows use of the perl module without pulling in net-snmp-config (which in the Fedora/RHEL RPM setup also pulls in gcc and *-devel packages, not otherwise needed when just using the perl SNMP module).  The in-tree module is updated with the rest of the net-snmp code anyway, so setting this at configure time should stay consistent.