### PR TITLE
snmp_agent.c: Fix crash caused by buf being a null pointer

### DIFF
--- a/agent/snmp_agent.c
+++ b/agent/snmp_agent.c
@@ -1470,16 +1470,16 @@ init_master_agent(void)
 
     if (cptr) {
         buf = strdup(cptr);
-        if (!buf) {
-            snmp_log(LOG_ERR,
-                     "Error processing transport \"%s\"\n", cptr);
-            return 1;
-        }
     } else {
         /*
          * No, so just specify the default port.  
          */
         buf = strdup("");
+    }
+    if (!buf) {
+        snmp_log(LOG_ERR,
+                    "Error processing transport \"%s\"\n", cptr ? cptr : "default");
+        return 1;
     }
 
     DEBUGMSGTL(("snmp_agent", "final port spec: \"%s\"\n", buf));


### PR DESCRIPTION
If buf = strdup("") failed, then the buf is NULL. When using DEBUGMSGTL to print logs, passing buf as a string parameter when buf is NULL can cause undefined behavior  (typically causing program crash).