### PR TITLE
notificationFilter: Fix mask data copying

### DIFF
--- a/agent/mibgroup/snmp-notification-mib/snmpNotifyFilterTable/snmpNotifyFilterTable_data_storage.c
+++ b/agent/mibgroup/snmp-notification-mib/snmpNotifyFilterTable/snmpNotifyFilterTable_data_storage.c
@@ -211,6 +211,7 @@ snmpNotifyFilter_storage_add(const u_char *profileName, size_t profileName_len,
     if (NULL == data)
         return NULL;
 
+    data->snmpNotifyFilterMask_len = filterMask_len;
     memcpy(data->snmpNotifyFilterMask, filterMask, filterMask_len);
 
     data->snmpNotifyFilterType = filterType;


### PR DESCRIPTION
Hello,
I'm a new contributor looking forward to correct some behavior I found.
 
After using the `notificationFilter` directive for creating SNMP-NOTIFICATION-MIB notification filter profile, the `snmpNotifyFilterTable` always showed entries with an empty mask (`0x`). The problem was an uninitialized length field.
