### PR TITLE
Fix include stdint.h missing to get SIZE_MAX

### DIFF
--- a/snmplib/snmpusm.c
+++ b/snmplib/snmpusm.c
@@ -34,6 +34,9 @@
 #ifdef HAVE_STDLIB_H
 #include <stdlib.h>
 #endif
+#ifdef HAVE_STDINT_H
+#include <stdint.h>
+#endif
 #ifdef TIME_WITH_SYS_TIME
 # include <sys/time.h>
 # include <time.h>


### PR DESCRIPTION
This fixes commit d33578d for ubuntu building.
This problem is same as #839 