### PR TITLE
build/freebsd: add FreeBSD 16 system header

### DIFF
--- a/include/net-snmp/system/freebsd16.h
+++ b/include/net-snmp/system/freebsd16.h
@@ -1,0 +1,3 @@
+/* freebsd16 is a superset of freebsd15 */
+#include "freebsd15.h"
+#define freebsd15 freebsd15


### PR DESCRIPTION
- Add include/net-snmp/system/freebsd16.h (currently inherits freebsd15.h).
- Matches existing pattern for FreeBSD 10–15 headers.

This prepares for FreeBSD 16 while keeping current behavior unchanged.

The patch originated from this FreeBSD PR: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=289351

Signed-off-by: Generic Rikka <rikka.goering@outlook.de>
Tested on: FreeBSD 16-CURRENT