### PR TITLE
proxy:  Return when NETSNMP_CALLBACK_OP_RESEND is

### DIFF
--- a/agent/mibgroup/ucd-snmp/proxy.c
+++ b/agent/mibgroup/ucd-snmp/proxy.c
@@ -579,7 +579,10 @@ proxy_got_response(int operation, netsnmp_session * sess, int reqid,
         }
         netsnmp_free_delegated_cache(cache);
         return 0;
-
+    case NETSNMP_CALLBACK_OP_RESEND:
+	DEBUGMSGTL(("proxy", "resend on session %8p req=0x%x\n",
+                    sess, (unsigned)reqid));
+        return 0;
     case NETSNMP_CALLBACK_OP_RECEIVED_MESSAGE:
         vars = pdu->variables;
 


### PR DESCRIPTION
 set to the callback

we encounter the following crash:
    at ./nptl/pthread_kill.c:44
    at ./nptl/pthread_kill.c:78
    at ./nptl/pthread_kill.c:89
    at ../sysdeps/posix/raise.c:26
    fmt=fmt@entry=0x7f6e1a718b77 "%s\n") at ../sysdeps/posix/libc_fatal.c:155
    str=str@entry=0x7f6e1a716744 "free(): invalid pointer")
    at ./malloc/malloc.c:5664
    have_lock=0) at ./malloc/malloc.c:4439
    at ./malloc/malloc.c:3391
    dcache=dcache@entry=0x55781417b010) at agent_handler.c:934
    sess=<optimized out>, reqid=<optimized out>, pdu=0x5578141f21a0,
    cb_data=<optimized out>) at ucd-snmp/proxy.c:752
--Type <RET> for more, q to quit, c to continue without paging--
    orp=orp@entry=0x0, rp=rp@entry=0x5578141d1690, incr_retries=1)
    at snmp_api.c:6778
    at snmp_api.c:6851

snmpd is terminated abnormally due to the double free for the request cache after the request is resend.

That is because the callback for NETSNMP_CALLBACK_OP_RESEND isn't cared and the cache is freed wrongly.

Let's just return if NETSNMP_CALLBACK_OP_RESEND is set on the callback.