### PR TITLE
loadave.c: fix out-of-bounds access in loadave_parse_config

### DIFF
--- a/agent/mibgroup/ucd-snmp/loadave.c
+++ b/agent/mibgroup/ucd-snmp/loadave.c
@@ -235,7 +235,10 @@ loadave_parse_config(const char *token, char *cptr)
         if (cptr != NULL)
             maxload[i] = atof(cptr);
         else
-            maxload[i] = maxload[i - 1];
+            if (i > 0)
+                maxload[i] = maxload[i - 1];
+            else
+                maxload[i] = NETSNMP_DEFMAXLOADAVE;
         cptr = skip_not_white(cptr);
         cptr = skip_white(cptr);
     }


### PR DESCRIPTION
Static analysis reported a potential buffer overflow when accessing maxload[i - 1] for i = 0.

The issue was fixed by:
- Adding a check to ensure i > 0 before accessing maxload[i - 1]
- Using NETSNMP_DEFMAXLOADAVE as a default value for the first element (i == 0)
- Ensuring that the code does not attempt to access memory outside of the maxload array

This change makes the code more robust and avoids undefined behavior.

Signed-off-by: Anton Moryakov <ant.v.moryakov@gmail.com>