### PR TITLE
snmpset/agentxtrap: fix memory leaks

### DIFF
--- a/apps/agentxtrap.c
+++ b/apps/agentxtrap.c
@@ -427,6 +427,7 @@ main(int argc, char *argv[])
     char           *prognam;
     char           *cp = NULL;
     const char     *sysUpTime = NULL;
+    char           *posix_env;
 
     /* initialize tcpip, if necessary */
     SOCK_STARTUP;
@@ -437,7 +438,8 @@ main(int argc, char *argv[])
     else
         prognam = argv[0];
 
-    putenv(strdup("POSIXLY_CORRECT=1"));
+    posix_env = strdup("POSIXLY_CORRECT=1");
+    putenv(posix_env);
 
     netsnmp_ds_set_boolean(NETSNMP_DS_LIBRARY_ID,
                            NETSNMP_DS_LIB_DISABLE_PERSISTENT_LOAD, 1);
@@ -605,6 +607,7 @@ main(int argc, char *argv[])
     snmp_shutdown(NETSNMP_APPLICATION_CONFIG_TYPE);
 
 out:
+    free(posix_env);
     SOCK_CLEANUP;
     return result;
 }

--- a/apps/snmptrap.c
+++ b/apps/snmptrap.c
@@ -132,6 +132,7 @@ main(int argc, char *argv[])
     char           *specific = NULL, *description = NULL, *agent = NULL;
     in_addr_t      *pdu_in_addr_t;
 #endif
+    char           *posix_env;
 
     SOCK_STARTUP;
 
@@ -141,7 +142,8 @@ main(int argc, char *argv[])
     else
         prognam = argv[0];
 
-    putenv(strdup("POSIXLY_CORRECT=1"));
+    posix_env = strdup("POSIXLY_CORRECT=1");
+    putenv(posix_env);
 
     if (strcmp(prognam, "snmpinform") == 0)
         inform = 1;
@@ -381,6 +383,7 @@ close_session:
     snmp_shutdown(NETSNMP_APPLICATION_CONFIG_TYPE);
 
 out:
+    free(posix_env);
     netsnmp_cleanup_session(&session);
     SOCK_CLEANUP;
     return exitval;


### PR DESCRIPTION
The valgrind tool detected  memory leaks when snmpset/agentxtrap allocated a char* with strdup. These memories should be freed before the program exits.