### PR TITLE
route_linux.c: Fix memory leak (Coverity 344582)

### DIFF
--- a/agent/mibgroup/ip-forward-mib/data_access/route_linux.c
+++ b/agent/mibgroup/ip-forward-mib/data_access/route_linux.c
@@ -254,6 +254,7 @@ _load_ipv6(netsnmp_container* container, u_long *index )
             snmp_log(LOG_ERR,
                      "/proc/net/ipv6_route data format error (%d!=8), "
                      "line ==|%s|", rc, line);
+            free(entry);
             continue;
         }
 


### PR DESCRIPTION
route_linux.c: Fix memory leak (Coverity 344582)

Avoid leaking memory referenced in entry if the IPv6 data is formatted incorrectly.