### PR TITLE
read_config.c: Remove dead store

### DIFF
--- a/snmplib/read_config.c
+++ b/snmplib/read_config.c
@@ -1451,7 +1451,7 @@ read_config_files(int when) {
 void
 read_config_print_usage(const char *lead)
 {
-    struct config_files *ctmp = config_files;
+    struct config_files *ctmp;
     struct config_line *ltmp;
 
     if (lead == NULL)


### PR DESCRIPTION
Remove dead store detected by clang.

read_config.c:1454:26: warning: Value stored to 'ctmp' during its initialization is never read [deadcode.DeadStores]
    struct config_files *ctmp = config_files;