### PR TITLE
Report unknown context

### DIFF
--- a/snmplib/snmp_api.c
+++ b/snmplib/snmp_api.c
@@ -4148,6 +4148,7 @@ snmpv3_make_report(netsnmp_pdu *pdu, int error)
     static const oid wrongDigest[] = { 1, 3, 6, 1, 6, 3, 15, 1, 1, 5, 0 };
     static const oid decryptionError[] =
         { 1, 3, 6, 1, 6, 3, 15, 1, 1, 6, 0 };
+    static const oid snmpUnknownContexts[] = {1, 3, 6, 1, 6, 3, 12, 1, 5, 0};
     const oid      *err_var;
     int             err_var_len;
 #ifndef NETSNMP_FEATURE_REMOVE_STATISTICS
@@ -4196,6 +4197,11 @@ snmpv3_make_report(netsnmp_pdu *pdu, int error)
 #endif /* !NETSNMP_FEATURE_REMOVE_STATISTICS */
         err_var = decryptionError;
         err_var_len = ERROR_STAT_LENGTH;
+        break;
+    case SNMPERR_BAD_CONTEXT:
+        stat_ind = STAT_SNMPUNKNOWNCONTEXTS;
+        err_var = snmpUnknownContexts;
+        err_var_len = sizeof(snmpUnknownContexts) / sizeof(snmpUnknownContexts[0]);
         break;
     default:
         return SNMPERR_GENERR;


### PR DESCRIPTION
So far, when the client uses an unknown context in a request, nothing is responded and the request runs into a timeout. Now we report the snmpUnknownContexts counter.

References issue #774. Not sure whether the behaviour introduced here is snmp spec conformant; any input is appreciated.