### PR TITLE
Implement force option for net-snmp-create-v3-user

### DIFF
--- a/man/net-snmp-create-v3-user.1.def
+++ b/man/net-snmp-create-v3-user.1.def
@@ -15,6 +15,11 @@ new user in the net-snmp configuration file (/var/net-snmp/snmpd.conf by default
 \fB\-\-version\fR
 displays the net-snmp version number
 .TP
+\fB\-f\fR
+create a user without checking for running snmpd daemons
+
+if snmpd is still running with \fB\-f\fR set, user creation will fail silently
+.TP
 \fB\-ro\fR
 create a user with read-only permissions
 .TP

--- a/net-snmp-create-v3-user.in
+++ b/net-snmp-create-v3-user.in
@@ -3,12 +3,6 @@
 # this shell script is designed to add new SNMPv3 users
 # to Net-SNMP config file.
 
-if @PSCMD@ | @EGREP@ ' snmpd *$' > /dev/null 2>&1 ; then
-    echo "Apparently at least one snmpd daemon is already running."
-    echo "You must stop them in order to use this command."
-    exit 1
-fi
-
 Aalgorithm="MD5"
 Xalgorithm="DES"
 token=rwuser
@@ -25,6 +19,10 @@ case $1 in
       usage="yes"
       ;;
 
+    -f)
+      force="yes"
+      shift
+      ;;
     -A|-a)
 	shift
 	if test "x$1" = "x" ; then
@@ -85,10 +83,19 @@ done
 if test "x$usage" = "xyes"; then
     echo ""
     echo "Usage:"
-    echo "  net-snmp-create-v3-user [-ro] [-A authpass] [-X privpass]"
+    echo "  net-snmp-create-v3-user [-f] [-ro] [-A authpass] [-X privpass]"
     echo "                          [-a MD5|SHA|SHA-512|SHA-384|SHA-256|SHA-224] [-x DES|AES|AES128] [username]"
     echo ""
     exit
+fi
+
+if @PSCMD@ | @EGREP@ ' snmpd *$' > /dev/null 2>&1 ; then
+	if test "x$force" != "xyes"; then
+		echo "Apparently at least one snmpd daemon is already running."
+		echo "You must stop them in order to use this command."
+		exit 1
+	fi
+    echo "Force set, ignoring running snmpd daemon(s)."
 fi
 
 if test "x$1" = "x" ; then


### PR DESCRIPTION
In some environments (e.g. Kubernetes) snmpd may be falsely detected as running when the process in question is actually confined within a container.

In these deployments, stopping all snmpd processes is not always feasible as doing so could require terminating containers owned by other cluster users.

This means that I'm unable to create users with the helper script on the container host.

This change introduces a new command-line option (-f) to force user creation, bypassing the check.