### PR TITLE
Report unsupported security level

### DIFF
--- a/snmplib/snmpusm.c
+++ b/snmplib/snmpusm.c
@@ -2899,6 +2899,19 @@ usm_check_secLevel(int level, struct usmUser *user)
         DEBUGMSG(("usm", "\n"));
         return 1;
     }
+    if ((level == SNMP_SEC_LEVEL_NOAUTH)
+        &&
+        (netsnmp_oid_equals
+         (user->authProtocol, user->authProtocolLen, usmNoAuthProtocol,
+          sizeof(usmNoAuthProtocol) / sizeof(oid)) != 0)) {
+        DEBUGMSGTL(("usm", "Level: %d\n", level));
+        DEBUGMSGTL(("usm", "User (%s) Auth Protocol: ", user->name));
+        DEBUGMSGOID(("usm", user->authProtocol, user->authProtocolLen));
+        DEBUGMSG(("usm", ", User Priv Protocol: "));
+        DEBUGMSGOID(("usm", user->privProtocol, user->privProtocolLen));
+        DEBUGMSG(("usm", "\n"));
+        return 1;
+    }
 
     return 0;
 }                               /* end usm_check_secLevel() */


### PR DESCRIPTION
So far, unsupported security level is only reported when the level specified in a request is higher than the one configured. Now we report the opposite case too, e.g. when authNoPriv is configured on the server, but noAuthNoPriv is requested.

Related to issue #772. I am not sure the behaviour introduced here is compliant to the snmp specification, any input is appreciated.