### PR TITLE
Fix warnings in V5 9 patches

### DIFF
--- a/configure
+++ b/configure
@@ -29999,9 +29999,75 @@ printf "%s\n" "#define HAVE_LIBSSL 1" >>confdefs.h
             TLSPROG=yes
         fi
         if echo " $transport_result_list " | $GREP " SSH " > /dev/null; then
-	    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for libssh2_session_startup in -lssh2" >&5
-printf %s "checking for libssh2_session_startup in -lssh2... " >&6; }
-if test ${ac_cv_lib_ssh2_libssh2_session_startup+y}
+	    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for library containing libssh2_session_handshake" >&5
+printf %s "checking for library containing libssh2_session_handshake... " >&6; }
+if test ${ac_cv_search_libssh2_session_handshake+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
+  ac_func_search_save_LIBS=$LIBS
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+char libssh2_session_handshake ();
+int
+main (void)
+{
+return libssh2_session_handshake ();
+  ;
+  return 0;
+}
+_ACEOF
+for ac_lib in '' ssh2
+do
+  if test -z "$ac_lib"; then
+    ac_res="none required"
+  else
+    ac_res=-l$ac_lib
+    LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
+  fi
+  if ac_fn_c_try_link "$LINENO"
+then :
+  ac_cv_search_libssh2_session_handshake=$ac_res
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam \
+    conftest$ac_exeext
+  if test ${ac_cv_search_libssh2_session_handshake+y}
+then :
+  break
+fi
+done
+if test ${ac_cv_search_libssh2_session_handshake+y}
+then :
+
+else $as_nop
+  ac_cv_search_libssh2_session_handshake=no
+fi
+rm conftest.$ac_ext
+LIBS=$ac_func_search_save_LIBS
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_libssh2_session_handshake" >&5
+printf "%s\n" "$ac_cv_search_libssh2_session_handshake" >&6; }
+ac_res=$ac_cv_search_libssh2_session_handshake
+if test "$ac_res" != no
+then :
+  test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
+
+fi
+
+	    ac_fn_c_check_func "$LINENO" "libssh2_session_handshake" "ac_cv_func_libssh2_session_handshake"
+if test "x$ac_cv_func_libssh2_session_handshake" = xyes
+then :
+  printf "%s\n" "#define HAVE_LIBSSH2_SESSION_HANDSHAKE 1" >>confdefs.h
+
+fi
+
+	    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for libssh2_session_init_ex in -lssh2" >&5
+printf %s "checking for libssh2_session_init_ex in -lssh2... " >&6; }
+if test ${ac_cv_lib_ssh2_libssh2_session_init_ex+y}
 then :
   printf %s "(cached) " >&6
 else $as_nop
@@ -30013,28 +30079,28 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* Override any GCC internal prototype to avoid an error.
    Use char because int might match the return type of a GCC
    builtin and then its argument prototype would still apply.  */
-char libssh2_session_startup ();
+char libssh2_session_init_ex ();
 int
 main (void)
 {
-return libssh2_session_startup ();
+return libssh2_session_init_ex ();
   ;
   return 0;
 }
 _ACEOF
 if ac_fn_c_try_link "$LINENO"
 then :
-  ac_cv_lib_ssh2_libssh2_session_startup=yes
+  ac_cv_lib_ssh2_libssh2_session_init_ex=yes
 else $as_nop
-  ac_cv_lib_ssh2_libssh2_session_startup=no
+  ac_cv_lib_ssh2_libssh2_session_init_ex=no
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.beam \
     conftest$ac_exeext conftest.$ac_ext
 LIBS=$ac_check_lib_save_LIBS
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_ssh2_libssh2_session_startup" >&5
-printf "%s\n" "$ac_cv_lib_ssh2_libssh2_session_startup" >&6; }
-if test "x$ac_cv_lib_ssh2_libssh2_session_startup" = xyes
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_ssh2_libssh2_session_init_ex" >&5
+printf "%s\n" "$ac_cv_lib_ssh2_libssh2_session_init_ex" >&6; }
+if test "x$ac_cv_lib_ssh2_libssh2_session_init_ex" = xyes
 then :
 
 printf "%s\n" "#define HAVE_LIBSSH2 1" >>confdefs.h

--- a/configure.d/config_os_libs2
+++ b/configure.d/config_os_libs2
@@ -532,7 +532,9 @@ if test "x$tryopenssl" != "xno" -a "x$tryopenssl" != "xinternal"; then
             TLSPROG=yes
         fi
         if echo " $transport_result_list " | $GREP " SSH " > /dev/null; then
-	    AC_CHECK_LIB(ssh2, libssh2_session_startup,
+	    AC_SEARCH_LIBS(libssh2_session_handshake, [ssh2])
+	    AC_CHECK_FUNCS(libssh2_session_handshake)
+	    AC_CHECK_LIB(ssh2, libssh2_session_init_ex,
                 AC_DEFINE(HAVE_LIBSSH2, 1,
                     [Define to 1 if you have the `ssh2' library (-lssh2).])
                 LIBCRYPTO=" -lssh2 $LIBCRYPTO",

--- a/include/net-snmp/net-snmp-config.h.in
+++ b/include/net-snmp/net-snmp-config.h.in
@@ -481,6 +481,9 @@
 /* Define to 1 if you have the `ssh2' library (-lssh2). */
 #undef HAVE_LIBSSH2
 
+/* Define to 1 if you have the `libssh2_session_handshake' function. */
+#undef HAVE_LIBSSH2_SESSION_HANDSHAKE
+
 /* Define to 1 if you have the `ssl' library. */
 #undef HAVE_LIBSSL
 

--- a/snmplib/transports/snmpSSHDomain.c
+++ b/snmplib/transports/snmpSSHDomain.c
@@ -731,8 +731,9 @@ netsnmp_ssh_transport(const struct sockaddr_in *addr, int local)
                     sshdomain_sock_group = -1;
                 DEBUGMSGTL(("ssh", "Setting socket user/group to %d/%d\n",
                             sshdomain_sock_user, sshdomain_sock_group));
-                chown(unaddr->sun_path,
-                      sshdomain_sock_user, sshdomain_sock_group);
+                if (chown(unaddr->sun_path,
+                          sshdomain_sock_user, sshdomain_sock_group) < 0)
+                    snmp_log_perror("SSH socket chown");
             }
         }
 
@@ -839,7 +840,11 @@ netsnmp_ssh_transport(const struct sockaddr_in *addr, int local)
 
         /* open the SSH session and channel */
         addr_pair->session = libssh2_session_init();
+#ifdef HAVE_LIBSSH2_SESSION_HANDSHAKE
+        if (libssh2_session_handshake(addr_pair->session, t->sock)) {
+#else
         if (libssh2_session_startup(addr_pair->session, t->sock)) {
+#endif
           shutdown:
             snmp_log(LOG_ERR, "Failed to establish an SSH session\n");
             netsnmp_ssh_close(t);

--- a/testing/fulltests/unit-tests/T001defaultstore_clib.c
+++ b/testing/fulltests/unit-tests/T001defaultstore_clib.c
@@ -11,7 +11,7 @@ for(i = 0; i < NETSNMP_DS_MAX_IDS; i++) {
             ("default store boolean: setting %d/%d returned failure", i, j));
         OKF(SNMPERR_SUCCESS == netsnmp_ds_set_int(i, j, i*j),
             ("default store int: setting %d/%d returned failure", i, j));
-        sprintf(buf,"%d/%d", i, j);
+        snprintf(buf, sizeof buf, "%d/%d", i, j);
         OKF(SNMPERR_SUCCESS == netsnmp_ds_set_string(i, j, buf),
             ("default store string: setting %d/%d returned failure", i, j));
     }
@@ -26,7 +26,7 @@ for(i = 0; i < NETSNMP_DS_MAX_IDS; i++) {
             ("default store boolean %d/%d was the expected value", i, j));
         OKF(netsnmp_ds_get_int(i, j) == (i*j),
             ("default store int %d/%d was the expected value", i, j));
-        sprintf(buf,"%d/%d", i, j);
+        snprintf(buf, sizeof buf, "%d/%d", i, j);
         OKF(strcmp(netsnmp_ds_get_string(i, j), buf) == 0,
             ("default store string %d/%d was the expected value", i, j));
     }

--- a/testing/fulltests/unit-tests/T004snmp_enum_clib.c
+++ b/testing/fulltests/unit-tests/T004snmp_enum_clib.c
@@ -32,7 +32,8 @@
 char tmp_persist_file[256];
 char *se_find_result;
 
-sprintf(tmp_persist_file, "/tmp/snmp-enum-unit-test-%ld", (long)getpid());
+snprintf(tmp_persist_file, sizeof tmp_persist_file,
+         "/tmp/snmp-enum-unit-test-%ld", (long)getpid());
 netsnmp_setenv("SNMP_PERSISTENT_FILE", tmp_persist_file, 1);
 
 init_snmp_enum("snmp");

--- a/testing/fulltests/unit-tests/T014gethostbyaddr_clib.c
+++ b/testing/fulltests/unit-tests/T014gethostbyaddr_clib.c
@@ -57,7 +57,7 @@ SOCK_STARTUP;
         if (bind(s, (struct sockaddr *) &sin6_addr, sizeof(sin6_addr)) >=
             0) {
             addr = NULL;
-            strcpy(buf, "(failed)");
+            strncpy(buf, "(failed)", sizeof buf);
             h = netsnmp_gethostbyaddr(&v6loop, sizeof(v6loop), AF_INET6);
             if (h) {
                 memset(&hints, 0, sizeof(hints));
@@ -74,7 +74,7 @@ SOCK_STARTUP;
                         }
                     }
                     if (!ap)
-                        strcpy(buf, "no AF_INET6 address found");
+                        strncpy(buf, "no AF_INET6 address found", sizeof buf);
                 } else {
                     snprintf(buf, sizeof(buf), "getaddrinfo() failed: %s",
                              strerror(errno));


### PR DESCRIPTION
libssh2 v1.2.8 deprecated libssh2_session_startup,
use libssh2_session_handshake when available.

Fix OpenBSD warning about strcpy, sprintf when runnoig tests.