### PR TITLE
Declare our OpenSSL interface version.

### DIFF
--- a/configure.d/config_net_snmp_config_h
+++ b/configure.d/config_net_snmp_config_h
@@ -42,6 +42,12 @@ AH_BOTTOM([/* end of definitions added by configure on-the-fly */
 #define HAVE_AES 1
 #endif
 
+#ifdef NETSNMP_USE_OPENSSL
+/* Suppress deprecation warnings from OpenSSL 3.0+ */
+/* Our interface match OpenSSL 1.0.0 */
+#define OPENSSL_API_COMPAT 0x10000000L
+#endif
+
 /* define signal if DNE */
 
 #ifndef HAVE_SIGNAL

--- a/include/net-snmp/net-snmp-config.h.in
+++ b/include/net-snmp/net-snmp-config.h.in
@@ -1974,6 +1974,12 @@
 #define HAVE_AES 1
 #endif
 
+#ifdef NETSNMP_USE_OPENSSL
+/* Suppress deprecation warnings from OpenSSL 3.0+ */
+/* Our interface match OpenSSL 1.0.0 */
+#define OPENSSL_API_COMPAT 0x10000000L
+#endif
+
 /* define signal if DNE */
 
 #ifndef HAVE_SIGNAL


### PR DESCRIPTION
This avoids warnings when compiling with OpenSSL 3.0+.