### PR TITLE
pingCtlTable.c: Avoid memory leak if an allocation fails

### DIFF
--- a/agent/mibgroup/disman/ping/pingCtlTable.c
+++ b/agent/mibgroup/disman/ping/pingCtlTable.c
@@ -241,6 +241,7 @@ create_pingCtlTable_data(void)
         StorageNew->pingCtlDescr == NULL ||
         StorageNew->pingCtlSourceAddress == NULL) {
         free(StorageNew->pingCtlTargetAddress);
+        free(StorageNew->pingCtlDataFill);
         free(StorageNew->pingCtlTrapGeneration);
         free(StorageNew->pingCtlType);
         free(StorageNew->pingCtlDescr);


### PR DESCRIPTION
Avoid memory leak if an allocation fails.
Fixes Coverity 454608