### PR TITLE
Fix memory leak of tclist

### DIFF
--- a/include/net-snmp/library/parse.h
+++ b/include/net-snmp/library/parse.h
@@ -45,6 +45,8 @@ SOFTWARE.
 #define MAXLABEL        NETSNMP_MAXLABEL
 #endif
 
+    struct tc *tclist;
+
     struct variable_list;
 
     /*

--- a/snmplib/mib.c
+++ b/snmplib/mib.c
@@ -2875,6 +2875,7 @@ shutdown_mib(void)
         Prefix = NULL;
     SNMP_FREE(confmibs);
     SNMP_FREE(confmibdir);
+    SNMP_FREE(tclist);
 }
 
 /**


### PR DESCRIPTION
`tclist` is dynamically allocated in `netsnmp_init_mib_internals()`, which is called unconditionally from `netsnmp_init_mib()`.  As such the memory should be freed in `shutdown_mib()`.