### PR TITLE
Add Linux 6.7 compatibility parsing /proc/net/snmp

### DIFF
--- a/agent/mibgroup/ip-mib/data_access/systemstats_linux.c
+++ b/agent/mibgroup/ip-mib/data_access/systemstats_linux.c
@@ -36,7 +36,7 @@ netsnmp_access_systemstats_arch_init(void)
 }
 
 /*
-  /proc/net/snmp
+  /proc/net/snmp - Linux 6.6 and lower
 
   Ip: Forwarding DefaultTTL InReceives InHdrErrors InAddrErrors ForwDatagrams InUnknownProtos InDiscards InDelivers OutRequests OutDiscards OutNoRoutes ReasmTimeout ReasmReqds ReasmOKs ReasmFails FragOKs FragFails FragCreates
   Ip: 2 64 7083534 0 0 0 0 0 6860233 6548963 0 0 1 286623 63322 1 259920 0 0
@@ -49,6 +49,26 @@ netsnmp_access_systemstats_arch_init(void)
   
   Udp: InDatagrams NoPorts InErrors OutDatagrams
   Udp: 1491094 122 0 1466178
+*
+  /proc/net/snmp - Linux 6.7 and higher
+
+  Ip: Forwarding DefaultTTL InReceives InHdrErrors InAddrErrors ForwDatagrams InUnknownProtos InDiscards InDelivers OutRequests OutDiscards OutNoRoutes ReasmTimeout ReasmReqds ReasmOKs ReasmFails FragOKs FragFails FragCreates OutTransmits
+  Ip: 1 64 50859058 496 0 37470604 0 0 20472980 7515791 1756 0 0 7264 3632 0 3548 0 7096 44961424
+
+  Icmp: InMsgs InErrors InCsumErrors InDestUnreachs InTimeExcds InParmProbs InSrcQuenchs InRedirects InEchos InEchoReps InTimestamps InTimestampReps InAddrMasks InAddrMaskReps OutMsgs OutErrors OutRateLimitGlobal OutRateLimitHost OutDestUnreachs OutTimeExcds OutParmProbs OutSrcQuenchs OutRedirects OutEchos OutEchoReps OutTimestamps OutTimestampReps OutAddrMasks OutAddrMaskReps
+  Icmp: 114447 2655 0 17589 0 0 0 0 66905 29953 0 0 0 0 143956 0 0 572 16610 484 0 0 0 59957 66905 0 0 0 0
+
+  IcmpMsg: InType0 InType3 InType8 OutType0 OutType3 OutType8 OutType11
+  IcmpMsg: 29953 17589 66905 66905 16610 59957 484
+
+  Tcp: RtoAlgorithm RtoMin RtoMax MaxConn ActiveOpens PassiveOpens AttemptFails EstabResets CurrEstab InSegs OutSegs RetransSegs InErrs OutRsts InCsumErrors
+  Tcp: 1 200 120000 -1 17744 13525 307 3783 6 18093137 9277788 3499 8 7442 0
+
+  Udp: InDatagrams NoPorts InErrors OutDatagrams RcvbufErrors SndbufErrors InCsumErrors IgnoredMulti MemErrors
+  Udp: 2257832 1422 0 2252835 0 0 0 84 0
+
+  UdpLite: InDatagrams NoPorts InErrors OutDatagrams RcvbufErrors SndbufErrors InCsumErrors IgnoredMulti MemErrors
+  UdpLite: 0 0 0 0 0 0 0 0 0
 */
 
 
@@ -101,10 +121,10 @@ _systemstats_v4(netsnmp_container* container, u_int load_flags)
     FILE           *devin;
     char            line[1024];
     netsnmp_systemstats_entry *entry = NULL;
-    int             scan_count;
+    int             scan_count, expected_scan_count;
     char           *stats, *start = line;
     int             len;
-    unsigned long long scan_vals[19];
+    unsigned long long scan_vals[20];
 
     DEBUGMSGTL(("access:systemstats:container:arch", "load v4 (flags %x)\n",
                 load_flags));
@@ -126,10 +146,17 @@ _systemstats_v4(netsnmp_container* container, u_int load_flags)
      */
     NETSNMP_IGNORE_RESULT(fgets(line, sizeof(line), devin));
     len = strlen(line);
-    if (224 != len) {
+    switch (len) {
+    case 224:
+	expected_scan_count = 19;
+	break;
+    case 237:
+	expected_scan_count = 20;
+	break;
+    default:
         fclose(devin);
         snmp_log(LOG_ERR, "systemstats_linux: unexpected header length in /proc/net/snmp."
-                 " %d != 224\n", len);
+                 " %d not in { 224, 237 } \n", len);
         return -4;
     }
 
@@ -178,20 +205,20 @@ _systemstats_v4(netsnmp_container* container, u_int load_flags)
         memset(scan_vals, 0x0, sizeof(scan_vals));
         scan_count = sscanf(stats,
                             "%llu %llu %llu %llu %llu %llu %llu %llu %llu %llu"
-                            "%llu %llu %llu %llu %llu %llu %llu %llu %llu",
+                            "%llu %llu %llu %llu %llu %llu %llu %llu %llu %llu",
                             &scan_vals[0],&scan_vals[1],&scan_vals[2],
                             &scan_vals[3],&scan_vals[4],&scan_vals[5],
                             &scan_vals[6],&scan_vals[7],&scan_vals[8],
                             &scan_vals[9],&scan_vals[10],&scan_vals[11],
                             &scan_vals[12],&scan_vals[13],&scan_vals[14],
                             &scan_vals[15],&scan_vals[16],&scan_vals[17],
-                            &scan_vals[18]);
+                            &scan_vals[18],&scan_vals[19]);
         DEBUGMSGTL(("access:systemstats", "  read %d values\n", scan_count));
 
-        if(scan_count != 19) {
+        if(scan_count != expected_scan_count) {
             snmp_log(LOG_ERR,
                      "error scanning systemstats data (expected %d, got %d)\n",
-                     19, scan_count);
+                     expected_scan_count, scan_count);
             netsnmp_access_systemstats_entry_free(entry);
             return -4;
         }
@@ -223,6 +250,7 @@ _systemstats_v4(netsnmp_container* container, u_int load_flags)
         entry->stats.HCOutFragFails.high = scan_vals[17] >> 32;
         entry->stats.HCOutFragCreates.low = scan_vals[18] & 0xffffffff;
         entry->stats.HCOutFragCreates.high = scan_vals[18] >> 32;
+        /* entry->stats. = scan_vals[19]; / * OutTransmits */
 
         entry->stats.columnAvail[IPSYSTEMSTATSTABLE_HCINRECEIVES] = 1;
         entry->stats.columnAvail[IPSYSTEMSTATSTABLE_INHDRERRORS] = 1;


### PR DESCRIPTION
Linux 6.7 adds a new OutTransmits field to Ip in /proc/net/snmp. This breaks the hard-coded assumptions about the Ip line length. Add compatibility to parse Linux 6.7 Ip header while keep support for previous versions.