### PR TITLE
Give memory back to system post snmp operation

### DIFF
--- a/snmplib/container.c
+++ b/snmplib/container.c
@@ -509,6 +509,7 @@ void CONTAINER_CLEAR(netsnmp_container *x, netsnmp_container_obj_func *f,
         x = x->prev;
     }
     x->clear(x, f, c);
+    malloc_trim(0);
 }
 
 #ifndef NETSNMP_FEATURE_REMOVE_CONTAINER_FREE_ALL


### PR DESCRIPTION
On low-end devices, there is no point to hold the memory with sub-agent. 
This memory can be used by other process.