### PR TITLE
snmplib: add deallocation of container name

### DIFF
--- a/snmplib/container_binary_array.c
+++ b/snmplib/container_binary_array.c
@@ -205,6 +205,7 @@ netsnmp_binary_array_release(netsnmp_container *c)
     binary_array_table *t = (binary_array_table*)c->container_data;
     SNMP_FREE(t->data);
     SNMP_FREE(t);
+    SNMP_FREE(c->container_name);
     SNMP_FREE(c);
 }
 


### PR DESCRIPTION
The function netsnmp_binary_array_release() does not deallocate dynamic char array.
Closes https://github.com/net-snmp/net-snmp/pull/924