### PR TITLE
nsDebug.c: Fix memory leak (Coverity 85684)

### DIFF
--- a/agent/mibgroup/agent/nsDebug.c
+++ b/agent/mibgroup/agent/nsDebug.c
@@ -82,6 +82,7 @@ init_nsDebug(void)
      */
     iinfo      = SNMP_MALLOC_TYPEDEF(netsnmp_iterator_info);
     if (!iinfo) {
+        free(table_info);
         return;
     }
     iinfo->get_first_data_point = get_first_debug_entry;


### PR DESCRIPTION
nsDebug.c: Fix memory leak (Coverity 85684)

Free memory allocation referenced in table_info that is not free()'d in the event of a failure