### PR TITLE
GH Workflows: Create CI job for Coverity scan

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,0 +1,26 @@
+# Creates a Coverity build on a schedule
+# Uses https://github.com/vapier/coverity-scan-action
+# for Coverity integration
+
+name: Coverity Scan
+
+on:
+  schedule:
+    # Run daily
+    - cron: '0 0 * * *'
+  # Support manual execution
+  workflow_dispatch:
+jobs:
+  coverity:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@main
+    - name: install required packages
+      run: sudo bash -c "MODE=regular ci/install.sh"
+    - name: configure
+      run: ci/net-snmp-configure master
+    - uses: vapier/coverity-scan-action@v1
+      with:
+        command: make
+        email: ${{ secrets.COVERITY_SCAN_EMAIL }}
+        token: ${{ secrets.COVERITY_SCAN_TOKEN }}


### PR DESCRIPTION
I've noticed that https://scan.coverity.com/projects/net-snmp already exists, but appears to be only updated on an ad-hoc basis.

This PR adds a GitHub Action-based CI job to create a new Coverity build daily, so that there is always a recent scan available.

Note: Even a daily scan is within the limit, as Net-SNMP is ~750K LOC and per https://scan.coverity.com/faq :
>Up to 14 builds per week, with a maximum of 2 build per day, for projects with 500K to 1 million lines of code

Before this is merged in, two new secrets will need to be created:
* COVERITY_SCAN_EMAIL with the email address used for accessing Coverity
* COVERITY_SCAN_TOKEN with the Project token from https://scan.coverity.com/projects/net-snmp?tab=project_settings