### PR TITLE
parse_octet_hint_fuzzer.c: Use size_t for value_start

### DIFF
--- a/testing/fuzzing/parse_octet_hint_fuzzer.c
+++ b/testing/fuzzing/parse_octet_hint_fuzzer.c
@@ -50,7 +50,8 @@ int LLVMFuzzerInitialize(int *argc, char ***argv) {
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     char *hint, *value;
-    int value_start, new_val_len;
+    size_t value_start;
+    int new_val_len;
     unsigned char *new_val;
 
     hint = strndup((const char *)data, size);


### PR DESCRIPTION
Fixes compiler warning:

Compiling testing/fuzzing/parse_octet_hint_fuzzer.c testing/fuzzing/parse_octet_hint_fuzzer.c:58:24: error: comparison of integers of different signs: 'int' and 'size_t' (aka 'unsigned long') [-Werror,-Wsign-compare]
    assert(value_start <= size);

Everything else is a size_t, no reason to not have value_start as a size_t too