### PR TITLE
Fixed snmpv3 for multithreaded env via saving usm user in session for snmp_sess_open()

### DIFF
--- a/Makefile.top
+++ b/Makefile.top
@@ -81,8 +81,8 @@ LINKCC	        = @LINKCC@
 # 5.3 was at 10, 5.4 is at 15, ...  This leaves some room for needed
 # changes for past releases if absolutely necessary.
 #
-# Most recent change: 40 for the v5.8.1 release.
-LIBCURRENT  = 40
+# Most recent change: 45 for the PR#586 - snmpv3 for multithread.
+LIBCURRENT  = 45
 LIBAGE      = 0
 LIBREVISION = 0
 

--- a/agent/mibgroup/agentx/master_admin.c
+++ b/agent/mibgroup/agentx/master_admin.c
@@ -93,6 +93,7 @@ open_agentx_session(netsnmp_session * session, netsnmp_pdu *pdu)
     sp->contextName = NULL;
     sp->securityEngineID = NULL;
     sp->securityPrivProto = NULL;
+    sp->sessUser = NULL;
 
     /*
      * This next bit utilises unused SNMPv3 fields

--- a/include/net-snmp/library/snmp_api.h
+++ b/include/net-snmp/library/snmp_api.h
@@ -180,6 +180,7 @@ typedef struct request_list {
 
 #define SNMP_DETAIL_SIZE        512
 
+#define SNMP_FLAGS_SESSION_USER    0x1000
 #define SNMP_FLAGS_UDP_BROADCAST   0x800
 #define SNMP_FLAGS_RESP_CALLBACK   0x400      /* Additional callback on response */
 #define SNMP_FLAGS_USER_CREATED    0x200      /* USM user has been created */

--- a/include/net-snmp/types.h
+++ b/include/net-snmp/types.h
@@ -418,6 +418,11 @@ struct snmp_session {
      * XXX: or should we add a new field into this structure?
      */
     void           *myvoid;
+
+    /**
+     * session specific user
+     */
+    struct usmUser *sessUser;
 };
 
 typedef struct netsnmp_index_s {

--- a/snmplib/snmp_api.c
+++ b/snmplib/snmp_api.c
@@ -1037,6 +1037,8 @@ snmp_open(netsnmp_session *session)
         return NULL;
     }
 
+    slp->session->flags &= ~SNMP_FLAGS_SESSION_USER;
+
     snmp_session_insert(slp);
 
     return (slp->session);
@@ -1074,6 +1076,8 @@ snmp_open_ex(netsnmp_session *session,
     slp->internal->hook_build = fbuild;
     slp->internal->hook_realloc_build = frbuild;
     slp->internal->check_packet = fcheck;
+
+    slp->session->flags &= ~SNMP_FLAGS_SESSION_USER;
 
     snmp_session_insert(slp);
 
@@ -1135,6 +1139,7 @@ _sess_copy(netsnmp_session * in_session)
     session->securityName = NULL;
     session->securityAuthProto = NULL;
     session->securityPrivProto = NULL;
+    session->sessUser = NULL;
     /*
      * session now points to the new structure that still contains pointers to
      * data allocated elsewhere.  Some of this data is copied to space malloc'd
@@ -1304,6 +1309,19 @@ _sess_copy(netsnmp_session * in_session)
             }
         }
     }
+
+#ifndef NETSNMP_NO_WRITE_SUPPORT
+    if (in_session->sessUser) {
+        struct usmUser *user;
+
+        user = calloc(1, sizeof(struct usmUser));
+        if (user == NULL) {
+            snmp_sess_close(slp);
+            return NULL;
+        }
+        session->sessUser = usm_cloneFrom_user(in_session->sessUser, user);
+    }
+#endif /* NETSNMP_NO_WRITE_SUPPORT */
 
     /* Anything below this point should only be done if the transport
        had no say in the matter */
@@ -1887,6 +1905,8 @@ snmp_sess_open(netsnmp_session * pss)
 {
     struct session_list *slp;
 
+    pss->flags |= SNMP_FLAGS_SESSION_USER;
+
     slp = _sess_open(pss);
     if (!slp) {
         SET_SNMP_ERROR(pss->s_snmp_errno);
@@ -1923,6 +1943,7 @@ void netsnmp_cleanup_session(netsnmp_session *s)
 #ifndef NETSNMP_NO_TRAP_STATS
     SNMP_FREE(s->trap_stats);
 #endif /* NETSNMP_NO_TRAP_STATS */
+    usm_free_user(s->sessUser);
 }
 
 /*


### PR DESCRIPTION
This patch will help to use the library in a multi-threaded environment to access snmpv3 nodes. The main idea is to keep the user in the session and avoid calling usm_add_user() which is not thread-safe. The new mode is only available for the snmp_sess_open() function. All other behavior remains unchanged.