### PR TITLE
SIGHUP for handling agent port change

### DIFF
--- a/agent/snmpd.c
+++ b/agent/snmpd.c
@@ -1200,9 +1200,11 @@ snmpd_reconfig(void)
     /* Stop and restart logging.  This allows logfiles to be rotated etc. */
     netsnmp_logging_restart();
     snmp_log(LOG_INFO, "NET-SNMP version %s restarted\n",
-             netsnmp_get_version());
+             netsnmp_get_version());         
+    shutdown_master_agent();
     read_premib_configs();
     update_config();
+    init_master_agent();
     send_easy_trap(SNMP_TRAP_ENTERPRISESPECIFIC, 3);
 #ifdef HAVE_SIGPROCMASK
     ret = sigprocmask(SIG_UNBLOCK, &set, NULL);


### PR DESCRIPTION
Fix - When the reconfig flag is set, we "shudown master agent" which closes the socket listening on 161 and then call "init_master_agent" (which internally calls "netsnmp_agent_listen_on") would re-establish the socket on new port without changing the PID of "snmpd".

Use-case where its failing - Though this change works for most of the cases, its failing in a peculiar case where when we send SIGHUP while parallely the snmpwalk is in progress. When we send SIGHUP in this usecase, the socket is closed by "shutdown_master_agent" but a new socket is never re-established by "init_master_agent" no matter how many sighups we sent, the snmp-server is down permanently.
Going to the root of the problem, I see that the bind is successful as kernel returns 0 but netstat(-nlpu) never reports that socket.