### PR TITLE
icmp.c: Fix memory leaks (Coverity 85667)

### DIFF
--- a/agent/mibgroup/mibII/icmp.c
+++ b/agent/mibgroup/mibII/icmp.c
@@ -751,6 +751,8 @@ bail:
         netsnmp_handler_registration_free(msg_stats_reginfo);
     if (table_reginfo)
         netsnmp_handler_registration_free(table_reginfo);
+    if (msg_stats_table_info)
+        free(msg_stats_table_info);
 #endif
     if (scalar_reginfo)
         netsnmp_handler_registration_free(scalar_reginfo);


### PR DESCRIPTION
icmp.c: Fix memory leaks (Coverity 85667)

Free memory allocation referenced in msg_stats_table_info that is not free()'d in the event of a failure