### PR TITLE
Hack-ish mods to enable build and install in Msys2/MINGW64 system

### DIFF
--- a/agent/mibgroup/util_funcs.c
+++ b/agent/mibgroup/util_funcs.c
@@ -16,6 +16,12 @@
 #include <net-snmp/net-snmp-config.h>
 #include <net-snmp/net-snmp-features.h>
 
+#if defined(WIN32) || defined(_WIN32)
+#ifndef NETSNMP_TIMEOUT_WAITFORSINGLEOBJECT
+#define NETSNMP_TIMEOUT_WAITFORSINGLEOBJECT 5000
+#endif
+#endif
+
 #include <sys/types.h>
 #ifdef HAVE_IO_H
 #include <io.h>

--- a/apps/snmpping.c
+++ b/apps/snmpping.c
@@ -632,7 +632,11 @@ int main(int argc, char **argv)
         username[32] = '\0';
         usernameLen = strlen(username); /* TODO session.securityNameLen */
     } else {
+#if defined(WIN32) || defined(_WIN32)
+	strncpy(username, getenv("USERNAME") ? getenv("USERNAME") : "unknown", sizeof(username) - 1);
+#else
         strncpy(username, getlogin(), sizeof(username) - 1);
+#endif
         username[32] = '\0';
         usernameLen = strlen(username);
     }

--- a/snmplib/parse.c
+++ b/snmplib/parse.c
@@ -4985,6 +4985,11 @@ static int elemcmp(const void *a, const void *b)
     return strcmp(*s1, *s2);
 }
 
+
+#ifdef WIN32
+#include <dirent.h>
+#endif
+
 /*
  * Scan a directory and return all filenames found as an array of pointers to
  * directory entries (@result).

--- a/snmplib/transports/snmpIPv6BaseDomain.c
+++ b/snmplib/transports/snmpIPv6BaseDomain.c
@@ -62,11 +62,17 @@
 #define IF_NAMESIZE 12
 #endif
 
+#if defined(WIN32) || defined(_WIN32)
+/* Don't redefine - use system definition */
+#else
+static const struct in6_addr in6addr_any;
+#endif
 
+#if 0
 #if defined(HAVE_WINSOCK_H) && !defined(mingw32)
 static const struct in6_addr in6addr_any; /*IN6ADDR_ANY_INIT*/
 #endif
-
+#endif
 
 #ifdef HAVE_STRUCT_SOCKADDR_IN6_SIN6_SCOPE_ID
 static unsigned

--- a/snmplib/winservice.c
+++ b/snmplib/winservice.c
@@ -23,12 +23,18 @@ labelFIN:                                       \
 
 #else
 
+#if defined(__MINGW32__) || defined(__MINGW64__)
+/* MinGW doesn't support __try/__except, so disable SEH */
+#define TRY if(1)
+#define FINALLY if(1)
+#define CATCH if(0)
+#define LEAVE do {} while(0)
+#else
 #define TRY __try
-#define LEAVE __leave
 #define FINALLY __finally
-
-#endif                          /* mingw32 */
-
+#define CATCH __except(EXCEPTION_EXECUTE_HANDLER)
+#define LEAVE __leave
+#endif
 
 #if defined(WIN32) && defined(HAVE_WIN32_PLATFORM_SDK) && !defined(mingw32)
 #pragma comment(lib, "iphlpapi.lib")
@@ -37,6 +43,7 @@ labelFIN:                                       \
 #ifdef USING_WINEXTDLL_MODULE
 #pragma comment(lib, "snmpapi.lib")
 #pragma comment(lib, "mgmtapi.lib")
+#endif
 #endif
 #endif
 


### PR DESCRIPTION
I used Claude.ai to guide me through making changes to net-snmp source code in order to be able to compile and install the applications that otherwise was causing compilation errors. I would not describe the resulting code as pretty in any way. After patching the souce code, I was able to complete the build by the following invocations:n

./configure --prefix=/mingw64 --with-openssl --enable-shared --without-perl-modules --disable-embedded-perl --enable-ipv6 CPPFLAGS="-I/mingw64/include -DHAVE_WINSOCK2_H -DHAVE_DIRENT_H" LIBS=""
make CFLAGS="-include dirent.h"
make install

