### PR TITLE
agent: fixed memory leak

### DIFF
--- a/agent/helpers/table_dataset.c
+++ b/agent/helpers/table_dataset.c
@@ -1173,7 +1173,7 @@ netsnmp_config_parse_add_row(const char *token, char *line)
     int             rc;
 
     data_set_tables *tables;
-    netsnmp_variable_list *vb;  /* containing only types */
+    netsnmp_variable_list *vb, *vars;  /* containing only types */
     netsnmp_table_row *row;
     netsnmp_table_data_set_storage *dr;
 
@@ -1202,7 +1202,8 @@ netsnmp_config_parse_add_row(const char *token, char *line)
                     vb->type));
         buf_size = sizeof(buf);
         line = read_config_read_memory(vb->type, line, buf, &buf_size);
-        netsnmp_table_row_add_index(row, vb->type, buf, buf_size);
+        vars = netsnmp_table_row_add_index(row, vb->type, buf, buf_size);
+        free(vars);
     }
 
     /*


### PR DESCRIPTION
Macro netsnmp_table_row_add_index called function
snmp_varlist_add_variable() that allocated memory by calling macro SNMP_MALLOC_TYPEDEF and returned pointer to this memory
Added assigment and call of free() for avoiding leaking  

Found by RASU JSC
Signed-off-by: Maxim Korotkov <maskorotkov@rasu.ru>