### PR TITLE
snmpd/snmptrapd.service: Remove dead syslog.target

### DIFF
--- a/dist/snmpd.service
+++ b/dist/snmpd.service
@@ -7,7 +7,7 @@
 
 [Unit]
 Description=Simple Network Management Protocol (SNMP) daemon.
-After=syslog.target network.target
+After=network.target
 
 [Service]
 # Type=notify is also supported. It should be set when snmpd.socket is not used.

--- a/dist/snmptrapd.service
+++ b/dist/snmptrapd.service
@@ -4,7 +4,7 @@
 
 [Unit]
 Description=Simple Network Management Protocol (SNMP) Trap daemon.
-After=syslog.target network.target
+After=network.target
 
 [Service]
 # Type=notify is also supported. It should be set when snmptrapd.socket is not


### PR DESCRIPTION
https://github.com/systemd/systemd/blob/6aa8d43ade72e24c9426e604f7fc4b7582b9db7c/NEWS#L72-L73
this target hasn't existed for over a decade