### PR TITLE
libsnmp: Do not truncate AGENT-CAPABILITIES descriptions

### DIFF
--- a/snmplib/parse.c
+++ b/snmplib/parse.c
@@ -2721,7 +2721,8 @@ parse_objecttype(FILE * fp, char *name)
             /*
              * Mark's defVal section 
              */
-            type = get_token(fp, quoted_string_buffer, MAXTOKEN);
+            type = get_token(fp, quoted_string_buffer,
+                             sizeof(quoted_string_buffer));
             if (type != LEFTBRACKET) {
                 print_error("Bad DEFAULTVALUE", quoted_string_buffer,
                             type);
@@ -2735,7 +2736,8 @@ parse_objecttype(FILE * fp, char *name)
 
                 defbuf[0] = 0;
                 while (1) {
-                    type = get_token(fp, quoted_string_buffer, MAXTOKEN);
+                    type = get_token(fp, quoted_string_buffer,
+                                     sizeof(quoted_string_buffer));
                     if ((type == RIGHTBRACKET && --level == 0)
                         || type == ENDOFFILE)
                         break;
@@ -3193,7 +3195,8 @@ parse_compliance(FILE * fp, char *name)
         np->description = strdup(quoted_string_buffer);
     type = get_token(fp, token, MAXTOKEN);
     if (type == REFERENCE) {
-        type = get_token(fp, quoted_string_buffer, MAXTOKEN);
+        type = get_token(fp, quoted_string_buffer,
+                         sizeof(quoted_string_buffer));
         if (type != QUOTESTRING) {
             print_error("Bad REFERENCE", quoted_string_buffer, type);
             goto skip;
@@ -3336,7 +3339,7 @@ parse_capabilities(FILE * fp, char *name)
         print_error("Expected DESCRIPTION", token, type);
         goto skip;
     }
-    type = get_token(fp, quoted_string_buffer, MAXTOKEN);
+    type = get_token(fp, quoted_string_buffer, sizeof(quoted_string_buffer));
     if (type != QUOTESTRING) {
         print_error("Bad DESCRIPTION", quoted_string_buffer, type);
         goto skip;
@@ -3347,7 +3350,8 @@ parse_capabilities(FILE * fp, char *name)
     }
     type = get_token(fp, token, MAXTOKEN);
     if (type == REFERENCE) {
-        type = get_token(fp, quoted_string_buffer, MAXTOKEN);
+        type = get_token(fp, quoted_string_buffer,
+                         sizeof(quoted_string_buffer));
         if (type != QUOTESTRING) {
             print_error("Bad REFERENCE", quoted_string_buffer, type);
             goto skip;
@@ -3469,7 +3473,8 @@ parse_capabilities(FILE * fp, char *name)
                 print_error("Expected DESCRIPTION", token, type);
                 goto skip;
             }
-            type = get_token(fp, quoted_string_buffer, MAXTOKEN);
+            type = get_token(fp, quoted_string_buffer,
+                             sizeof(quoted_string_buffer));
             if (type != QUOTESTRING) {
                 print_error("Bad DESCRIPTION", quoted_string_buffer, type);
                 goto skip;


### PR DESCRIPTION
backport from master