### PR TITLE
support openbsd8

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -25,7 +25,8 @@ INCLUDESUBDIRHEADERS= aix.h bsd.h bsdi3.h bsdi4.h bsdi.h cygwin.h \
 	generic.h \
 	hpux.h irix.h kfreebsd.h linux.h mingw32.h mingw32msvc.h mips.h \
 	netbsd.h nto-qnx6.h osf5.h \
-	openbsd.h openbsd6.h openbsd5.h openbsd4.h \
+	openbsd4.h openbsd5.h openbsd6.h openbsd7.h openbsd8.h \
+	openbsd.h \
 	solaris2.3.h solaris2.4.h solaris2.5.h solaris2.6.h \
 	solaris.h sunos.h svr5.h sysv.h ultrix4.h
 INCLUDESUBDIR2=machine

--- a/include/net-snmp/system/openbsd8.h
+++ b/include/net-snmp/system/openbsd8.h
@@ -1,0 +1,3 @@
+/* openbsd8 is a superset of all since openbsd3 */
+#include "openbsd7.h"
+#define openbsd7 openbsd7


### PR DESCRIPTION
Preemptive, but OpenBSD follows a roughly 6 month release schedule with a simple 0.1 increment each time and there are no plans to diverge from this, so this will be needed in the future. (No big hurry, development code just moved to using 7.7 for a release in a month or so, but seemed worth including as you're working on a release).