### PR TITLE
add pcre2 support

### DIFF
--- a/agent/mibgroup/if-mib/data_access/interface.c
+++ b/agent/mibgroup/if-mib/data_access/interface.c
@@ -16,7 +16,11 @@
 #include "if-mib/ifTable/ifTable.h"
 #include "if-mib/data_access/interface.h"
 #include "interface_private.h"
-#if defined(HAVE_PCRE_H)
+
+#if defined(HAVE_PCRE2_H)
+#define PCRE2_CODE_UNIT_WIDTH 8
+#include <pcre2.h>
+#elif defined(HAVE_PCRE_H)
 #include <pcre.h>
 #elif defined(HAVE_REGEX_H)
 #include <sys/types.h>
@@ -825,7 +829,13 @@ int netsnmp_access_interface_max_reached(const char *name)
 int netsnmp_access_interface_include(const char *name)
 {
     netsnmp_include_if_list *if_ptr;
-#ifdef HAVE_PCRE_H
+#if defined(HAVE_PCRE2_H) 
+    //pcre_exec->pcre2_match
+    //ovector->pcre2_match_data
+    pcre2_match_data *ndx_match;
+    ndx_match = pcre2_match_data_create(3, NULL);
+    int *found_ndx = pcre2_get_ovector_pointer(ndx_match);
+#elif defined(HAVE_PCRE_H)
     int                      found_ndx[3];
 #endif
 
@@ -841,7 +851,13 @@ int netsnmp_access_interface_include(const char *name)
 
 
     for (if_ptr = include_list; if_ptr; if_ptr = if_ptr->next) {
-#if defined(HAVE_PCRE_H)
+#if defined(HAVE_PCRE2_H)
+        if (pcre2_match(if_ptr->regex_ptr, name, strlen(name), 0, 0, 
+                                ndx_match, NULL) >= 0)  {
+                pcre2_match_data_free(ndx_match);
+                return TRUE;
+        }
+#elif defined(HAVE_PCRE_H)
         if (pcre_exec(if_ptr->regex_ptr, NULL, name, strlen(name), 0, 0,
                       found_ndx, 3) >= 0)
             return TRUE;
@@ -854,6 +870,9 @@ int netsnmp_access_interface_include(const char *name)
 #endif
     }
 
+#if defined(HAVE_PCRE2_H)
+    pcre2_match_data_free(ndx_match);
+#endif
     return FALSE;
 }
 
@@ -965,7 +984,13 @@ _parse_include_if_config(const char *token, char *cptr)
 {
     netsnmp_include_if_list *if_ptr, *if_new;
     char                    *name, *st;
-#if defined(HAVE_PCRE_H)
+#if defined(HAVE_PCRE2_H)
+    //we can only get the message upon calling pcre2_error_message.
+    // so an additional variable is required.
+    int                     pcre2_err_code;
+    unsigned char           pcre2_error[128];
+    int                     pcre2_error_offset;
+#elif defined(HAVE_PCRE_H)
     const char              *pcre_error;
     int                     pcre_error_offset;
 #elif defined(HAVE_REGEX_H)
@@ -997,7 +1022,15 @@ _parse_include_if_config(const char *token, char *cptr)
             config_perror("Out of memory");
             goto err;
         }
-#if defined(HAVE_PCRE_H)
+#if defined(HAVE_PCRE2_H)
+        if_new->regex_ptr = pcre2_compile(if_new->name, PCRE2_ZERO_TERMINATED, 0,
+                         &pcre2_err_code, &pcre2_error_offset, NULL);
+        if (!if_new->regex_ptr) {
+            pcre2_get_error_message(pcre2_err_code, pcre2_error, 128);
+            config_perror(pcre2_error);
+            goto err;
+        }
+#elif defined(HAVE_PCRE_H)
         if_new->regex_ptr = pcre_compile(if_new->name, 0,  &pcre_error,
                                          &pcre_error_offset, NULL);
         if (!if_new->regex_ptr) {
@@ -1033,7 +1066,7 @@ _parse_include_if_config(const char *token, char *cptr)
 
 err:
     if (if_new) {
-#if defined(HAVE_PCRE_H) || defined(HAVE_REGEX_H)
+#if defined(HAVE_PCRE2_H) || defined(HAVE_PCRE_H) || defined(HAVE_REGEX_H)
         free(if_new->regex_ptr);
 #endif
         free(if_new->name);
@@ -1048,7 +1081,7 @@ _free_include_if_config(void)
 
     while (if_ptr) {
         if_next = if_ptr->next;
-#if defined(HAVE_PCRE_H)
+#if defined(HAVE_PCRE2_H) || defined(HAVE_PCRE_H)
         free(if_ptr->regex_ptr);
 #elif defined(HAVE_REGEX_H)
         regfree(if_ptr->regex_ptr);

--- a/agent/mibgroup/struct.h
+++ b/agent/mibgroup/struct.h
@@ -30,7 +30,7 @@ struct extensible {
 
 struct myproc {
     char            name[STRMAX];
-#ifdef HAVE_PCRE_H
+#if defined(HAVE_PCRE2_H) || defined(HAVE_PCRE_H)
     netsnmp_regex_ptr regexp;
 #endif
     char            fixcmd[STRMAX];

--- a/agent/mibgroup/ucd-snmp/proc.c
+++ b/agent/mibgroup/ucd-snmp/proc.c
@@ -39,7 +39,10 @@
 #  include <time.h>
 # endif
 #endif
-#ifdef HAVE_PCRE_H
+#ifdef HAVE_PCRE2_H
+#define PCRE2_CODE_UNIT_WIDTH 8
+#include <pcre2.h>
+#elif HAVE_PCRE_H
 #include <pcre.h>
 #endif
 
@@ -108,7 +111,7 @@ init_proc(void)
     REGISTER_MIB("ucd-snmp/proc", extensible_proc_variables, variable2,
                  proc_variables_oid);
 
-#ifdef HAVE_PCRE_H
+#if defined(HAVE_PCRE2_H) || defined(HAVE_PCRE_H)
 #define proc_parse_usage "process-name [max-num] [min-num] [regexp]"
 #else
 #define proc_parse_usage "process-name [max-num] [min-num]"
@@ -134,7 +137,7 @@ proc_free_config(void)
     for (ptmp = procwatch; ptmp != NULL;) {
         ptmp2 = ptmp;
         ptmp = ptmp->next;
-#ifdef HAVE_PCRE_H
+#if defined(HAVE_PCRE2_H) || defined(HAVE_PCRE_H)
         free(ptmp2->regexp.regex_ptr);
 #endif
         free(ptmp2);
@@ -208,7 +211,7 @@ proc_parse_config(const char *token, char *cptr)
     if (*procp == NULL)
         return;                 /* memory alloc error */
     numprocs++;
-#ifdef HAVE_PCRE_H
+#if defined(HAVE_PCRE2_H) || defined(HAVE_PCRE_H)
     (*procp)->regexp.regex_ptr = NULL;
 #endif
     /*
@@ -220,18 +223,31 @@ proc_parse_config(const char *token, char *cptr)
         cptr = skip_not_white(cptr);
         if ((cptr = skip_white(cptr))) {
             (*procp)->min = atoi(cptr);
-#ifdef HAVE_PCRE_H
+#if defined(HAVE_PCRE2_H) || defined(HAVE_PCRE_H)
             cptr = skip_not_white(cptr);
             if ((cptr = skip_white(cptr))) {
+                DEBUGMSGTL(("ucd-snmp/regexp_proc", "Loading regex %s\n", cptr));
+#ifdef HAVE_PCRE2_H
+                unsigned char pcre2_error_msg[128];
+                int pcre2_err_code;
+                int pcre2_error_offset;
+
+                (*procp)->regexp.regex_ptr =
+                    pcre2_compile(cptr, PCRE2_ZERO_TERMINATED, 0, &pcre2_err_code, &pcre2_error_offset, NULL);
+                pcre2_get_error_message(pcre2_err_code, pcre2_error_msg, 128);
+                if ((*procp)->regexp.regex_ptr == NULL) {
+                    config_perror(pcre2_error_msg);
+                }
+#elif HAVE_PCRE_H
                 const char *pcre_error;
                 int pcre_error_offset;
 
-                DEBUGMSGTL(("ucd-snmp/regexp_proc", "Loading regex %s\n", cptr));
                 (*procp)->regexp.regex_ptr =
                     pcre_compile(cptr, 0,  &pcre_error, &pcre_error_offset, NULL);
                 if ((*procp)->regexp.regex_ptr == NULL) {
                     config_perror(pcre_error);
                 }
+#endif
             }
 #endif
         } else
@@ -390,7 +406,7 @@ sh_count_myprocs(struct myproc *proc)
     if (proc == NULL)
         return 0;
 
-#if defined(USING_HOST_DATA_ACCESS_SWRUN_MODULE) && defined(HAVE_PCRE_H)
+#if defined(USING_HOST_DATA_ACCESS_SWRUN_MODULE) && (defined(HAVE_PCRE2_H) || defined(HAVE_PCRE_H))
     if (proc->regexp.regex_ptr != NULL)
       return sh_count_procs_by_regex(proc->name, proc->regexp);
 #endif
@@ -406,7 +422,7 @@ sh_count_procs(char *procname)
   return swrun_count_processes_by_name( procname );
 }
 
-#ifdef HAVE_PCRE_H
+#if defined(HAVE_PCRE2_H) || defined(HAVE_PCRE_H)
 netsnmp_feature_require(swrun_count_processes_by_regex);
 int
 sh_count_procs_by_regex(char *procname, netsnmp_regex_ptr regexp)

--- a/agent/mibgroup/ucd-snmp/proc.h
+++ b/agent/mibgroup/ucd-snmp/proc.h
@@ -12,7 +12,7 @@ config_require(util_funcs);
      extern WriteMethod fixProcError;
      int sh_count_myprocs(struct myproc *);
      int             sh_count_procs(char *);
-#ifdef HAVE_PCRE_H
+#if defined(HAVE_PCRE2_H) || defined(HAVE_PCRE_H)
      int sh_count_procs_by_regex(char *, netsnmp_regex_ptr);
 #endif
 

--- a/configure.d/config_os_libs1
+++ b/configure.d/config_os_libs1
@@ -97,6 +97,32 @@ LIBS="$netsnmp_save_LIBS"
 #
 #   regex in process table
 #
+if test "x$with_pcre2" != "xno"; then
+  AC_CHECK_HEADER([pcre2.h], [
+      AC_DEFINE([HAVE_PCRE2_H], [1], [Define to 1 if you have <pcre2.h>.])
+      pcre2_h=yes
+    ],
+    [pcre2_h=no], [#define PCRE2_CODE_UNIT_WIDTH 8]
+  )
+fi
+if test "x$pcre2header_h" = "xno" -o "x$pcre2_h" = "xno" ; then
+  if test "x$with_pcre2" = "xyes" ; then
+    AC_MSG_ERROR([Could not find the pcre2 header file needed and was specifically asked to use pcre2 support])
+  else
+    with_pcre2=no
+  fi
+fi
+
+if test "x$with_pcre2" != "xno"; then
+  NETSNMP_SEARCH_LIBS([pcre2_match_8], [pcre2-8], [
+    LMIBLIBS="$LMIBLIBS -lpcre2-8"
+    ],,, LAGENTLIBS)
+  AC_SUBST(LAGENTLIBS)
+  AC_SUBST(LMIBLIBS)
+fi
+
+if test "x$with_pcre2" != "xyes"; then
+
 if test "x$with_pcre" != "xno"; then
   AC_CHECK_HEADER([pcre.h], [
       AC_DEFINE([HAVE_PCRE_H], [1], [Define to 1 if you have <pcre.h>.])
@@ -122,4 +148,5 @@ if test "x$with_pcre" != "xno"; then
     ],,, LAGENTLIBS)
   AC_SUBST(LAGENTLIBS)
   AC_SUBST(LMIBLIBS)
+fi
 fi

--- a/configure.d/config_project_with_enable
+++ b/configure.d/config_project_with_enable
@@ -171,6 +171,10 @@ NETSNMP_ARG_WITH(rpm,
                                   management system when building the host MIB
                                   module.])
 
+NETSNMP_ARG_WITH(pcre2-8,
+[  --without-pcre2                  Don't include pcre2 process searching
+                                  support in the agent.],
+      with_pcre2="$withval", with_pcre2="maybe")
 
 NETSNMP_ARG_WITH(pcre,
 [  --without-pcre                  Don't include pcre process searching

--- a/include/net-snmp/data_access/interface.h
+++ b/include/net-snmp/data_access/interface.h
@@ -10,7 +10,10 @@
 extern          "C" {
 #endif
 
-#if defined(HAVE_PCRE_H)
+#if defined(HAVE_PCRE2_H)
+#define PCRE2_CODE_UNIT_WIDTH 8
+#include <pcre2.h>
+#elif defined(HAVE_PCRE_H)
 #include <pcre.h>
 #elif defined(HAVE_REGEX_H)
 #include <regex.h>
@@ -211,7 +214,9 @@ typedef struct _conf_if_list {
     typedef netsnmp_conf_if_list conf_if_list; /* backwards compat */
 
 typedef struct _include_if_list {
-#if defined(HAVE_PCRE_H)
+#if defined(HAVE_PCRE2_H)
+    pcre2_code              *regex_ptr;
+#elif defined(HAVE_PCRE_H)
     pcre                    *regex_ptr;
 #elif defined(HAVE_REGEX_H)
     regex_t                 *regex_ptr;

--- a/include/net-snmp/data_access/swrun.h
+++ b/include/net-snmp/data_access/swrun.h
@@ -90,7 +90,7 @@ extern "C" {
     int  swrun_count_processes_by_name( char *name );
 
 #if !defined(NETSNMP_FEATURE_REMOVE_SWRUN_COUNT_PROCESSES_BY_REGEX) \
-    && defined(HAVE_PCRE_H)
+    && (defined(HAVE_PCRE2_H) || defined(HAVE_PCRE_H))
     int  swrun_count_processes_by_regex(char *name, netsnmp_regex_ptr regexp);
 #endif
 

--- a/include/net-snmp/types.h
+++ b/include/net-snmp/types.h
@@ -63,7 +63,7 @@ typedef long ssize_t;
 typedef unsigned long int nfds_t;
 #endif
 
-#ifdef HAVE_PCRE_H
+#if defined(HAVE_PCRE2_H) || defined(HAVE_PCRE_H)
 /*
  * Abstract the pcre typedef such that not all *.c files have to include
  * <pcre.h>.


### PR DESCRIPTION
the dutchman was insistent i create a "pull request", which wasn't so bad once i read closer, but i wish my patch was embraced unconditionally. 

BUT, i digress. original message is here below:


hi,

my boy a*s**ck (@brainslayer) has decided to update snmp, and i noticed there is a small chunk of code using pcre for interface searching (or something like that).

as such, i've attached a patch that should provide proper pcre2_support.

an aside: i noticed i had to remove the "#ifdef" macros for PCRE in interface.h, as i'd get some configuration error that would prevent the interface.c/interface.h (and associated files) from being built. i found it very unusual. it could be the fact i'm on a mac and cross-compiling. not sure. i hope someone else can figure out any problems with my modifications to 


> configure.d/config_os_libs1
> configure.d/config_project_with_enable


are suboptimal, which causes the following issue

```
configure: WARNING: unrecognized options: --without-efence, --without-dmalloc
configure: WARNING: using cross tools not prefixed with host triplet
 agent/extend agentx default_modules host/hr_device host/hr_disk host/hr_filesys host/hr_network host/hr_partition host/hr_proc host/hr_storage host/hr_system ieee802dot11 if-mib/ifXTable ip-mib/inetNetToMediaTable mibII/at mibII/icmp mibII/ifTable mibII/ip mibII/snmp_mib mibII/sysORTable mibII/system_mib mibII/tcp mibII/udp mibII/vacm_context mibII/vacm_vars tunnel ucd-snmp/extensible ucd-snmp/loadave ucd-snmp/memory ucd-snmp/pass ucd-snmp/pass_persist ucd-snmp/proc ucd-snmp/vmstat util_funcs utilities/execute util_funcs/header_simple_table agentx/master agentx/subagent mibII/vacm_conf hardware/cpu hardware/memoryIn file included from ../agent/mibgroup/if-mib/ifXTable/ifXTable.h:20,
                 from module_tmp_header.h:180:
../include/net-snmp/data_access/interface.h:15:10: fatal error: pcre2.h: No such file or directory
   15 | #include <pcre2.h>
      |          ^~~~~~~~~
compilation terminated.
In file included from ../agent/mibgroup/if-mib/ifXTable/ifXTable.h:20,
                 from module_tmp_header.h:180:
../include/net-snmp/data_access/interface.h:15:10: fatal error: pcre2.h: No such file or directory
   15 | #include <pcre2.h>
      |          ^~~~~~~~~
compilation terminated.
In file included from ../agent/mibgroup/if-mib/ifXTable/ifXTable.h:20,
                 from module_tmp_header.h:180:
../include/net-snmp/data_access/interface.h:15:10: fatal error: pcre2.h: No such file or directory
   15 | #include <pcre2.h>
      |          ^~~~~~~~~
compilation terminated.
In file included from ../agent/mibgroup/if-mib/ifXTable/ifXTable.h:20,
                 from module_tmp_header.h:180:
../include/net-snmp/data_access/interface.h:15:10: fatal error: pcre2.h: No such file or directory
   15 | #include <pcre2.h>
      |          ^~~~~~~~~
compilation terminated.
In file included from ../agent/mibgroup/if-mib/ifXTable/ifXTable.h:20,
                 from module_tmp_header.h:180:
../include/net-snmp/data_access/interface.h:15:10: fatal error: pcre2.h: No such file or directory
   15 | #include <pcre2.h>
      |          ^~~~~~~~~
compilation terminated.
In file included from ../agent/mibgroup/if-mib/ifXTable/ifXTable.h:20,
                 from module_tmp_header.h:180:
../include/net-snmp/data_access/interface.h:15:10: fatal error: pcre2.h: No such file or directory
   15 | #include <pcre2.h>
      |          ^~~~~~~~~
compilation terminated.
In file included from ../agent/mibgroup/if-mib/ifXTable/ifXTable.h:20,
                 from module_tmp_header.h:180:
../include/net-snmp/data_access/interface.h:15:10: fatal error: pcre2.h: No such file or directory
   15 | #include <pcre2.h>
      |          ^~~~~~~~~
compilation terminated.
In file included from ../agent/mibgroup/if-mib/ifXTable/ifXTable.h:20,
                 from module_tmp_header.h:180:
../include/net-snmp/data_access/interface.h:15:10: fatal error: pcre2.h: No such file or directory
   15 | #include <pcre2.h>
      |          ^~~~~~~~~
compilation terminated.
In file included from ../agent/mibgroup/if-mib/ifXTable/ifXTable.h:20,
                 from module_tmp_header.h:180:
../include/net-snmp/data_access/interface.h:15:10: fatal error: pcre2.h: No such file or directory
   15 | #include <pcre2.h>
      |          ^~~~~~~~~
compilation terminated.
In file included from ../agent/mibgroup/if-mib/ifXTable/ifXTable.h:20,
                 from module_tmp_header.h:180:
../include/net-snmp/data_access/interface.h:15:10: fatal error: pcre2.h: No such file or directory
   15 | #include <pcre2.h>
      |          ^~~~~~~~~
compilation terminated.
 if-mib/ifXTable/ifXTable ip-mib/data_access/arp ip-mib/inetNetToMediaTable/inetNetToMediaTable ip-mib/inetNetToMediaTable/inetNetToMediaTable_interface ip-mib/inetNetToMediaTable/inetNetToMediaTable_data_access mibII/data_access/at_linux mibII/data_access/at_unix mibII/kernel_linux if-mib/ifTable mibII/ipAddr mibII/var_route mibII/route_write mibII/updates mibII/tcpTable mibII/udpTable util_funcs/header_generic tunnel/tunnel ucd-snmp/pass_common agentx/protocol agentx/master_admin agentx/agentx_config agentx/client hardware/cpu/cpu hardware/cpu/cpu_linux hardware/memory/hw_mem hardware/memory/memory_linux ip-mib/data_access/arp_common ip-mib/data_access/arp_netlinkIn file included from ../agent/mibgroup/if-mib/ifTable/ifTable.h:21,
                 from module_tmp_header.h:180:
../include/net-snmp/data_access/interface.h:15:10: fatal error: pcre2.h: No such file or directory
   15 | #include <pcre2.h>
      |          ^~~~~~~~~
compilation terminated.
In file included from ../agent/mibgroup/if-mib/ifTable/ifTable.h:21,
                 from module_tmp_header.h:180:
../include/net-snmp/data_access/interface.h:15:10: fatal error: pcre2.h: No such file or directory
   15 | #include <pcre2.h>
      |          ^~~~~~~~~
compilation terminated.
In file included from ../agent/mibgroup/if-mib/ifTable/ifTable.h:21,
                 from module_tmp_header.h:180:
../include/net-snmp/data_access/interface.h:15:10: fatal error: pcre2.h: No such file or directory
   15 | #include <pcre2.h>
      |          ^~~~~~~~~
compilation terminated.
In file included from ../agent/mibgroup/if-mib/ifTable/ifTable.h:21,
                 from module_tmp_header.h:180:
../include/net-snmp/data_access/interface.h:15:10: fatal error: pcre2.h: No such file or directory
   15 | #include <pcre2.h>
      |          ^~~~~~~~~
compilation terminated.
In file included from ../agent/mibgroup/if-mib/ifTable/ifTable.h:21,
                 from module_tmp_header.h:180:
../include/net-snmp/data_access/interface.h:15:10: fatal error: pcre2.h: No such file or directory
   15 | #include <pcre2.h>
      |          ^~~~~~~~~
compilation terminated.
In file included from ../agent/mibgroup/if-mib/ifTable/ifTable.h:21,
                 from module_tmp_header.h:180:
../include/net-snmp/data_access/interface.h:15:10: fatal error: pcre2.h: No such file or directory
   15 | #include <pcre2.h>
      |          ^~~~~~~~~
compilation terminated.
In file included from ../agent/mibgroup/if-mib/ifTable/ifTable.h:21,
                 from module_tmp_header.h:180:
../include/net-snmp/data_access/interface.h:15:10: fatal error: pcre2.h: No such file or directory
   15 | #include <pcre2.h>
      |          ^~~~~~~~~
compilation terminated.
In file included from ../agent/mibgroup/if-mib/ifTable/ifTable.h:21,
                 from module_tmp_header.h:180:
../include/net-snmp/data_access/interface.h:15:10: fatal error: pcre2.h: No such file or directory
   15 | #include <pcre2.h>
      |          ^~~~~~~~~
compilation terminated.
In file included from ../agent/mibgroup/if-mib/ifTable/ifTable.h:21,
                 from module_tmp_header.h:180:
../include/net-snmp/data_access/interface.h:15:10: fatal error: pcre2.h: No such file or directory
   15 | #include <pcre2.h>
      |          ^~~~~~~~~
compilation terminated.
In file included from ../agent/mibgroup/if-mib/ifTable/ifTable.h:21,
                 from module_tmp_header.h:180:
../include/net-snmp/data_access/interface.h:15:10: fatal error: pcre2.h: No such file or directory
   15 | #include <pcre2.h>
      |          ^~~~~~~~~
compilation terminated.
 if-mib/ifTable/ifTable
fgrep: warning: fgrep is obsolescent; using ggrep -F
fgrep: warning: fgrep is obsolescent; using ggrep -F
   usm 
configure: WARNING: Can't check sysctl, manually define NETSNMP_CAN_USE_SYSCTL if platform support available
configure: WARNING: unrecognized options: --without-efence, --without-dmalloc

---------------------------------------------------------
            Net-SNMP configuration summary:
---------------------------------------------------------

  SNMP Versions Supported:    1 2c 3
  Building for:               linux
  Net-SNMP Version:           5.9.3
  Network transport support:  Alias Callback UDP Unix UDPIPv4Base UDPBase IPv4Base IPBase SocketBase
  SNMPv3 Security Modules:     usm
  Agent MIB code:            agent/extend agentx default_modules host/hr_device host/hr_disk host/hr_filesys host/hr_network host/hr_partition host/hr_proc host/hr_storage host/hr_system ieee802dot11 if-mib/ifXTable ip-mib/inetNetToMediaTable mibII/at mibII/icmp mibII/ifTable mibII/ip mibII/snmp_mib mibII/sysORTable mibII/system_mib mibII/tcp mibII/udp mibII/vacm_context mibII/vacm_vars tunnel ucd-snmp/extensible ucd-snmp/loadave ucd-snmp/memory ucd-snmp/pass ucd-snmp/pass_persist ucd-snmp/proc ucd-snmp/vmstat util_funcs utilities/execute =>  util_funcs/header_simple_table utilities/execute agentx/master agentx/subagent mibII/snmp_mib mibII/system_mib mibII/sysORTable mibII/vacm_vars mibII/vacm_conf host/hr_device host/hr_device host/hr_device mibII/ifTable host/hr_disk hardware/cpu host/hr_device hardware/memory util_funcs if-mib/ifXTable/ifXTable ip-mib/data_access/arp ip-mib/inetNetToMediaTable/inetNetToMediaTable ip-mib/inetNetToMediaTable/inetNetToMediaTable_interface ip-mib/inetNetToMediaTable/inetNetToMediaTable_data_access mibII/data_access/at_linux mibII/data_access/at_unix mibII/kernel_linux if-mib/ifTable mibII/ifTable mibII/ipAddr mibII/var_route mibII/route_write mibII/at mibII/kernel_linux mibII/ip mibII/ip mibII/updates util_funcs mibII/updates mibII/tcpTable mibII/kernel_linux mibII/udpTable mibII/kernel_linux util_funcs/header_generic mibII/vacm_context mibII/vacm_conf tunnel/tunnel ucd-snmp/pass util_funcs/header_simple_table util_funcs utilities/execute util_funcs/header_simple_table hardware/memory ucd-snmp/pass_common util_funcs utilities/execute ucd-snmp/pass_common util_funcs utilities/execute util_funcs hardware/cpu util_funcs/header_generic util_funcs/header_simple_table
  MYSQL Trap Logging:         unavailable
  Embedded Perl support:      disabled
  SNMP Perl modules:          disabled
  SNMP Python modules:        disabled
  Crypto support from:        use_pkg_config_for_openssl
  Authentication support:     MD5
  Encryption support:         
  Local DNSSEC validation:    disabled

---------------------------------------------------------
```

i concede i am no master when it comes to autoconf, but it certainly looks successful if the macro evaluates to true. it just seems the CFLAGS aren't used for the test.

anyways, after i configure successfully by removing this macro, i then re-insert it and everything builds cleanly. i have tested the program to see if it runs, but i am no master of snmp. i do this for the fans.

so any feedback on possible issues are welcome. this is probably on the lower-end of what i've done for pcre2 porting (snort,  privoxy, now this). 

[snmp_pcre2.patch](https://github.com/net-snmp/net-snmp/files/11523216/snmp_pcre2.patch)



