### PR TITLE
Fix regression of memory leak when using RPMDB macros.

### DIFF
--- a/agent/mibgroup/host/hr_swinst.c
+++ b/agent/mibgroup/host/hr_swinst.c
@@ -234,6 +234,9 @@ init_hr_swinst(void)
             snprintf(path, sizeof(path), "%s/rpmdb.sqlite", swi->swi_dbpath);
         path[ sizeof(path)-1 ] = 0;
         swi->swi_directory = strdup(path);
+#ifdef HAVE_RPMGETPATH
+        rpmFreeRpmrc();
+#endif
     }
 #else
 #  ifdef _PATH_HRSW_directory


### PR DESCRIPTION
This change is fixing memory leak when using RPMDB macros. The fix was introduced in PR #49 but was overwritten over time. Fix is needed in agent/mibgroup/host/hr_swinst.c only as the regression in the agent/mibgroup/host/data_access/swinst_rpm.c was fixed few weeks ago.

This is proposed solution for issue #652