### PR TITLE
Update man page for net-snmp-create-v3-user

### DIFF
--- a/man/net-snmp-create-v3-user.1.def
+++ b/man/net-snmp-create-v3-user.1.def
@@ -1,4 +1,4 @@
-.TH net-snmp-create-v3-user 1 "17 Sep 2008" VVERSIONINFO "Net-SNMP"
+.TH net-snmp-create-v3-user 1 "09 Aug 2024" VVERSIONINFO "Net-SNMP"
 .SH NAME
 net-snmp-create-v3-user \- create a SNMPv3 user in net-snmp configuration file
 .SH SYNOPSIS

--- a/man/net-snmp-create-v3-user.1.def
+++ b/man/net-snmp-create-v3-user.1.def
@@ -3,7 +3,7 @@
 net-snmp-create-v3-user \- create a SNMPv3 user in net-snmp configuration file
 .SH SYNOPSIS
 .PP
-.B net-snmp-create-v3-user [-ro] [-a authpass] [-x privpass] [-X DES|AES]
+.B net-snmp-create-v3-user [-ro] [-A authpass] [-a MD5|SHA|SHA-512|SHA-384|SHA-256|SHA-224] [-X privpass] [-x DES|AES|AES128]
 .B [username]
 .SH DESCRIPTION
 .PP
@@ -18,11 +18,14 @@ displays the net-snmp version number
 \fB\-ro\fR
 create a user with read-only permissions
 .TP
-\fB\-a authpass\fR
+\fB\-A authpass\fR
 specify authentication password
 .TP
-\fB\-x privpass\fR
+\fB\-a MD5|SHA|SHA-512|SHA-384|SHA-256|SHA-224\fR
+specify authentication algorithm
+.TP
+\fB\-X privpass\fR
 specify encryption password
 .TP
-\fB\-X DES|AES\fR
+\fB\-x DES|AES|AES128\fR
 specify encryption algorithm


### PR DESCRIPTION
Hi! Noticed the manpage was missing some options for `net-snmp-create-v3-user`:

```
Usage:
  net-snmp-create-v3-user [-ro] [-A authpass] [-X privpass]
                          [-a MD5|SHA|SHA-512|SHA-384|SHA-256|SHA-224] [-x DES|AES|AES128] [username]
```

Missing option for authentication algorithm and missing parameters for encryption algorithms have been documented.

Although case does not matter for `-A` and `-X` (which seems to be its own can of worms that needs to be kept for compatibility), I've switched them around to match the usage string of `net-snmp-create-v3-user --help`.