### PR TITLE
Add option to exclude Network Block Devices

### DIFF
--- a/agent/mibgroup/ucd-snmp/diskio_linux.c
+++ b/agent/mibgroup/ucd-snmp/diskio_linux.c
@@ -96,6 +96,8 @@ diskio_free_config(void)
                            NETSNMP_DS_AGENT_DISKIO_NO_RAM, 0);
     netsnmp_ds_set_boolean(NETSNMP_DS_APPLICATION_ID,
                            NETSNMP_DS_AGENT_DISKIO_NO_MD, 0);
+    netsnmp_ds_set_boolean(NETSNMP_DS_APPLICATION_ID,
+                           NETSNMP_DS_AGENT_DISKIO_NO_NBD, 0);
 
     if (la_head.length) {
         /*
@@ -258,6 +260,9 @@ void init_diskio_linux(void)
     netsnmp_ds_register_config(ASN_BOOLEAN, app, "diskio_exclude_md",
                                NETSNMP_DS_APPLICATION_ID,
                                NETSNMP_DS_AGENT_DISKIO_NO_MD);
+    netsnmp_ds_register_config(ASN_BOOLEAN, app, "diskio_exclude_nbd",
+                               NETSNMP_DS_APPLICATION_ID,
+                               NETSNMP_DS_AGENT_DISKIO_NO_NBD);
 
     snmpd_register_config_handler("diskio", diskio_parse_config_disks,
         diskio_free_config, "path | device");
@@ -335,6 +340,10 @@ is_excluded(const char *name)
     if (netsnmp_ds_get_boolean(NETSNMP_DS_APPLICATION_ID,
                                NETSNMP_DS_AGENT_DISKIO_NO_MD)
         && !(strncmp(name, "md", 2)))
+        return 1;
+    if (netsnmp_ds_get_boolean(NETSNMP_DS_APPLICATION_ID,
+                               NETSNMP_DS_AGENT_DISKIO_NO_NBD)
+        && !(strncmp(name, "nbd", 2)))
         return 1;
     return 0;
 }

--- a/include/net-snmp/agent/ds_agent.h
+++ b/include/net-snmp/agent/ds_agent.h
@@ -41,6 +41,7 @@
 #define NETSNMP_DS_AGENT_DISKIO_NO_LOOP 19      /* 1 = don't report /dev/loop* entries in diskIOTable */
 #define NETSNMP_DS_AGENT_DISKIO_NO_RAM  20      /* 1 = don't report /dev/ram*  entries in diskIOTable */
 #define NETSNMP_DS_AGENT_DISKIO_NO_MD   21      /* 1 = don't report /dev/md*   entries in diskIOTable */
+#define NETSNMP_DS_AGENT_DISKIO_NO_NBD  22      /* 1 = don't report /dev/nbd*  entries in diskIOTable */
 
 /* WARNING: The trap receiver also uses DS flags and must not conflict with these!
  * If you define additional boolean entries, check in "apps/snmptrapd_ds.h" first */

--- a/man/snmpd.conf.5.def
+++ b/man/snmpd.conf.5.def
@@ -778,8 +778,8 @@ e.g. "fd0"
 Excludes all Linux loopback block devices, whose names start with "loop",
 e.g. "loop0"
 .IP "diskio_exclude_ram yes"
-Excludes all LInux ramdisk block devices, whose names start with "ram", e.g.
-"ram0"
+Excludes all Linux ramdisk block devices, whose names start with "ram",
+e.g. "ram0"
 .PP
 On Linux systems, it is also possible to report only explicitly whitelisted
 devices. It may take a significant amount of time to process diskIOTable data

--- a/man/snmpd.conf.5.def
+++ b/man/snmpd.conf.5.def
@@ -780,6 +780,9 @@ e.g. "loop0"
 .IP "diskio_exclude_ram yes"
 Excludes all Linux ramdisk block devices, whose names start with "ram",
 e.g. "ram0"
+.IP "diskio_exclude_md yes"
+Excludes all Linux RAID block devices, whose names start with "md",
+e.g. "md0"
 .PP
 On Linux systems, it is also possible to report only explicitly whitelisted
 devices. It may take a significant amount of time to process diskIOTable data

--- a/man/snmpd.conf.5.def
+++ b/man/snmpd.conf.5.def
@@ -783,6 +783,9 @@ e.g. "ram0"
 .IP "diskio_exclude_md yes"
 Excludes all Linux RAID block devices, whose names start with "md",
 e.g. "md0"
+.IP "diskio_exclude_nbd yes"
+Excludes all Linux network block devices, whose names start with "nbd",
+e.g. "nbd0"
 .PP
 On Linux systems, it is also possible to report only explicitly whitelisted
 devices. It may take a significant amount of time to process diskIOTable data


### PR DESCRIPTION
On Linux, loading the `nbd` driver creates a number of `nbd` devices even if they aren't actually in use. On top of that, QEMU supports using them as fancier loopback devices for manipulating QCOW2 images. So even when they are in use, there may be reasons to exclude them from the SNMP data.

Since I was updating the manpage, I also added the missing documentation for `diskio_exclude_md` from PR #511 

I'm also not a troff expert in any way (only reason I could update the manpage was that it was a copy and paste job) but ending a line in a period seems to insert an extra space into the text. So I rewrapped the text so that none of these lines end in `e.g.`