### PR TITLE
Add include/net-snmp/library/openssl_config.h to declare OpenSSL API …

### DIFF
--- a/agent/mibgroup/snmp-usm-dh-objects-mib/usmDHParameters/usmDHParameters.c
+++ b/agent/mibgroup/snmp-usm-dh-objects-mib/usmDHParameters/usmDHParameters.c
@@ -4,6 +4,7 @@
  */
 
 #include <net-snmp/net-snmp-config.h>
+#include <net-snmp/library/openssl_config.h>
 #include <net-snmp/net-snmp-includes.h>
 #include <net-snmp/library/snmp_openssl.h>
 #include <net-snmp/agent/net-snmp-agent-includes.h>

--- a/agent/mibgroup/snmp-usm-dh-objects-mib/usmDHUserKeyTable/usmDHUserKeyTable_data_get.c
+++ b/agent/mibgroup/snmp-usm-dh-objects-mib/usmDHUserKeyTable/usmDHUserKeyTable_data_get.c
@@ -8,6 +8,7 @@
  * standard Net-SNMP includes 
  */
 #include <net-snmp/net-snmp-config.h>
+#include <net-snmp/library/openssl_config.h>
 #include <net-snmp/net-snmp-includes.h>
 #include <net-snmp/library/snmp_openssl.h>
 #include <net-snmp/agent/net-snmp-agent-includes.h>

--- a/agent/mibgroup/snmp-usm-dh-objects-mib/usmDHUserKeyTable/usmDHUserKeyTable_data_set.c
+++ b/agent/mibgroup/snmp-usm-dh-objects-mib/usmDHUserKeyTable/usmDHUserKeyTable_data_set.c
@@ -9,6 +9,7 @@
  * standard Net-SNMP includes 
  */
 #include <net-snmp/net-snmp-config.h>
+#include <net-snmp/library/openssl_config.h>
 #include <net-snmp/net-snmp-includes.h>
 #include <net-snmp/agent/net-snmp-agent-includes.h>
 

--- a/apps/snmpusm.c
+++ b/apps/snmpusm.c
@@ -17,6 +17,7 @@
  * distributed with the Net-SNMP package.
  */
 #include <net-snmp/net-snmp-config.h>
+#include <net-snmp/library/openssl_config.h>
 #include <net-snmp/net-snmp-includes.h>
 #include <net-snmp/library/snmp_openssl.h>
 #if defined(HAVE_OPENSSL_DH_H) && defined(HAVE_LIBCRYPTO)

--- a/include/net-snmp/library/openssl_config.h
+++ b/include/net-snmp/library/openssl_config.h
@@ -1,0 +1,12 @@
+/*
+ * Declare our OpenSSL API usage, to avoid deprecation warnings.
+ * This must be included before any OpenSSL header files.
+ */
+
+#ifndef NETSNMP_OPENSSL_COMPAT_H
+#define NETSNMP_OPENSSL_COMPAT_H
+
+/* Our interface matches OpenSSL 1.0.0 */
+#define OPENSSL_API_COMPAT 0x10000000L
+
+#endif /* NETSNMP_OPENSSL_COMPAT_H */

--- a/snmplib/scapi.c
+++ b/snmplib/scapi.c
@@ -65,6 +65,7 @@ netsnmp_feature_child_of(usm_scapi, usm_support);
 #ifdef NETSNMP_USE_INTERNAL_MD5
 #include <net-snmp/library/md5.h>
 #endif
+#include <net-snmp/library/openssl_config.h>
 #include <net-snmp/library/snmp_api.h>
 #include <net-snmp/library/callback.h>
 #include <net-snmp/library/snmp_secmod.h>

--- a/snmplib/snmp_openssl.c
+++ b/snmplib/snmp_openssl.c
@@ -21,6 +21,7 @@
 #if defined(NETSNMP_USE_OPENSSL)
 
 #include <string.h>
+#include <net-snmp/library/openssl_config.h>
 #include <openssl/dh.h>
 
 #ifndef HAVE_DH_GET0_PQG

--- a/snmplib/snmpusm.c
+++ b/snmplib/snmpusm.c
@@ -62,6 +62,7 @@
 #include <net-snmp/config_api.h>
 #include <net-snmp/utilities.h>
 
+#include <net-snmp/library/openssl_config.h>
 #include <net-snmp/library/asn1.h>
 #include <net-snmp/library/snmp_api.h>
 #include <net-snmp/library/callback.h>


### PR DESCRIPTION
…version.

This fixes warnings from OpenSSL 3.0+.