### PR TITLE
deliverByNotify.c: Fix memory leak (Coverity 144379)

### DIFF
--- a/agent/mibgroup/deliver/deliverByNotify.c
+++ b/agent/mibgroup/deliver/deliverByNotify.c
@@ -298,6 +298,7 @@ deliver_execute(unsigned int clientreg, void *clientarg) {
             /* XXX: disable? and reset the next query time point! */
             snmp_log(LOG_ERR, "deliverByNotify: failed to issue the query");
             ITERATOR_RELEASE(iterator);
+            free(vars);
             return;
         }
 


### PR DESCRIPTION
Avoid leaking memory referenced in vars if it fails to issue the query.