### PR TITLE
snmpv3.c: Avoid leaking memory if -E or -e is repeated

### DIFF
--- a/snmplib/snmpv3.c
+++ b/snmplib/snmpv3.c
@@ -203,6 +203,7 @@ snmpv3_parse_arg(int arg, char *optarg, netsnmp_session *session, char **Apsz,
                 free(ebuf);
                 return (-1);
             }
+	    free(session->securityEngineID);
             session->securityEngineID = ebuf;
             session->securityEngineIDLen = eout_len;
             break;
@@ -227,6 +228,7 @@ snmpv3_parse_arg(int arg, char *optarg, netsnmp_session *session, char **Apsz,
                 free(ebuf);
                 return (-1);
             }
+	    free(session->contextEngineID);
             session->contextEngineID = ebuf;
             session->contextEngineIDLen = eout_len;
             break;


### PR DESCRIPTION
snmpv3.c: Avoid leaking memory if -E or -e is repeated

Fixes #703