### PR TITLE
FreeBSD jail support: fix snmpd running check in net-snmp-create-v3-user

### DIFF
--- a/configure.d/config_os_misc4
+++ b/configure.d/config_os_misc4
@@ -111,6 +111,22 @@ AC_CACHE_CHECK([for correct flags to ps],
      ac_cv_ps_flags,
      [
 case "x$PARTIALTARGETOS" in
+    xfreebsd*)
+	ac_cv_ps_flags=""
+	for args in -e -el acx -acx "-o pid,tt,state,time,ucomm" ax; do
+	    if test "`($PSPROG $args 2>&1) | $EGREP ' (ps) *$' | awk '{print $NF}'`" = "ps"; then
+		ac_cv_ps_flags=$args
+		break
+	    fi
+	done
+	if test "x${ac_cv_ps_flags}" = x; then
+	    AC_MSG_WARN([Unable to determine valid ps flags...  defaulting...])
+	    ac_cv_ps_flags="-acx"
+	fi
+	if $PSPROG $ac_cv_ps_flags -J 0 >/dev/null 2>&1; then
+	    ac_cv_ps_flags="$ac_cv_ps_flags -J 0"
+	fi
+	;;
     xcygwin|xmingw32*)
 	ac_cv_ps_flags="-e";;
     *)
@@ -124,8 +140,6 @@ case "x$PARTIALTARGETOS" in
 	if test "x${ac_cv_ps_flags}" = x; then
 	    AC_MSG_WARN([Unable to determine valid ps flags...  defaulting...])
 	    ac_cv_ps_flags="-acx"
-	elif $PSPROG $ac_cv_ps_flags -J 0 >/dev/null 2>&1; then
-	    ac_cv_ps_flags="$ac_cv_ps_flags -J 0"
 	fi
 	;;
 esac


### PR DESCRIPTION
`net-snmp-create-v3-user` refuses to run if `snmpd` is already running. On FreeBSD in jail environments, the current `ps` invocation may not list the expected processes, allowing the script to proceed when it shouldn’t (or vice versa, depending on how `@PSCMD@` is defined).
FreeBSD` ps` supports -J to select a jail ID; `-J 0` makes the check work reliably in jail setups.
This patch adds `-J 0` for FreeBSD only and keeps behavior unchanged on other OSes.

This change originates from the FreeBSD ports tree, where it is used to improve compatibility in jail-based deployments.