### PR TITLE
Add 'ubifs' to other_fs

### DIFF
--- a/agent/mibgroup/hardware/fsys/fsys_mntent.c
+++ b/agent/mibgroup/hardware/fsys/fsys_mntent.c
@@ -90,6 +90,7 @@ static const char *other_fs[] = {
     "reiserfs",
     "simfs",
     "tmpfs",
+    "ubifs",
     "virtiofs",
     "vxfs",
     "xfs",


### PR DESCRIPTION
ubifs used to be automatically taken into account in UCD-SNMP-MIB::dskTable but commit e3fc76e0ae ("CHANGES: snmpd: Make UCD-SNMP::dskTable dynamic if includeAllDisks is set.") added a verification that drops all filesystems not present in other_fs[] table.

So add 'ubifs' in other_fs[] to fix it.