### PR TITLE
agent: mibgroup: avoid potential NULL dereference

### DIFF
--- a/agent/mibgroup/disman/schedule/schedConf.c
+++ b/agent/mibgroup/disman/schedule/schedConf.c
@@ -231,7 +231,7 @@ parse_sched_timed( const char *token, char *line )
      */
     while (line && isspace((unsigned char)(*line)))
         line++;
-    if ( *line == '=' ) {
+    if (line && *line == '=') {
         line++;
         while (line && isspace((unsigned char)(*line))) {
             line++;


### PR DESCRIPTION
The "while" loop shifts the pointer,
which can cause it to be NULL.
Fixes: 8baf64d4ae616(Re-worked Schedule MIB implementation.)  
Found by RASU JSC