### PR TITLE
Add gitattributes file to use eol=lf for almost all files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+* eol=lf
+*.bat eol=crlf
+/win32/dist/README* eol=crlf
+*.gif -text
+*.jpg -text
+*.bin -text
+*.bmp -text


### PR DESCRIPTION
This fixes autoreconf on MSYS2 and possibly other issues.