### PR TITLE
lookupCtlTable.c: Fix memory leak (Coverity 85698-2)

### DIFF
--- a/agent/mibgroup/disman/nslookup/lookupCtlTable.c
+++ b/agent/mibgroup/disman/nslookup/lookupCtlTable.c
@@ -551,6 +551,7 @@ run_lookup(struct lookupTable_data *item)
                         "Can't get a network host entry for ipv4 address: %s\n",
                         address));
             modify_lookupCtlRc(item, h_errno);
+            free(address);
             return;
         } else {
             modify_lookupCtlRc(item, 0L);


### PR DESCRIPTION
lookupCtlTable.c: Fix memory leak (Coverity 85698-2) Avoid leaking memory referenced in address if IPv4 DNS lookup fails.