### PR TITLE
mib2c-update: fix ls breakage introduced in a8cbc8db2e971990ad

### DIFF
--- a/local/mib2c-update
+++ b/local/mib2c-update
@@ -174,7 +174,7 @@ do_cp()
 save_diff()
 {
     echo "Creating patch for your custom code"
-    cnt=`ls ./"$UPDATE_CURR/"*"$UPDATE_OID"* 2>/dev/null | grep -E "(file|onf|m2d|txt|\.c|\.h)$" | wc -l`
+    cnt=`ls "$UPDATE_CURR/"*"$UPDATE_OID"* 2>/dev/null | grep -E "(file|onf|m2d|txt|\.c|\.h)$" | wc -l`
     if [ "$cnt" -eq 0 ]; then
         echo "   no custom code!"
         FIRST_RUN=1


### PR DESCRIPTION
$UPDATE_CURR is an absolute path, prepending ./ does not make sense