### PR TITLE
Protect malloc_trim() call with configure #ifdef

### DIFF
--- a/snmplib/container.c
+++ b/snmplib/container.c
@@ -510,7 +510,9 @@ void CONTAINER_CLEAR(netsnmp_container *x, netsnmp_container_obj_func *f,
         x = x->prev;
     }
     x->clear(x, f, c);
+#ifdef HAVE_MALLOC_TRIM
     malloc_trim(0);
+#endif
 }
 
 #ifndef NETSNMP_FEATURE_REMOVE_CONTAINER_FREE_ALL


### PR DESCRIPTION
This fixes 460a97c  "Give memory back to system post snmp operation" for BSD and others without the malloc_trim() function.