### PR TITLE
snmpNotifyTable_data.c: Fix memory leak (Coverity 266308)

### DIFF
--- a/agent/mibgroup/notification/snmpNotifyTable_data.c
+++ b/agent/mibgroup/notification/snmpNotifyTable_data.c
@@ -471,6 +471,7 @@ notifyTable_register_notifications(int major, int minor,
 
     if (NULL != nptr)
         snmpNotifyTable_remove(nptr);
+    free(nptr);
 
     if (NULL != pptr)
         snmpTargetParamTable_remove(pptr);


### PR DESCRIPTION
snmpNotifyTable_data.c: Fix memory leak (Coverity 266308)

Avoid leaking memory referenced in nptr if netsnmp_memdup_nt fails.