### PR TITLE
snmp_transport.c: Remove redundant if statement

### DIFF
--- a/snmplib/snmp_transport.c
+++ b/snmplib/snmp_transport.c
@@ -452,9 +452,7 @@ netsnmp_transport_recv(netsnmp_transport *t, void *packet, int length,
         char *str = netsnmp_transport_peer_string(t,
                                                   opaque ? *opaque : NULL,
                                                   olength ? *olength : 0);
-        if (debugLength)
-            DEBUGMSGT_NC(("transport:recv","%d bytes from %s\n",
-                          length, str));
+        DEBUGMSGT_NC(("transport:recv","%d bytes from %s\n", length, str));
         SNMP_FREE(str);
     }
 


### PR DESCRIPTION
Found with cppcheck