### PR TITLE
Fix leak in snmpusm.c

### DIFF
--- a/snmplib/snmpusm.c
+++ b/snmplib/snmpusm.c
@@ -5141,6 +5141,9 @@ init_usm_post_config(int majorid, int minorid, void *serverarg,
     }
 #endif
 
+    // Free noNameUser before it is assigned
+    usm_free_user(noNameUser);
+
 #ifndef NETSNMP_DISABLE_MD5
     noNameUser = usm_create_initial_user("", usmHMACMD5AuthProtocol,
                                          OID_LENGTH(usmHMACMD5AuthProtocol),


### PR DESCRIPTION
Fixes #723.

The leaks are :
```
=================================================================
==snmpd==329330==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 208 byte(s) in 1 object(s) allocated from:
    #0 0x7f357aede9a7 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:77
    #1 0x7f357946ecad in usm_create_user /home/user/Desktop/net-snmp/snmplib/snmpusm.c:4101
    #2 0x7f357946f110 in usm_create_initial_user /home/user/Desktop/net-snmp/snmplib/snmpusm.c:4141
    #3 0x7f357947af27 in init_usm_post_config /home/user/Desktop/net-snmp/snmplib/snmpusm.c:5077
    #4 0x7f35793e27d2 in snmp_call_callbacks /home/user/Desktop/net-snmp/snmplib/callback.c:360
    #5 0x7f35793aa71d in read_premib_configs /home/user/Desktop/net-snmp/snmplib/read_config.c:1114
    #6 0x7f3579318664 in init_snmp /home/user/Desktop/net-snmp/snmplib/snmp_api.c:925
    #7 0x5627e3f62ec1 in main /home/user/Desktop/net-snmp/agent/snmpd.c:909
    #8 0x7f3578823a8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58

Indirect leak of 80 byte(s) in 1 object(s) allocated from:
    #0 0x7f357aedefef in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x7f3579363b1f in snmp_duplicate_objid /home/user/Desktop/net-snmp/snmplib/snmp_api.c:7983
    #2 0x7f357946fbae in usm_create_initial_user /home/user/Desktop/net-snmp/snmplib/snmpusm.c:4170
    #3 0x7f357947af27 in init_usm_post_config /home/user/Desktop/net-snmp/snmplib/snmpusm.c:5077
    #4 0x7f35793e27d2 in snmp_call_callbacks /home/user/Desktop/net-snmp/snmplib/callback.c:360
    #5 0x7f35793aa71d in read_premib_configs /home/user/Desktop/net-snmp/snmplib/read_config.c:1114
    #6 0x7f3579318664 in init_snmp /home/user/Desktop/net-snmp/snmplib/snmp_api.c:925
    #7 0x5627e3f62ec1 in main /home/user/Desktop/net-snmp/agent/snmpd.c:909
    #8 0x7f3578823a8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58

Indirect leak of 80 byte(s) in 1 object(s) allocated from:
    #0 0x7f357aedefef in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x7f3579363b1f in snmp_duplicate_objid /home/user/Desktop/net-snmp/snmplib/snmp_api.c:7983
    #2 0x7f357946f8dd in usm_create_initial_user /home/user/Desktop/net-snmp/snmplib/snmpusm.c:4162
    #3 0x7f357947af27 in init_usm_post_config /home/user/Desktop/net-snmp/snmplib/snmpusm.c:5077
    #4 0x7f35793e27d2 in snmp_call_callbacks /home/user/Desktop/net-snmp/snmplib/callback.c:360
    #5 0x7f35793aa71d in read_premib_configs /home/user/Desktop/net-snmp/snmplib/read_config.c:1114
    #6 0x7f3579318664 in init_snmp /home/user/Desktop/net-snmp/snmplib/snmp_api.c:925
    #7 0x5627e3f62ec1 in main /home/user/Desktop/net-snmp/agent/snmpd.c:909
    #8 0x7f3578823a8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58

Indirect leak of 16 byte(s) in 1 object(s) allocated from:
    #0 0x7f357aedefef in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x7f357946f481 in usm_create_initial_user /home/user/Desktop/net-snmp/snmplib/snmpusm.c:4155
    #2 0x7f357947af27 in init_usm_post_config /home/user/Desktop/net-snmp/snmplib/snmpusm.c:5077
    #3 0x7f35793e27d2 in snmp_call_callbacks /home/user/Desktop/net-snmp/snmplib/callback.c:360
    #4 0x7f35793aa71d in read_premib_configs /home/user/Desktop/net-snmp/snmplib/read_config.c:1114
    #5 0x7f3579318664 in init_snmp /home/user/Desktop/net-snmp/snmplib/snmp_api.c:925
    #6 0x5627e3f62ec1 in main /home/user/Desktop/net-snmp/agent/snmpd.c:909
    #7 0x7f3578823a8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58

Indirect leak of 1 byte(s) in 1 object(s) allocated from:
    #0 0x7f357ae841b8 in __interceptor_strdup ../../../../src/libsanitizer/asan/asan_interceptors.cpp:454
    #1 0x7f357946f24f in usm_create_initial_user /home/user/Desktop/net-snmp/snmplib/snmpusm.c:4148
    #2 0x7f357947af27 in init_usm_post_config /home/user/Desktop/net-snmp/snmplib/snmpusm.c:5077
    #3 0x7f35793e27d2 in snmp_call_callbacks /home/user/Desktop/net-snmp/snmplib/callback.c:360
    #4 0x7f35793aa71d in read_premib_configs /home/user/Desktop/net-snmp/snmplib/read_config.c:1114
    #5 0x7f3579318664 in init_snmp /home/user/Desktop/net-snmp/snmplib/snmp_api.c:925
    #6 0x5627e3f62ec1 in main /home/user/Desktop/net-snmp/agent/snmpd.c:909
    #7 0x7f3578823a8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58

Indirect leak of 1 byte(s) in 1 object(s) allocated from:
    #0 0x7f357ae841b8 in __interceptor_strdup ../../../../src/libsanitizer/asan/asan_interceptors.cpp:454
    #1 0x7f357946f147 in usm_create_initial_user /home/user/Desktop/net-snmp/snmplib/snmpusm.c:4145
    #2 0x7f357947af27 in init_usm_post_config /home/user/Desktop/net-snmp/snmplib/snmpusm.c:5077
    #3 0x7f35793e27d2 in snmp_call_callbacks /home/user/Desktop/net-snmp/snmplib/callback.c:360
    #4 0x7f35793aa71d in read_premib_configs /home/user/Desktop/net-snmp/snmplib/read_config.c:1114
    #5 0x7f3579318664 in init_snmp /home/user/Desktop/net-snmp/snmplib/snmp_api.c:925
    #6 0x5627e3f62ec1 in main /home/user/Desktop/net-snmp/agent/snmpd.c:909
    #7 0x7f3578823a8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58

SUMMARY: AddressSanitizer: 386 byte(s) leaked in 6 allocation(s).
```
The leaks occur within function `init_usm_post_config`. Here this static global variable is assigned before being freed. The patch corrects this.

I was able to confirm that the leak is gone after the patch and there is no double-free.
Let me know if you found the patch useful!

Signed-off-by: Aniruddhan Murali <a25mural@uwaterloo.ca>
