### PR TITLE
fix prevent buffer overflow in ASN_OCTET_STR index allocation

### DIFF
--- a/agent/agent_index.c
+++ b/agent/agent_index.c
@@ -346,21 +346,33 @@ register_index(netsnmp_variable_list * varbind, int flags,
             break;
         case ASN_OCTET_STR:
             if (prev_idx_ptr) {
+                size_t maxlen = sizeof(new_index->varbind->buf);
                 i = new_index->varbind->val_len - 1;
-                while (new_index->varbind->buf[i] == 'z') {
+
+                while (i >= 0 && new_index->varbind->buf[i] == 'z') {
                     new_index->varbind->buf[i] = 'a';
                     i--;
-                    if (i < 0) {
-                        i = new_index->varbind->val_len;
-                        new_index->varbind->buf[i] = 'a';
-                        new_index->varbind->buf[i + 1] = 0;
+                }
+
+                if (i >= 0) {
+                    new_index->varbind->buf[i]++;
+                } else {
+                    /* All 'z's — need to grow */
+                    if (new_index->varbind->val_len + 1 < maxlen) {
+                        memmove(new_index->varbind->buf + 1, new_index->varbind->buf,
+                                new_index->varbind->val_len);
+                        new_index->varbind->buf[0] = 'a';
+                        new_index->varbind->val_len++;
+                    } else {
+                        /* Buffer full — cannot grow */
+                        free(new_index);
+                        return NULL;
                     }
                 }
-                new_index->varbind->buf[i]++;
-            } else
+            } else {
                 strcpy((char *) new_index->varbind->buf, "aaaa");
-            new_index->varbind->val_len =
-                strlen((char *) new_index->varbind->buf);
+                new_index->varbind->val_len = 4;
+            }
             break;
         case ASN_OBJECT_ID:
             if (prev_idx_ptr) {


### PR DESCRIPTION
In register_index(), when generating sequential string indices from 'prev_idx_ptr', the code used a flawed algorithm that could lead to buffer overflow by writing beyond the end of new_index->varbind->buf.

The loop condition relied on buf[i] without proper bounds checking, and the fallback logic for growing the string wrote to buf[i+1] without validating available space.

Rewrite the octet string increment logic to:
- Properly check array bounds using i >= 0
- Use memmove to shift string left when growing
- Validate buffer capacity before extending
- Update val_len correctly

Now returns NULL if buffer is full, preventing memor

Signed-off-by: Anton Moryakov <ant.v.moryakov@gmail.com>
