### PR TITLE
OpenBSD needs explicit include for stdint.h to get SIZE_MAX

### DIFF
--- a/snmplib/container_binary_array.c
+++ b/snmplib/container_binary_array.c
@@ -22,6 +22,9 @@
 #ifdef HAVE_STDLIB_H
 #include <stdlib.h>
 #endif
+#ifdef HAVE_STDINT_H
+#include <stdint.h>
+#endif
 #ifdef HAVE_MALLOC_H
 #include <malloc.h>
 #endif


### PR DESCRIPTION
This fixes commit ccfcecb (libsnmp: Fix a potential integer overflow in netsnmp_binary_array_get_subset())