### PR TITLE
snmpget.c: Avoid leak if parsing OID fails

### DIFF
--- a/apps/snmpget.c
+++ b/apps/snmpget.c
@@ -180,8 +180,10 @@ main(int argc, char *argv[])
         } else
             snmp_add_null_var(pdu, name, name_length);
     }
-    if (failures)
+    if (failures) {
+        snmp_free_pdu(pdu);
         goto close_session;
+    }
 
     exitval = 0;
 


### PR DESCRIPTION
snmpget.c: Avoid leak if parsing OID fails. This leak would not normally cause any problems, but might make investigating other leaks more difficult