### PR TITLE
table_dataset.c: Fix memory leak (Coverity 144371)

### DIFF
--- a/agent/helpers/table_dataset.c
+++ b/agent/helpers/table_dataset.c
@@ -480,6 +480,7 @@ netsnmp_register_table_data_set(netsnmp_handler_registration *reginfo,
         snmp_log(LOG_ERR, "could not create table data set handler\n");
         netsnmp_handler_free(handler);
         netsnmp_handler_registration_free(reginfo);
+        free(table_info);
         return MIB_REGISTRATION_FAILED;
     }
 


### PR DESCRIPTION
Free memory allocation referenced in table_info that is not free()'d in the event of a failure