### PR TITLE
Fix example binding to IPv6 localhost instead of all interfaces

### DIFF
--- a/EXAMPLE.conf.def
+++ b/EXAMPLE.conf.def
@@ -14,7 +14,7 @@
 #  Listen for connections from the local system only
 agentAddress  udp:127.0.0.1:161
 #  Listen for connections on all interfaces (both IPv4 *and* IPv6)
-#agentAddress udp:161,udp6:[::1]:161
+#agentAddress udp:161,udp6:[::]:161
 
 
 


### PR DESCRIPTION
`[::]` means all interfaces. 

`[::1]` is the IPv6 equivalent of the `127.0.0.1/8` loopback address.

The comments mention "all interfaces (both IPv4 *and* IPv6)". 

Tested it by setting agentaddress to `[::]` and verifying I could connect over IPv6. Setting it to `[::1]` disabled connections from outside of locahost. 