### PR TITLE
agent: mibgroup: util_funcs.c: prevent buffer overflow in cachefile path construction

### DIFF
--- a/agent/mibgroup/util_funcs.c
+++ b/agent/mibgroup/util_funcs.c
@@ -271,7 +271,7 @@ get_exec_output(struct extensible *ex)
 
     DEBUGMSGTL(("exec:get_exec_output","calling %s\n", ex->command));
 
-    sprintf(cachefile, "%s/%s", get_persistent_directory(), NETSNMP_CACHEFILE);
+    snprintf(cachefile, sizeof cachefile, "%s/%s", get_persistent_directory(), NETSNMP_CACHEFILE);
 #ifdef NETSNMP_EXCACHETIME
     curtime = time(NULL);
     if (curtime > (cachetime + NETSNMP_EXCACHETIME) ||


### PR DESCRIPTION

Replace unsafe sprintf() with snprintf() when constructing cache file path to prevent potential buffer overflow. The get_persistent_directory() function may return user-controlled paths (via SNMP_PERSISTENT_DIR environment variable) of arbitrary length, which could exceed the fixed STRMAX (1024) buffer size when combined with NETSNMP_CACHEFILE suffix.

The vulnerability existed in get_exec_output() function where:
  sprintf(cachefile, "%s/%s", get_persistent_directory(), NETSNMP_CACHEFILE);

This change uses snprintf() with explicit buffer size to guarantee safe termination within allocated bounds, aligning with CERT C STR07-C and project's existing safe string handling practices (e.g., strlcpy usage).

Signed-off-by: Anton Moryakov <ant.v.moryakov@gmail.com>
