### PR TITLE
ucdDemoPublic.c: Fix memory leak (Coverity 85639)

### DIFF
--- a/agent/mibgroup/examples/ucdDemoPublic.c
+++ b/agent/mibgroup/examples/ucdDemoPublic.c
@@ -188,6 +188,7 @@ write_ucdDemoResetKeys(int action,
                                           demopass);
                 }
             }
+            free(engineID);
             /*
              * reset the keys 
              */


### PR DESCRIPTION
ucdDemoPublic.c: Fix memory leak (Coverity 85639)
Avoid leaking engineID