### PR TITLE
Add support for RPM SQLite DB background.

### DIFF
--- a/agent/mibgroup/host/data_access/swinst_rpm.c
+++ b/agent/mibgroup/host/data_access/swinst_rpm.c
@@ -73,15 +73,23 @@ netsnmp_swinst_arch_init(void)
 #endif
 
     snprintf( pkg_directory, SNMP_MAXPATH, "%s/Packages", dbpath );
+    
+    if (-1 == stat( pkg_directory, &stat_buf )) {
+
+        /* check for SQLite DB backend */
+        snprintf( pkg_directory, SNMP_MAXPATH, "%s/rpmdb.sqlite", dbpath );
+        
+        if (-1 == stat( pkg_directory, &stat_buf )) {
+            snmp_log(LOG_ERR, "Can't find directory of RPM packages\n");
+            pkg_directory[0] = '\0';
+        }
+    }
+
     SNMP_FREE(rpmdbpath);
     dbpath = NULL;
 #ifdef HAVE_RPMGETPATH
     rpmFreeRpmrc();
-#endif
-    if (-1 == stat( pkg_directory, &stat_buf )) {
-        snmp_log(LOG_ERR, "Can't find directory of RPM packages\n");
-        pkg_directory[0] = '\0';
-    }
+#endif    
 }
 
 void

--- a/agent/mibgroup/host/hr_swinst.c
+++ b/agent/mibgroup/host/hr_swinst.c
@@ -229,6 +229,9 @@ init_hr_swinst(void)
         snprintf(path, sizeof(path), "%s/Packages", swi->swi_dbpath);
         if (stat(path, &stat_buf) == -1)
             snprintf(path, sizeof(path), "%s/packages.rpm", swi->swi_dbpath);
+        /* check for SQLite DB backend */
+        if (stat(path, &stat_buf) == -1)
+            snprintf(path, sizeof(path), "%s/rpmdb.sqlite", swi->swi_dbpath);
         path[ sizeof(path)-1 ] = 0;
         swi->swi_directory = strdup(path);
     }


### PR DESCRIPTION
From RPM 4.16 the SQLite support is available for RPM DB. After https://fedoraproject.org/wiki/Changes/Sqlite_Rpmdb, rpm changed it's background DB from Berkeley to SQLite in Fedora. Net-SNMP is using hard coded paths to determine where RPM DB files are.

This update is adding check for rpmdb.sqlite file in order to be able invalidate internal cache after system package change.

Closes #596