### PR TITLE
T011snmp_old_api_registration_cagentlib.c: Avoid leaking session object

### DIFF
--- a/testing/fulltests/unit-tests/T011snmp_old_api_registration_cagentlib.c
+++ b/testing/fulltests/unit-tests/T011snmp_old_api_registration_cagentlib.c
@@ -44,3 +44,4 @@ netsnmp_register_old_api("exp.327.b",
 OK(res == MIB_DUPLICATE_REGISTRATION, "Handler registration (2).");
 
 snmp_shutdown("snmp");
+free(sess);


### PR DESCRIPTION
Avoid leaking session object, so another test passes with leak sanitizer enabled