### PR TITLE
snmptrap.c: Properly clean up session values

### DIFF
--- a/apps/snmptrap.c
+++ b/apps/snmptrap.c
@@ -378,7 +378,6 @@ main(int argc, char *argv[])
 
 close_session:
     snmp_close(ss);
-    memset(&session, 0, sizeof(session));
     snmp_shutdown(NETSNMP_APPLICATION_CONFIG_TYPE);
 
 out:


### PR DESCRIPTION
snmptrap.c: Properly clean up session values
Avoid zero-ing session structure so that its members can be free()'d.