### PR TITLE
Fix ipv6.c for DragonflyBSD (#841)

### DIFF
--- a/agent/mibgroup/mibII/ipv6.c
+++ b/agent/mibgroup/mibII/ipv6.c
@@ -1516,7 +1516,7 @@ var_udp6(register struct variable * vp,
     int             result;
     int             i, j;
     caddr_t         p;
-#if defined(openbsd4)
+#if defined(openbsd4) || defined(dragonfly)
     static struct inpcb in6pcb, savpcb;
 #elif defined(freebsd3)
     static struct xinpcb in6pcb, savpcb;
@@ -1618,7 +1618,7 @@ var_udp6(register struct variable * vp,
         ) {
         DEBUGMSGTL(("mibII/ipv6", "looping: p=%p\n", p));
 
-#if defined(freebsd3)
+#if defined(freebsd3) &&!defined(dragonfly)
 	in6pcb = *(struct xinpcb *) xig;
 #elif defined(darwin)
 	in6pcb = ((struct xinpcb *) xig)->xi_inp;
@@ -2112,7 +2112,7 @@ var_tcp6(register struct variable * vp,
     int             result;
     int             i, j;
     caddr_t         p;
-#if defined(openbsd4)
+#if defined(openbsd4) || defined(dragonfly)
     static struct inpcb in6pcb, savpcb;
 #elif defined(freebsd3)
     static struct xinpcb in6pcb;
@@ -2120,7 +2120,7 @@ var_tcp6(register struct variable * vp,
 #else
     static struct in6pcb in6pcb, savpcb;
 #endif
-#if !defined(freebsd3)
+#if !defined(freebsd3) || defined(dragonfly)
     struct tcpcb    tcpcb;
 #endif
     int             state;
@@ -2217,10 +2217,10 @@ var_tcp6(register struct variable * vp,
         ) {
         DEBUGMSGTL(("mibII/ipv6", "looping: p=%p\n", p));
 
-#if defined(freebsd3)
-	in6pcb = ((struct xtcpcb *) xig)->xt_inp;
-#elif defined(dragonfly)
+#if defined(dragonfly)
 	in6pcb = xtp->xt_inp;
+#elif defined(freebsd3)
+	in6pcb = ((struct xtcpcb *) xig)->xt_inp;
 #elif defined(darwin)
         in6pcb = ((struct xinpcb *) xig)->xi_inp;
 #else
@@ -2303,7 +2303,7 @@ var_tcp6(register struct variable * vp,
 #endif
         result = snmp_oid_compare(name, *length, newname, j);
         if (exact && (result == 0)) {
-#if defined(freebsd3)
+#if defined(freebsd3) && !defined(dragonfly)
                 savstate = ((struct xtcpcb *) xig)->t_state;
 #else
                 memcpy(&savpcb, &in6pcb, sizeof(savpcb));
@@ -2318,7 +2318,7 @@ var_tcp6(register struct variable * vp,
              */
             if ((savnameLen == 0) ||
               (snmp_oid_compare(savname, savnameLen, newname, j) > 0)) {
-#if defined(freebsd3)
+#if defined(freebsd3) && !defined(dragonfly)
                 savstate = ((struct xtcpcb *) xig)->t_state;
 #else
                 memcpy(&savpcb, &in6pcb, sizeof(savpcb));
@@ -2361,7 +2361,7 @@ var_tcp6(register struct variable * vp,
         return NULL;
     *length = savnameLen;
     memcpy((char *) name, (char *) savname, *length * sizeof(oid));
-#if defined(freebsd3)
+#if defined(freebsd3) && !defined(dragonfly)
     state = savstate;
 #elif defined(__NetBSD__) && __NetBSD_Version__ >= 999010400
     memcpy(&in6pcb, &savpcb, sizeof(savpcb));


### PR DESCRIPTION
Fixes: ebb758e3 (x Fix var_udp6 and var_tcp6 on FreeBSD)