### PR TITLE
agent_global_vars.h: Remove redundant forward declaration

### DIFF
--- a/agent/agent_global_vars.h
+++ b/agent/agent_global_vars.h
@@ -11,7 +11,6 @@
 
 struct snmp_session;
 struct netsnmp_agent_session_s;
-struct netsnmp_agent_session_s;
 
 /* Global variable declarations. */
 


### PR DESCRIPTION
Detected with SonarCloud