### PR TITLE
Fix configuration of NETSNMP_FD_MASK_TYPE

### DIFF
--- a/configure
+++ b/configure
@@ -30871,7 +30871,7 @@ CFLAGS="$CFLAGS -Werror"
 
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for the type of fd_set::fds_bits" >&5
 printf %s "checking for the type of fd_set::fds_bits... " >&6; }
-for type in __fd_mask __int32_t unknown; do
+for type in __fd_mask __int32_t long\ int unknown; do
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 

--- a/configure.d/config_project_types
+++ b/configure.d/config_project_types
@@ -66,7 +66,7 @@ netsnmp_save_CFLAGS=$CFLAGS
 CFLAGS="$CFLAGS -Werror"
 
 AC_MSG_CHECKING([for the type of fd_set::fds_bits])
-for type in __fd_mask __int32_t unknown; do
+for type in __fd_mask __int32_t long\ int unknown; do
   AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
 #include <sys/select.h>
 #include <stddef.h>


### PR DESCRIPTION
In Alpine Linux there is a compilation error due to an unknown type.
