### PR TITLE
Avoid unused variable warning

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -81,8 +81,8 @@ diffs or instructions to the address given in the `README' so they can
 be considered for the next release.  If at some point `config.cache'
 contains results you don't want to keep, you may remove or edit it.
 
-   The file `configure.in' is used to create `configure' by a program
-called `autoconf'.  You only need `configure.in' if you want to change
+   The file `configure.ac' is used to create `configure' by a program
+called `autoconf'.  You only need `configure.ac' if you want to change
 it or regenerate `configure' using a newer version of `autoconf'.
 
 The simplest way to compile this package is:

--- a/snmplib/parse.c
+++ b/snmplib/parse.c
@@ -3993,7 +3993,7 @@ read_module_internal(const char *name)
 void
 adopt_orphans(void)
 {
-    struct node    *np, *onp;
+    struct node    *np = NULL, *onp;
     struct tree    *tp;
     int             i, adopted = 1;
 


### PR DESCRIPTION
Happens on latest Rpi compiler. Also trivial update of INSTALL