### PR TITLE
use correct filename when installing generic-get-in_addr_t.m2i

### DIFF
--- a/local/Makefile.in
+++ b/local/Makefile.in
@@ -36,7 +36,7 @@ MIB2CFILES=default-mfd-top.m2c details-enums.m2i details-node.m2i \
 	generic-ctx-set.m2i generic-data-allocate.m2i generic-data-context.m2i \
 	generic-get-char.m2i generic-get-decl-bot.m2i generic-get-decl.m2i \
 	generic-get-long.m2i generic-get-oid.m2i generic-get-U64.m2i \
-	generic-get-inaddr_t.m2i generic-header-bottom.m2i \
+	generic-get-in_addr_t.m2i generic-header-bottom.m2i \
 	generic-header-top.m2i generic-source-includes.m2i \
 	generic-table-constants.m2c generic-table-enums.m2c \
 	generic-table-indexes-from-oid.m2i generic-table-indexes-set.m2i \


### PR DESCRIPTION
d3a541a added local/mib2c-conf.d/generic-get-in_addr_t.m2i but the Makefile tries to install generic-get-inaddr_t.m2i resulting in "install: ./mib2c-conf.d/generic-get-inaddr_t.m2i: No such file or directory"