### PR TITLE
pingCtlTable.c: Avoid memory leak if strdup fails

### DIFF
--- a/agent/mibgroup/disman/ping/pingCtlTable.c
+++ b/agent/mibgroup/disman/ping/pingCtlTable.c
@@ -208,6 +208,7 @@ create_pingCtlTable_data(void)
     StorageNew->pingCtlAdminStatus = 2;
     StorageNew->pingCtlDataFill = strdup("00");
     if (StorageNew->pingCtlDataFill == NULL) {
+        free(StorageNew->pingCtlTargetAddress);
         free(StorageNew);
         return NULL;
     }


### PR DESCRIPTION
Avoid memory leak if strdup fails.
Fixes Coverity 454615