### PR TITLE
Update V5-90-patches with my fixes for modern OpenSSL

### DIFF
--- a/snmplib/cert_util.c
+++ b/snmplib/cert_util.c
@@ -1040,7 +1040,7 @@ netsnmp_ocert_get(netsnmp_cert *cert)
     }
     
     if (NULL == cert->fingerprint) {
-        cert->hash_type = netsnmp_openssl_cert_get_hash_type(ocert);
+        cert->hash_type = NS_HASH_SHA1;
         cert->fingerprint =
             netsnmp_openssl_cert_get_fingerprint(ocert, cert->hash_type);
     }
@@ -2061,7 +2061,7 @@ netsnmp_cert_trust(SSL_CTX *ctx, netsnmp_cert *thiscert)
                                 SNMPERR_GENERR);
 
     /* Put the certificate into the store */
-    fingerprint = netsnmp_openssl_cert_get_fingerprint(cert, -1);
+    fingerprint = netsnmp_openssl_cert_get_fingerprint(cert, NS_HASH_SHA1);
     DEBUGMSGTL(("cert:trust",
                 "putting trusted cert %p = %s in certstore %p\n", cert,
                 fingerprint, certstore));
@@ -2769,7 +2769,7 @@ netsnmp_certToTSN_parse_common(char **line)
         map->fingerprint = strdup(buf);
     } else {
         map->fingerprint =
-            netsnmp_openssl_cert_get_fingerprint(tmpcert->ocert, -1);
+            netsnmp_openssl_cert_get_fingerprint(tmpcert->ocert, NS_HASH_SHA1);
     }
     
     if (NULL == *line) {

--- a/snmplib/snmp_openssl.c
+++ b/snmplib/snmp_openssl.c
@@ -12,6 +12,7 @@
  */
 
 #include <net-snmp/net-snmp-config.h>
+#include <net-snmp/library/openssl_config.h>
 
 #include <net-snmp/net-snmp-includes.h>
 
@@ -21,7 +22,6 @@
 #if defined(NETSNMP_USE_OPENSSL)
 
 #include <string.h>
-#include <net-snmp/library/openssl_config.h>
 #include <openssl/dh.h>
 
 #ifndef HAVE_DH_GET0_PQG
@@ -711,7 +711,7 @@ netsnmp_openssl_get_cert_chain(SSL *ssl)
     /*
      * get fingerprint and save it
      */
-    fingerprint = netsnmp_openssl_cert_get_fingerprint(ocert, -1);
+    fingerprint = netsnmp_openssl_cert_get_fingerprint(ocert, NS_HASH_SHA1);
     if (NULL == fingerprint)
         return NULL;
 
@@ -749,7 +749,7 @@ netsnmp_openssl_get_cert_chain(SSL *ssl)
         sk_num_res = sk_num((const void *)ochain);
         for(i = 0; i < sk_num_res; ++i) {
             ocert_tmp = (X509*)sk_value((const void *)ochain,i);
-            fingerprint = netsnmp_openssl_cert_get_fingerprint(ocert_tmp, -1);
+            fingerprint = netsnmp_openssl_cert_get_fingerprint(ocert_tmp, NS_HASH_SHA1);
             if (NULL == fingerprint)
                 break;
             cert_map = netsnmp_cert_map_alloc(NULL, ocert);

--- a/snmplib/transports/snmpTLSBaseDomain.c
+++ b/snmplib/transports/snmpTLSBaseDomain.c
@@ -81,7 +81,7 @@ int verify_callback(int ok, X509_STORE_CTX *ctx) {
     /* things to do: */
 
     X509_NAME_oneline(X509_get_subject_name(thecert), buf, sizeof(buf));
-    fingerprint = netsnmp_openssl_cert_get_fingerprint(thecert, -1);
+    fingerprint = netsnmp_openssl_cert_get_fingerprint(thecert, NS_HASH_SHA1);
     DEBUGMSGTL(("tls_x509:verify", "Cert: %s\n", buf));
     DEBUGMSGTL(("tls_x509:verify", "  fp: %s\n", fingerprint ?
                 fingerprint : "unknown"));
@@ -160,7 +160,7 @@ _netsnmp_tlsbase_verify_remote_fingerprint(X509 *remote_cert,
     char            *fingerprint;
 
     fingerprint =
-        netsnmp_openssl_cert_get_fingerprint(remote_cert, -1);
+        netsnmp_openssl_cert_get_fingerprint(remote_cert, NS_HASH_SHA1);
 
     if (!fingerprint) {
         /* no peer cert */
@@ -177,7 +177,7 @@ _netsnmp_tlsbase_verify_remote_fingerprint(X509 *remote_cert,
 
         if (peer_cert)
             tlsdata->their_fingerprint =
-                netsnmp_openssl_cert_get_fingerprint(peer_cert->ocert, -1);
+                netsnmp_openssl_cert_get_fingerprint(peer_cert->ocert, NS_HASH_SHA1);
     }
 
     if (!tlsdata->their_fingerprint && try_default) {
@@ -189,7 +189,7 @@ _netsnmp_tlsbase_verify_remote_fingerprint(X509 *remote_cert,
 
         if (peer_cert)
             tlsdata->their_fingerprint =
-                netsnmp_openssl_cert_get_fingerprint(peer_cert->ocert, -1);
+                netsnmp_openssl_cert_get_fingerprint(peer_cert->ocert, NS_HASH_SHA1);
     }
     
     if (tlsdata->their_fingerprint) {

--- a/snmplib/transports/snmpTLSTCPDomain.c
+++ b/snmplib/transports/snmpTLSTCPDomain.c
@@ -719,7 +719,7 @@ netsnmp_tlstcp_open_client(netsnmp_transport *t)
     }
 
 #ifdef SSL_CTX_set_max_proto_version
-    SSL_CTX_set_max_proto_version(tlsdata->ssl_context, TLS1_VERSION);
+    SSL_CTX_set_max_proto_version(tlsdata->ssl_context, 0);
 #endif
 
     /* RFC5953 Section 5.3.1:  Establishing a Session as a Client
@@ -919,7 +919,7 @@ netsnmp_tlstcp_open_server(netsnmp_transport *t)
     tlsdata->ssl_context = sslctx_server_setup(TLS_method());
 #ifdef SSL_CTX_set_max_proto_version
     if (tlsdata->ssl_context)
-        SSL_CTX_set_max_proto_version(tlsdata->ssl_context, TLS1_VERSION);
+        SSL_CTX_set_max_proto_version(tlsdata->ssl_context, 0);
 #endif
 
     t->sock = BIO_get_fd(tlsdata->accept_bio, NULL);


### PR DESCRIPTION
I hope someone will pick it up and continue.
There are now 5-7 failures when running the TLS test suite, if you run without leak checking.
There are a number of leaks that still needs fising too.