### PR TITLE
Fix memory corruption in agentx_got_response

### DIFF
--- a/include/net-snmp/session_api.h
+++ b/include/net-snmp/session_api.h
@@ -102,6 +102,28 @@ extern          "C" {
 
 
     /*
+     * int snmp_async_send_cp(session, pdu, callback, cb_data, cp_inc)
+     *     netsnmp_session *session;
+     *     netsnmp_pdu      *pdu;
+     *     netsnmp_callback callback;
+     *     void             *cb_data;
+     *     int              cp_inc;
+     *
+     * Sends the input pdu on the session after calling snmp_build to create
+     * a serialized packet.  If necessary, set some of the pdu data from the
+     * session defaults.  Add a request corresponding to this pdu to the list
+     * of outstanding requests on this session and store callback and data,
+     * then send the pdu.
+     * Returns the request id of the generated packet if applicable, otherwise 1.
+     * On any error, 0 is returned.
+     * The pdu is freed by snmp_send() unless a failure occured.
+     */
+    NETSNMP_IMPORT
+    int             snmp_async_send_cp(netsnmp_session *, netsnmp_pdu *,
+                                       netsnmp_callback, void *, int);
+
+
+    /*
      * void snmp_read(fdset)
      *     fd_set  *fdset;
      *
@@ -248,6 +270,9 @@ extern          "C" {
     NETSNMP_IMPORT
     int             snmp_sess_async_send(struct session_list *, netsnmp_pdu *,
                                          netsnmp_callback, void *);
+    NETSNMP_IMPORT
+    int             snmp_sess_async_send_cp(struct session_list *, netsnmp_pdu *,
+                                            netsnmp_callback, void *, int); 
     NETSNMP_IMPORT
     int             snmp_sess_select_info(struct session_list *, int *, fd_set *,
                                           struct timeval *, int *);

--- a/include/net-snmp/types.h
+++ b/include/net-snmp/types.h
@@ -445,6 +445,11 @@ typedef struct netsnmp_ref_void_s {
     void           *val;
 } netsnmp_ref_void;
 
+typedef struct netsnmp_refcnt_void {
+    size_t         refcnt;
+    void           *val;
+} netsnmp_refcnt_void;
+
 typedef union {
     u_long          ul;
     u_int           ui;


### PR DESCRIPTION
we encounter the following crash (onfield)

(gdb) bt
    at ./nptl/pthread_kill.c:44
    at ./nptl/pthread_kill.c:78
    at ./nptl/pthread_kill.c:89
    at ../sysdeps/posix/raise.c:26
    fmt=fmt@entry=0x7e22cf9dbb77 "%s\n") at ../sysdeps/posix/libc_fatal.c:156
    str=str@entry=0x7e22cf9de7b0 "double free or corruption (!prev)")
    at ./malloc/malloc.c:5664
    p=0x56fc941985c0, have_lock=<optimized out>) at ./malloc/malloc.c:4591
    at ./malloc/malloc.c:3391
    dcache=dcache@entry=0x56fc941985d0) at agent_handler.c:934
    session=0x56fc941a5240, reqid=<optimized out>, pdu=<optimized out>,
    magic=0x56fc941985d0) at mibgroup/agentx/master.c:220
--Type <RET> for more, q to quit, c to continue without paging--
    at snmp_api.c:1984
    numfds=0x7fff49e28ee4, fdset=0x7fff49e28f00, timeout=0x7fff49e28ef0,
    block=0x7fff49e28eec, flags=0) at snmp_api.c:6580

in "agentx_got_response" delegated_cache is no more valid and freeing it encounter following error "double free or corruption (!prev)".

memory inspection shows that delegated_cache had been freed and replace by another variable of another type.

thus a copy of that pointer exists and a free occured on it.

Fix: add a refcount in delegated_cache, and increase it when a copy occurs.
     separates the contents from the container by creating a box which has
     a refcount. This ensures that the container is freed when the refcount
     reaches 0.