### PR TITLE
agent: mibgroup: if-mib: data_access: interface_linux.c: prevent out-of-bounds array access in MII speed detection

### DIFF
--- a/agent/mibgroup/if-mib/data_access/interface_linux.c
+++ b/agent/mibgroup/if-mib/data_access/interface_linux.c
@@ -998,8 +998,9 @@ netsnmp_linux_interface_get_if_speed(int fd, const char *name,
         int max_capability = 0;
         /* Scan for the highest negotiated capability, highest priority
            (100baseTx-FDX) to lowest (10baseT-HDX). */
-        int media_priority[] = {8, 9, 7, 6, 5}; 	/* media_names[i-5] */
-        for (i = 0; media_priority[i]; i++){
+        int media_priority[] = {8, 9, 7, 6, 5};
+        int num_priorities = sizeof(media_priority) / sizeof(media_priority[0]);
+        for (i = 0; i < num_priorities; i++)
             if (negotiated & (1 << media_priority[i])) {
                 max_capability = media_priority[i];
                 break;


### PR DESCRIPTION
The loop condition in netsnmp_linux_interface_get_if_speed_mii() relied on array element value (media_priority[i]) as termination condition without ensuring array bounds. The media_priority[] array lacked a terminating zero, causing potential out-of-bounds reads when i reached 5 (array size = 5).

This could lead to:
- Undefined behavior from reading uninitialized memory
- Potential infinite loops if no zero byte encountered
- Security vulnerabilities in constrained environments

Fixed by replacing value-based termination with explicit bounds check using compile-time array size calculation. Added 'static const' qualifier to emphasize immutability of the priority table.

Signed-off-by: Anton Moryakov <ant.v.moryakov@gmail.com>