### PR TITLE
Fix null pointer dereference in debug output

### DIFF
--- a/snmplib/asn1.c
+++ b/snmplib/asn1.c
@@ -3411,6 +3411,9 @@ asn_realloc_rbuild_bitstring(u_char ** pkt, size_t * pkt_len,
     static const char *errpre = "build bitstring";
     size_t          start_offset = *offset;
 
+    if (str == NULL && strlength != 0) 
+        return 0;
+
     while ((*pkt_len - *offset) < strlength) {
         if (!(r && asn_realloc(pkt, pkt_len))) {
             return 0;


### PR DESCRIPTION
Static analysis reported a possible null pointer dereference in asn_realloc_rbuild_string.

The issue occurs when 'str' is NULL but 'strlength > 0': the pointer is passed to sprint_realloc_asciistring inside a debug block without prior null check, leading to dereference at mib.c:409.

Corrected by adding a null check before calling
sprint_realloc_asciistring, ensuring it is only
invoked when 'str != NULL'.

Triggers found by static analyzer Svace.

Signed-off-by: Anton Moryakov <ant.v.moryakov@gmail.com>