### PR TITLE
Handle SIGHUP for engine-id change

### DIFF
--- a/agent/snmpd.c
+++ b/agent/snmpd.c
@@ -1168,6 +1168,7 @@ snmpd_reconfig(void)
     netsnmp_logging_restart();
     snmp_log(LOG_INFO, "NET-SNMP version %s restarted\n",
              netsnmp_get_version());
+    read_premib_configs();
     update_config();
     send_easy_trap(SNMP_TRAP_ENTERPRISESPECIFIC, 3);
 #ifdef HAVE_SIGPROCMASK


### PR DESCRIPTION
SNMP operations continue to work with old engine-id with SIGHUP.