### PR TITLE
Fix build failure

### DIFF
--- a/agent/snmpd.c
+++ b/agent/snmpd.c
@@ -169,6 +169,8 @@ netsnmp_feature_want(logging_file);
 netsnmp_feature_want(logging_stdio);
 netsnmp_feature_want(logging_syslog);
 
+#include <net-snmp/library/snmpusm.h>
+
 /*
  * Globals.
  */

--- a/include/net-snmp/library/snmpusm.h
+++ b/include/net-snmp/library/snmpusm.h
@@ -125,6 +125,9 @@ extern          "C" {
     NETSNMP_IMPORT
     oid            *usm_generate_OID(const oid *prefix, size_t prefixLen,
                                    const struct usmUser *uptr, size_t *length);
+
+    NETSNMP_IMPORT
+    void            clear_user_list(void);
     void            init_usm(void);
     NETSNMP_IMPORT
     void            init_usm_conf(const char *app);

--- a/snmplib/snmpusm.c
+++ b/snmplib/snmpusm.c
@@ -3966,7 +3966,7 @@ usm_lookup_priv_str(int value)
     return usm_lookup_alg_str(value, usm_priv_type );
 }
 
-static void
+void
 clear_user_list(void)
 {
     struct usmUser *tmp = userList, *next = NULL;


### PR DESCRIPTION
Handle SIGHUP cases for:

Deleted user continue to work when snmpd recived SIGHUP. User cache is not cleared.
Modified engine-id doesnt work with SIGHUP, SNMP operations continue to work with old engine-id