### PR TITLE
agent: Added NULL check for handlerName when it is assigend by strdup()

### DIFF
--- a/agent/agent_handler.c
+++ b/agent/agent_handler.c
@@ -189,8 +189,13 @@ netsnmp_handler_registration_create(const char *name,
 
     the_reg->handler = handler;
     the_reg->priority = DEFAULT_MIB_PRIORITY;
-    if (name)
+    if (name) {
         the_reg->handlerName = strdup(name);
+        if (NULL == the_reg->handlerName) {
+            SNMP_FREE(the_reg);
+            return NULL;
+        }
+    }
     the_reg->rootoid = snmp_duplicate_objid(reg_oid, reg_oid_len);
     the_reg->rootoid_len = reg_oid_len;
     return the_reg;


### PR DESCRIPTION
In the function responsible for creating SNMP handler registrations, the handlerName field was assigned directly using strdup(name) without verifying if the memory allocation succeeded. If strdup() fails (returns NULL), the code would proceed with an invalid pointer in the_reg->handlerName. This could lead to undefined behavior, such as segmentation faults.