### PR TITLE
mib2c: Fix re-initialization of tables

### DIFF
--- a/local/mib2c-conf.d/mfd-interface.m2c
+++ b/local/mib2c-conf.d/mfd-interface.m2c
@@ -235,6 +235,8 @@ _${context}_initialize_interface(${context}_registration * reg_ptr,  u_long flag
 
     DEBUGMSGTL(("internal:${context}:_${context}_initialize_interface","called\n"));
 
+    /* Start with clean info, allows re-initializing */
+    memset(tbl_info, 0, sizeof(*tbl_info));
 
     /*************************************************
      *


### PR DESCRIPTION
Allows re-initialization of tables, if e.g. a table needs to be registered under a different snmp-context or to a different agent on a different IP. The table can be re-initialized with different configuration.

Problem solved here is that the table info is reset to no configuration before re-initializing. E.g. the snmp indexes are added during initialization, but not removed in shutdown. To make sure we clear all configuration from the table, a memset() was chosen: we start with a clean table.