### PR TITLE
snmpset: fix memory leak

### DIFF
--- a/apps/snmpset.c
+++ b/apps/snmpset.c
@@ -131,7 +131,8 @@ main(int argc, char *argv[])
 
     SOCK_STARTUP;
 
-    putenv(strdup("POSIXLY_CORRECT=1"));
+    const char *posix_env = strdup("POSIXLY_CORRECT=1");
+    putenv(posix_env);
 
     /*
      * get the common command line arguments 
@@ -283,6 +284,7 @@ close_session:
     snmp_close(ss);
 
 out:
+    free(posix_env);
     netsnmp_cleanup_session(&session);
     SOCK_CLEANUP;
     return exitval;


### PR DESCRIPTION
Small memory leak fixed when allocating a char* with strdup. The memory is now correctly freed before closing.

I know it is very small and that snmpset binary memory is anyway freed after execution but there are teams using snmpset.c code as a guide to implement snmp set operations in their applications with net-snmp library, and this memory leak could be copied.