### PR TITLE
lookupCtlTable.c: Fix memory leak (Coverity 85732)

### DIFF
--- a/agent/mibgroup/disman/nslookup/lookupCtlTable.c
+++ b/agent/mibgroup/disman/nslookup/lookupCtlTable.c
@@ -260,6 +260,7 @@ parse_lookupCtlTable(const char *token, char *line)
                               &StorageTmp->lookupCtlOwnerIndexLen);
     if (StorageTmp->lookupCtlOwnerIndex == NULL) {
         config_perror("invalid specification for lookupCtlOwnerIndex");
+        free(StorageTmp);
         return;
     }
 
@@ -269,6 +270,7 @@ parse_lookupCtlTable(const char *token, char *line)
                               &StorageTmp->lookupCtlOperationNameLen);
     if (StorageTmp->lookupCtlOperationName == NULL) {
         config_perror("invalid specification for lookupCtlOperationName");
+        free(StorageTmp);
         return;
     }
 
@@ -283,6 +285,7 @@ parse_lookupCtlTable(const char *token, char *line)
                               &StorageTmp->lookupCtlTargetAddressLen);
     if (StorageTmp->lookupCtlTargetAddress == NULL) {
         config_perror("invalid specification for lookupCtlTargetAddress");
+        free(StorageTmp);
         return;
     }
 


### PR DESCRIPTION
Avoid leaking memory referenced in StorageTmp if invalid data is passed in.