### PR TITLE
netSnmpHostsTable.c: Fix memory leak (Coverity 344583)

### DIFF
--- a/agent/mibgroup/examples/netSnmpHostsTable.c
+++ b/agent/mibgroup/examples/netSnmpHostsTable.c
@@ -65,8 +65,9 @@ initialize_table_netSnmpHostsTable(void)
     if (!my_handler || !table_info || !iinfo) {
         snmp_log(LOG_ERR,
                  "malloc failed in initialize_table_netSnmpHostsTable");
-        free(iinfo);
+        free(my_handler);
         free(table_info);
+        free(iinfo);
         return; /** Serious error. */
     }
 


### PR DESCRIPTION
netSnmpHostsTable.c: Fix memory leak (Coverity 344583)

Free memory allocation referenced in my_handler that is not free()'d in the event of a failure.