### PR TITLE
snmpNotifyFilterProfileTable_data.c: Fix memory leaks (Coverity 85636)

### DIFF
--- a/agent/mibgroup/notification/snmpNotifyFilterProfileTable_data.c
+++ b/agent/mibgroup/notification/snmpNotifyFilterProfileTable_data.c
@@ -318,6 +318,7 @@ parse_snmpNotifyFilterProfileTable(const char *token, char *line)
                               &StorageTmp->snmpTargetParamsNameLen);
     if (StorageTmp->snmpTargetParamsName == NULL) {
         config_perror("invalid specification for snmpTargetParamsName");
+        free(StorageTmp);
         return;
     }
 


### PR DESCRIPTION
snmpNotifyFilterProfileTable_data.c: Fix memory leaks (Coverity 85636)

Free memory allocation referenced in StorageTmp that is not free()'d in the event of a failure