### PR TITLE
pingResultsTable.c: Fix memory leaks (Coverity 85662)

### DIFF
--- a/agent/mibgroup/disman/ping/pingResultsTable.c
+++ b/agent/mibgroup/disman/ping/pingResultsTable.c
@@ -145,6 +145,7 @@ parse_pingResultsTable(const char *token, char *line)
                               &StorageTmp->pingCtlOwnerIndexLen);
     if (StorageTmp->pingCtlOwnerIndex == NULL) {
         config_perror("invalid specification for pingCtlOwnerIndex");
+        free(StorageTmp);
         return;
     }
 
@@ -154,6 +155,7 @@ parse_pingResultsTable(const char *token, char *line)
                               &StorageTmp->pingCtlTestNameLen);
     if (StorageTmp->pingCtlTestName == NULL) {
         config_perror("invalid specification for pingCtlTestName");
+        free(StorageTmp);
         return;
     }
 
@@ -171,6 +173,7 @@ parse_pingResultsTable(const char *token, char *line)
     if (StorageTmp->pingResultsIpTargetAddress == NULL) {
         config_perror
             ("invalid specification for pingResultsIpTargetAddress");
+        free(StorageTmp);
         return;
     }
 
@@ -201,6 +204,7 @@ parse_pingResultsTable(const char *token, char *line)
     if (StorageTmp->pingResultsLastGoodProbe == NULL) {
         config_perror
             ("invalid specification for pingResultsLastGoodProbe!");
+        free(StorageTmp);
         return;
     }
 


### PR DESCRIPTION
pingResultsTable.c: Fix memory leaks (Coverity 85662)

Free memory allocation referenced in StorageTmp that is not free()'d in the event of a failure