### PR TITLE
Correct header comment about retry timeout

### DIFF
--- a/include/net-snmp/types.h
+++ b/include/net-snmp/types.h
@@ -299,7 +299,7 @@ struct snmp_session {
     long            version;
     /** Number of retries before timeout. */
     int             retries;
-    /** Number of uS until first timeout, then exponential backoff */
+    /** Message timeout in uS before first retry and between retries */
     long            timeout;        
     u_long          flags;
     struct snmp_session *subsession;

--- a/include/net-snmp/types.h
+++ b/include/net-snmp/types.h
@@ -299,7 +299,7 @@ struct snmp_session {
     long            version;
     /** Number of retries before timeout. */
     int             retries;
-    /** Message timeout in uS before first retry and between retries */
+    /** Message timeout in μs before first retry and between retries */
     long            timeout;        
     u_long          flags;
     struct snmp_session *subsession;


### PR DESCRIPTION
Correct header comment about retry timeout

The header `<net-snmp/types.h>` contains the following [comment](https://github.com/net-snmp/net-snmp/blob/c1a34f3cbc1bf33fb65b125852541b8336e977cf/include/net-snmp/types.h#L302) in `struct snmp_session`:
```C
/** Number of uS until first timeout, then exponential backoff */
```
This is misleading as [according](https://net-snmp-users.narkive.com/g8tqnRhi/timeout-exponentially-backoff#post1) to the mailing list the exponential back-off behaviour was removed in 1998.

I can confirm that the retry timeout is still fixed at the value set in the `timeout` field:
```
sudo tcpdump -i lo udp port 161 & sleep 1 && time snmpget -v 2c -c public -r 3 -t 5 localhost 1.3.6.1.2.1.1.3.0;
[1] 97961
tcpdump: verbose output suppressed, use -v or -vv for full protocol decode
listening on lo, link-type EN10MB (Ethernet), capture size 262144 bytes
22:22:00.352056 IP localhost.40363 > localhost.snmp:  GetRequest(28)  system.sysUpTime.0
22:22:05.357578 IP localhost.40363 > localhost.snmp:  GetRequest(28)  system.sysUpTime.0
22:22:10.363094 IP localhost.40363 > localhost.snmp:  GetRequest(28)  system.sysUpTime.0
22:22:15.368632 IP localhost.40363 > localhost.snmp:  GetRequest(28)  system.sysUpTime.0


real	0m20.028s
user	0m0.000s
sys	0m0.006s
```