### PR TITLE
Adding server cipher order by default

### DIFF
--- a/snmplib/transports/snmpTLSBaseDomain.c
+++ b/snmplib/transports/snmpTLSBaseDomain.c
@@ -750,6 +750,8 @@ sslctx_server_setup(const SSL_METHOD *method) {
                        SSL_VERIFY_CLIENT_ONCE,
                        &verify_callback);
 
+    SSL_CTX_set_options(the_ctx, SSL_OP_CIPHER_SERVER_PREFERENCE);
+
     return _sslctx_common_setup(the_ctx, NULL);
     
 err:


### PR DESCRIPTION
According to testssl tool (https://testssl.sh/), it is not ok when Server has not set a cipher order, see image below

![image](https://github.com/net-snmp/net-snmp/assets/84147506/1ec33931-dd83-4be2-bb3f-c12f6221d0e3)
