### PR TITLE
fix prevent buffer overflow in hrSWRunParameters assignment

### DIFF
--- a/agent/mibgroup/host/data_access/swrun_procfs_status.c
+++ b/agent/mibgroup/host/data_access/swrun_procfs_status.c
@@ -146,7 +146,8 @@ netsnmp_arch_swrun_container_load( netsnmp_container *container, u_int flags)
                             *cp = ' ';
 
             entry->hrSWRunParameters_len
-                = sprintf(entry->hrSWRunParameters, "%.*s",
+                = snprintf(entry->hrSWRunParameters,
+                          sizeof(entry->hrSWRunParameters), "%.*s",
                           (int)sizeof(entry->hrSWRunParameters) - 1,
                           buf + ret + 1);
         } else {


### PR DESCRIPTION
Static analysis reported a potential buffer overflow in netsnmp_arch_swrun_container_load.

The issue occurs when using snprintf with a
tainted source (process cmdline data) and
improper size handling. Although the format
'%.*s' limits string width, the destination
buffer hrSWRunParameters (size 129) was not
safely bounded by the function call itself,
risking overflow if bounds calculation is
incorrect or bypassed.

Corrected by ensuring safe use of snprintf
with explicit buffer size and proper field
width limit. The call now uses
sizeof(entry->hrSWRunParameters) as the
output bound, while retaining the precision
limit to cap string length at 128 characters,
preventing any out-of-bounds write.

Triggers found by static analyzer Svace.

Signed-off-by: Anton Moryakov <ant.v.moryakov@gmail.com>