### PR TITLE
snmplib: scapi.c: fix unchecked function result

### DIFF
--- a/snmplib/scapi.c
+++ b/snmplib/scapi.c
@@ -1001,7 +1001,9 @@ sc_hash_type_quit:
         if (*MAC_len < MD5_DIGEST_LENGTH)
             return (SNMPERR_GENERR);      /* the buffer isn't big enough */
         MD5_Init(&cmd5);
-        MD5_Update(&cmd5, buf, buf_len);
+        ret = !MD5_Update(&cmd5, buf, buf_len);
+        if (ret != 0)
+            return SNMPERR_GENERR;
         MD5_Final(MAC, &cmd5);
         *MAC_len = MD5_DIGEST_LENGTH;
     } else 
@@ -1010,7 +1012,9 @@ sc_hash_type_quit:
         if (*MAC_len < SHA_DIGEST_LENGTH)
             return (SNMPERR_GENERR);      /* the buffer isn't big enough */
         SHA1_Init(&csha1);
-        SHA1_Update(&csha1, buf, buf_len);
+        ret = !SHA1_Update(&csha1, buf, buf_len);
+        if (ret != 0)
+            return SNMPERR_GENERR;
         SHA1_Final(MAC, &csha1);
         *MAC_len = SHA_DIGEST_LENGTH;
             


### PR DESCRIPTION
Checking the return values ​​of MD5_Update and SHA1_Update in the
sc_hash_type() function. In case of an error, returning SNMPERR_GENERR.

Previously, calls to these functions were not checked, which could lead to
undefined behavior in case of hash errors.

Triggers found by static analyzer Svace.

Signed-off-by: Anton Moryakov [ant.v.moryakov@gmail.com](mailto:ant.v.moryakov@gmail.com)