### PR TITLE
Add missing semicolon to function definition

### DIFF
--- a/configure.d/config_modules_agent
+++ b/configure.d/config_modules_agent
@@ -27,7 +27,7 @@ done
 #
 AC_MSG_CHECKING([for and configuring mib modules to use])
 
-AH_TOP([#define NETSNMP_REQUIRE_SEMICOLON extern void netsnmp_unused_function(void)])
+AH_TOP([#define NETSNMP_REQUIRE_SEMICOLON extern void netsnmp_unused_function(void);])
 
 # set up the CPP command
 MODULECPP="$CPP $PARTIALTARGETFLAGS $CPPFLAGS -DNETSNMP_FEATURE_CHECKING -I${srcdir}/include -I${srcdir}/agent/mibgroup"


### PR DESCRIPTION
It was discovered, that missing semicolon causes build failure of s390utils package. From further investigation it shows that function call netsnmp_unused_function(void) should be ended by semicolon.

This issue was introduced via commit a2cb167 and reported in issue #650.