### PR TITLE
win32: add build support for Windows on ARM

### DIFF
--- a/win32/build.pl
+++ b/win32/build.pl
@@ -14,13 +14,13 @@ use constant true => 1;
 my $target_arch = $ENV{TARGET_CPU} ? $ENV{TARGET_CPU} : $ENV{Platform} ?
                   $ENV{Platform} : "x86";
 $target_arch = lc $target_arch;
-if ($target_arch ne "x86" && $target_arch ne "x64") {
+if ($target_arch ne "x86" && $target_arch ne "x64" && $target_arch ne "arm64") {
     print "Error: unsupported target architecture $target_arch\n";
     die;
 }
 my @perl_arch = split(/-/, $Config{archname});
 my $openssl = false;
-my $default_openssldir = $target_arch eq "x64" ?
+my $default_openssldir = $target_arch eq "x64" || $target_arch eq "arm64" ?
     "C:\\OpenSSL-Win64" : "C:\\OpenSSL-Win32";
 my $default_opensslincdir = $default_openssldir . "\\include";
 my $opensslincdir = $default_opensslincdir;

--- a/win32/net-snmp/net-snmp-config.h
+++ b/win32/net-snmp/net-snmp-config.h
@@ -1143,7 +1143,7 @@
 
 #if defined(_M_PPC) || defined(_M_MPPC)
 # define NETSNMP_BIGENDIAN 1
-#elif defined(_M_IX86) || defined(_M_X64)
+#elif defined(_M_IX86) || defined(_M_X64) || defined(_M_ARM64)
 # define NETSNMP_BIGENDIAN 0
 #else
 #  error Unknown byte order

--- a/win32/net-snmp/net-snmp-config.h.in
+++ b/win32/net-snmp/net-snmp-config.h.in
@@ -1143,7 +1143,7 @@
 
 #if defined(_M_PPC) || defined(_M_MPPC)
 # define NETSNMP_BIGENDIAN 1
-#elif defined(_M_IX86) || defined(_M_X64)
+#elif defined(_M_IX86) || defined(_M_X64) || defined(_M_ARM64)
 # define NETSNMP_BIGENDIAN 0
 #else
 #  error Unknown byte order


### PR DESCRIPTION
I was able to produce a successful build without trouble on my Windows 11 ARM64 + MSVC 2022.