### PR TITLE
mteTrigger.c: Fix copy-paste bug (Coverity 85524)

### DIFF
--- a/agent/mibgroup/disman/event/mteTrigger.c
+++ b/agent/mibgroup/disman/event/mteTrigger.c
@@ -1105,7 +1105,7 @@ mteTrigger_run( unsigned int reg, void *clientarg)
                      * Similarly, if no fallEvent is configured,
                      *  there's no point in trying to fire it either.
                      */
-                    if (entry->mteTThDRiseEvent[0] != '\0' ) {
+                    if (entry->mteTThDFallEvent[0] != '\0' ) {
                         entry->mteTriggerXOwner   = entry->mteTThObjOwner;
                         entry->mteTriggerXObjects = entry->mteTThObjects;
                         entry->mteTriggerFired    = vp1;


### PR DESCRIPTION
mteTrigger.c: Fix copy-paste bug (Coverity 85524)

Examine the proper variable when determining whether or not fire a fall event.