### PR TITLE
FreeBSD: Fix the sysctl() configure test

### DIFF
--- a/configure
+++ b/configure
@@ -35767,7 +35767,7 @@ else $as_nop
 #include <stddef.h>
 #include <stdlib.h>
 
-int main(void)
+int main(int argc, char **argv)
 {
   int                 mib[2];
   size_t              len;
@@ -35777,11 +35777,7 @@ int main(void)
   mib[1] = KERN_BOOTTIME;
 
   len = sizeof(boottime);
-  sysctl(mib, 2, &boottime, &len, NULL, NULL);
-  if (boottime.tv_sec != 0)
-    exit(0);
-  else
-    exit(1);
+  return 1 - (sysctl(mib, 2, &boottime, &len, NULL, 0) == 0 && boottime.tv_sec);
 }
 
 _ACEOF

--- a/configure.d/config_os_misc4
+++ b/configure.d/config_os_misc4
@@ -187,7 +187,7 @@ else
 #include <stddef.h>
 #include <stdlib.h>
 
-int main(void)
+int main(int argc, char **argv)
 {
   int                 mib[2];
   size_t              len;
@@ -197,11 +197,7 @@ int main(void)
   mib[1] = KERN_BOOTTIME;
   
   len = sizeof(boottime);
-  sysctl(mib, 2, &boottime, &len, NULL, NULL);
-  if (boottime.tv_sec != 0)
-    exit(0);
-  else
-    exit(1);
+  return 1 - (sysctl(mib, 2, &boottime, &len, NULL, 0) == 0 && boottime.tv_sec);
 }
         ]])],[ac_cv_NETSNMP_CAN_USE_SYSCTL=yes],[ac_cv_NETSNMP_CAN_USE_SYSCTL=no],[ac_cv_NETSNMP_CAN_USE_SYSCTL=no])])
 fi


### PR DESCRIPTION
Forward a patch from 2020 that fixed the sysctl for FreeBSD. This allows compilation to complete for current FreeBSD releases.