### PR TITLE
snmplib: snmpcmds should load host conf consistently

### DIFF
--- a/include/net-snmp/library/snmp_transport.h
+++ b/include/net-snmp/library/snmp_transport.h
@@ -346,6 +346,9 @@ netsnmp_transport *netsnmp_tdomain_transport_oid(const oid * dom,
 						 int local);
 
 NETSNMP_IMPORT
+int netsnmp_tdomain_host_configs_of_type(int when);
+
+NETSNMP_IMPORT
 netsnmp_transport *netsnmp_tdomain_transport_tspec(netsnmp_tdomain_spec *tspec);
 
 NETSNMP_IMPORT

--- a/snmplib/read_config.c
+++ b/snmplib/read_config.c
@@ -1476,6 +1476,9 @@ read_config_files(int when) {
             ret = SNMPERR_SUCCESS;
     }
 
+    if ( netsnmp_tdomain_host_configs_of_type(when) == SNMPERR_SUCCESS )
+        ret = SNMPERR_SUCCESS;
+
     if (config_errors) {
         snmp_log(LOG_ERR, "net-snmp: %d error(s) in config file(s)\n",
                  config_errors);

--- a/snmplib/snmp_parse_args.c
+++ b/snmplib/snmp_parse_args.c
@@ -497,6 +497,21 @@ netsnmp_parse_args(int argc,
     }
 
     /*
+     * get the hostname 
+     */
+    if (optind == argc) {
+        fprintf(stderr, "No hostname specified.\n");
+        ret = NETSNMP_PARSE_ARGS_ERROR_USAGE;
+        goto out;
+    }
+    session->peername = strdup(argv[optind++]); /* hostname */
+
+    /* used to load hosts/<peername>.conf files */
+    netsnmp_ds_set_string(NETSNMP_DS_LIBRARY_ID,
+                          NETSNMP_DS_LIB_HOSTNAME,
+                          session->peername);
+
+    /*
      * read in MIB database and initialize the snmp library, read the config file
      */
     init_snmp(NETSNMP_APPLICATION_CONFIG_TYPE);
@@ -621,16 +636,6 @@ netsnmp_parse_args(int argc,
         Xpsz = NULL;
     }
 #endif /* NETSNMP_SECMOD_USM */
-
-    /*
-     * get the hostname 
-     */
-    if (optind == argc) {
-        fprintf(stderr, "No hostname specified.\n");
-        ret = NETSNMP_PARSE_ARGS_ERROR_USAGE;
-        goto out;
-    }
-    session->peername = strdup(argv[optind++]); /* hostname */
 
 #if !defined(NETSNMP_DISABLE_SNMPV1) || !defined(NETSNMP_DISABLE_SNMPV2C)
     /*

--- a/snmplib/snmp_transport.c
+++ b/snmplib/snmp_transport.c
@@ -620,6 +620,71 @@ netsnmp_is_fqdn(const char *thename)
 }
 
 /*
+ * Calls read_config_files_of_type(), and replacing the "smtp" config
+ * file type with "hosts/<host>". <when> == NORMAL_CONFIG ensures further
+ * calls are no-op (prevent snmp_sess_open() overriding cmdline)
+ */
+static int
+netsnmp_tdomain_host_config_of_type(int when, const char *host)
+{
+    char buf[SNMP_MAXPATH];
+    struct config_files file_names;
+    static int have_added_handler = 0;
+    static int final_pass = 0;
+    int ret = SNMPERR_GENERR;
+
+    /* don't set final_pass if no host */
+    if ((host == NULL) || final_pass)
+        return ret;
+
+    /* read_config_files( NORMAL_CONFIG, <host> != NULL ),
+       no-op further calls in snmp_sess_open() to protect cmdline overrides */
+    if ( when == NORMAL_CONFIG )
+        final_pass = 1;
+
+    if (netsnmp_ds_get_boolean(NETSNMP_DS_LIBRARY_ID,
+                               NETSNMP_DS_LIB_DONT_LOAD_HOST_FILES) ||
+        !netsnmp_is_fqdn(host)) {
+        return ret;
+    }
+
+    /* register a "transport" specifier (only in host files) */
+    if (!have_added_handler) {
+        have_added_handler = 1;
+        netsnmp_ds_register_config(ASN_OCTET_STR, "snmp", "transport",
+                                   NETSNMP_DS_LIBRARY_ID,
+                                   NETSNMP_DS_LIB_HOSTNAME);
+    }
+
+    /* read in the hosts/STRING.conf files */
+    snprintf(buf, sizeof(buf)-1, "hosts/%s", host);
+    buf[ sizeof(buf)-1 ] = 0;
+    file_names.fileHeader = buf;
+    file_names.start = read_config_get_handlers("snmp");
+    file_names.next = NULL;
+    DEBUGMSGTL(("tdomain", "checking for host specific config %s (%d)\n",
+                buf, when));
+    ret = read_config_files_of_type(when, &file_names);
+
+    /* read_config_files( PREMIB_CONFIG ), ensure non-host "snmp" files
+       reject "transport" */
+    if ( when == PREMIB_CONFIG ) {
+        have_added_handler = 0;
+        unregister_config_handler("snmp", "transport");
+    }
+
+    return ret;
+}
+
+int
+netsnmp_tdomain_host_configs_of_type(int when)
+{
+    const char *host = netsnmp_ds_get_string(NETSNMP_DS_LIBRARY_ID,
+                                             NETSNMP_DS_LIB_HOSTNAME);
+    return netsnmp_tdomain_host_config_of_type(when, host);
+}
+
+/*
  * Locate the appropriate transport domain and call the create function for
  * it.
  */
@@ -655,22 +720,10 @@ netsnmp_tdomain_transport_tspec(netsnmp_tdomain_spec *tspec)
     if (!netsnmp_ds_get_boolean(NETSNMP_DS_LIBRARY_ID,
                                 NETSNMP_DS_LIB_DONT_LOAD_HOST_FILES) &&
         netsnmp_is_fqdn(str)) {
-        static int have_added_handler = 0;
         char *newhost;
-        struct config_line *config_handlers;
-        struct config_files file_names;
         char *prev_hostname;
 
-        /* register a "transport" specifier */
-        if (!have_added_handler) {
-            have_added_handler = 1;
-            netsnmp_ds_register_config(ASN_OCTET_STR,
-                                       "snmp", "transport",
-                                       NETSNMP_DS_LIBRARY_ID,
-                                       NETSNMP_DS_LIB_HOSTNAME);
-        }
-
-        /* we save on specific setting that we don't allow to change
+        /* we save one specific setting that we don't allow to change
            from one transport creation to the next; ie, we don't want
            the "transport" specifier to be a default.  It should be a
            single invocation use only */
@@ -679,15 +732,9 @@ netsnmp_tdomain_transport_tspec(netsnmp_tdomain_spec *tspec)
         if (prev_hostname)
             prev_hostname = strdup(prev_hostname);
 
-        /* read in the hosts/STRING.conf files */
-        config_handlers = read_config_get_handlers("snmp");
-        snprintf(buf, sizeof(buf)-1, "hosts/%s", str);
-        file_names.fileHeader = buf;
-        file_names.start = config_handlers;
-        file_names.next = NULL;
-        DEBUGMSGTL(("tdomain", "checking for host specific config %s\n",
-                    buf));
-        read_config_files_of_type(EITHER_CONFIG, &file_names);
+        /* only parses host config if read_config_files() didn't
+           have <host> set */
+        (void)netsnmp_tdomain_host_config_of_type(EITHER_CONFIG, str);
 
         if (NULL !=
             (newhost = netsnmp_ds_get_string(NETSNMP_DS_LIBRARY_ID,


### PR DESCRIPTION
Currently, host config files are loaded too late for defVersion/defCommunity/mibs to have effect.  This patch updates snmp_parse_args (most apps) to load host config files in documented order so they can configure version/community (and mib) loading as documented in the man pages and wiki examples. Command line overrides (currenly just -Op) are now honored for host files.  Library use of the transport host config is unaffected.

As an example, currently a file .snmp/hosts/test.conf containing:
defVersion 1
defCommunity public

will cause `snmpget test sysDescr.0` to timeout for a v1-only host "test" since snmp v3 is chosen in snmp_parse_args long before the sess_open loads the host config.  Even if "defVersion 1" is added in snmp.conf,  the host config defCommunity  will not work as snmp_parse_args fails with "No community name specified." long before sess_open is called.

A similar problem affects per-host MIB loading specified in host config...

This patch adds a hook into read_config that loads host files in the documented order before mibs are loaded and session version/community are set.  The man pages (and wiki) have long documented that defVersion should work in host files (eg see HOST-SPECIFIC FILES in snmp.conf(5) ), but when trying to track down the patch that broke the feature, I think it might have been broken even in the initial 5.6 release.