### PR TITLE
Perl: Do not crash on resend callbacks.

### DIFF
--- a/perl/SNMP/SNMP.xs
+++ b/perl/SNMP/SNMP.xs
@@ -1178,6 +1178,10 @@ __snmp_xs_cb(int op, netsnmp_session *ss, int reqid, netsnmp_pdu *pdu,
   SV **err_num_svp = hv_fetch((HV*)SvRV(sess_ref), "ErrorNum", 8, 1);
   SV **err_ind_svp = hv_fetch((HV*)SvRV(sess_ref), "ErrorInd", 8, 1);
 
+  /* These are purely informative; only act on the final callback. */
+  if (op == NETSNMP_CALLBACK_OP_RESEND)
+    return 1;
+
   ENTER;
   SAVETMPS;
 


### PR DESCRIPTION
Do not act on NETSNMP_CALLBACK_OP_RESEND messages, as they are not final (the callback assumes that we can free the callback struct and generally mutate it freely without ever seeing it again, causing double-frees on resends).

Possibly related to #955.