### PR TITLE
subagent.c: Fix memory leak (Coverity 357928)

### DIFF
--- a/agent/mibgroup/agentx/subagent.c
+++ b/agent/mibgroup/agentx/subagent.c
@@ -504,8 +504,10 @@ handle_agentx_packet(int operation, netsnmp_session * session, int reqid,
      */
 
     internal_pdu = snmp_clone_pdu(pdu);
-    if (!internal_pdu)
+    if (!internal_pdu) {
+        free(smagic);
         return 1;
+    }
     free(internal_pdu->contextName);
     internal_pdu->contextName = (char *) internal_pdu->community;
     internal_pdu->contextNameLen = internal_pdu->community_len;


### PR DESCRIPTION
Avoid leaking memory referenced in smagic if snmp_clone_pdu fails.