### PR TITLE
snmplib/snmp_parse_args.c: Add null-check for strdup of hostname in argument parsing

### DIFF
--- a/snmplib/snmp_parse_args.c
+++ b/snmplib/snmp_parse_args.c
@@ -640,6 +640,12 @@ netsnmp_parse_args(int argc,
         goto out;
     }
     session->peername = strdup(argv[optind++]); /* hostname */
+    if (session->peername == NULL) {
+        snmp_log(LOG_ERR, "strdup hostname failed - out of memory.\n");
+        fprintf(stderr, "strdup hostname failed - out of memory.\n");
+        ret = NETSNMP_PARSE_ARGS_ERROR;
+        goto out;
+    }
 
 #if !defined(NETSNMP_DISABLE_SNMPV1) || !defined(NETSNMP_DISABLE_SNMPV2C)
     /*


### PR DESCRIPTION
It is crucial to return an error upon failing to resolve the hostname to prevent the program from subsequently dereferencing a null pointer and causing unexpected errors.