### PR TITLE
Fix leaks in snmpv3.c

### DIFF
--- a/snmplib/snmpv3.c
+++ b/snmplib/snmpv3.c
@@ -274,6 +274,7 @@ snmpv3_parse_arg(int arg, char *optarg, netsnmp_session *session, char **Apsz,
 
             auth_proto = sc_get_auth_oid(auth_type,
                                          &session->securityAuthProtoLen);
+            free(session->securityAuthProto);
             session->securityAuthProto = snmp_duplicate_objid(auth_proto,
                                              session->securityAuthProtoLen);
          } else {
@@ -296,6 +297,7 @@ snmpv3_parse_arg(int arg, char *optarg, netsnmp_session *session, char **Apsz,
             return (-1);
         }
         priv_proto = sc_get_priv_oid(priv_type, &session->securityPrivProtoLen);
+        free(session->securityPrivProto);
         session->securityPrivProto = snmp_duplicate_objid(priv_proto,
                                          session->securityPrivProtoLen);
         break;


### PR DESCRIPTION
Hi,
I am a new contributor looking forward to contribute to the shc project :).

This commit fixes leak described in #700.
$ './net-snmp/apps/snmpget' '' '-xd' 'A' '-xd' 'B'
is enough to trigger the leak.


In the case of 'x' option the leak occurs because `session->securityPrivProto` is not freed before assigning. The patch corrects this.
It also fixes another similar leak in case of 'a' argument. Similarly in this case `session->securityAuthProto` is not free before assigning,

Let me know if this is a good patch! If not let me know what changes need be done. I am eager to contribute more to this repository :)