### PR TITLE
icmp.c: Avoid uninitialized variable error

### DIFF
--- a/agent/mibgroup/mibII/icmp.c
+++ b/agent/mibgroup/mibII/icmp.c
@@ -638,7 +638,7 @@ init_icmp(void)
     netsnmp_iterator_info *iinfo;
     netsnmp_iterator_info *msg_stats_iinfo;
     netsnmp_table_registration_info *table_info = NULL;
-    netsnmp_table_registration_info *msg_stats_table_info;
+    netsnmp_table_registration_info *msg_stats_table_info = NULL;
 #endif
     netsnmp_handler_registration *scalar_reginfo = NULL;
     int                    rc;


### PR DESCRIPTION
Set the variable msg_stats_table_info to a default value of NULL, to avoid potentially accessing the pointer when it's uninitialized