### PR TITLE
snmpv3.c: Confirm snmpv3_generate_engineID() was successful

### DIFF
--- a/snmplib/snmpv3.c
+++ b/snmplib/snmpv3.c
@@ -1062,9 +1062,9 @@ init_snmpv3_post_config(int majorid, int minorid, void *serverarg,
 
     c_engineID = snmpv3_generate_engineID(&engineIDLen);
 
-    if (engineIDLen == 0 || !c_engineID) {
+    if (!c_engineID || engineIDLen == 0) {
         /*
-         * Somethine went wrong - help! 
+         * Something went wrong - help! 
          */
         SNMP_FREE(c_engineID);
         return SNMPERR_GENERR;


### PR DESCRIPTION
Confirm snmpv3_generate_engineID() was successful before using data from it

If snmpv3_generate_engineID() fails, it returns NULL, possibly without modifying the passed-in engineIDLen parameter. This change examines the return value from snmpv3_generate_engineID() before examining the possibly-uninitialized engineIDLen.


Found with clang scan-build