### PR TITLE
coverity.yml: Only run in main repository

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -10,6 +10,7 @@ on:
   workflow_dispatch:
 jobs:
   coverity:
+    if: github.repository == 'net-snmp/net-snmp'
     runs-on: ubuntu-latest
     steps:
     - name: Check github variables


### PR DESCRIPTION
This prevents the Coverity scheduled job from automatically running in forked repos

`github.repository` is documented here: https://docs.github.com/en/actions/learn-github-actions/contexts#github-context

YAML entry is similar to here: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-only-run-job-for-specific-repository