### PR TITLE
snmpUnixDomain.c: Free memory if recvfrom fails

### DIFF
--- a/snmplib/transports/snmpUnixDomain.c
+++ b/snmplib/transports/snmpUnixDomain.c
@@ -150,6 +150,7 @@ netsnmp_unix_recv(netsnmp_transport *t, void *buf, int size,
             if (rc < 0 && errno != EINTR) {
                 DEBUGMSGTL(("netsnmp_unix", "recv fd %d err %d (\"%s\")\n",
                             t->sock, errno, strerror(errno)));
+                free(to);
                 return rc;
             }
             *opaque = (void*)to;


### PR DESCRIPTION
Free memory if recvfrom() fails.
Found with clang scan-build