### PR TITLE
snmplib: do not filter internal request

### DIFF
--- a/snmplib/snmp_api.c
+++ b/snmplib/snmp_api.c
@@ -5651,6 +5651,13 @@ _sess_process_packet_parse_pdu(struct session_list *slp, netsnmp_session * sp,
                   *c = 0;
               filtered = netsnmp_transport_filter_check(sourceaddr);
           }
+          else if (!strncmp(addrtxt, "callback", 8)) {
+              /* do not filter internal request */
+              DEBUGMSGTL(("sess_process_packet:filter",
+                          "bypass packet from %s \n",
+                          addrtxt));
+              filtered = 1;
+          }
           if ((filter == -1) && filtered)
               dropstr = "matched blacklist";
           else if ((filter == 1) && !filtered)


### PR DESCRIPTION
sourceFilterType and sourceFilterAddress options in snmpd.conf. However, once activated, internal requests are also blocked. The filtering is based on IP in the string returned by the function "fmtaddr". Internal requests do not have a source IP, instead of an IP address, the function returns a string that starts with "callback" following a file descriptor numero. These internal requests are generated by alarms to define event triggers. If they are blocked, no traps will be sent.

Therefore, do not filter internal requests by checking if the string returned by "fmtaddr" starts with "callback".

Fixes: 9d28612ac03b ("add packet filtering by source ip")