### PR TITLE
agent: auto_nlist.c: check return value of malloc() calls

### DIFF
--- a/agent/auto_nlist.c
+++ b/agent/auto_nlist.c
@@ -52,16 +52,33 @@ auto_nlist_value(const char *string)
     }
     if (*ptr == 0) {
         *ptr = (struct autonlist *) malloc(sizeof(struct autonlist));
+        if (*ptr == NULL) {
+            snmp_log(LOG_ERR, "auto_nlist: malloc failed\n");
+            return 0;
+        }
         memset(*ptr, 0, sizeof(struct autonlist));
         it = *ptr;
         it->left = 0;
         it->right = 0;
         it->symbol = (char *) malloc(strlen(string) + 1);
+        if (it->symbol == NULL) {
+            snmp_log(LOG_ERR, "auto_nlist: malloc failed\n");
+            free(*ptr);
+            *ptr = NULL;
+            return 0;
+        }
         strcpy(it->symbol, string);
         /*
-         * allocate an extra byte for inclusion of a preceding '_' later 
+         * allocate an extra byte for inclusion of a preceding '_' later
          */
         it->nl[0].n_name = (char *) malloc(strlen(string) + 2);
+        if (it->nl[0].n_name == NULL) {
+            snmp_log(LOG_ERR, "auto_nlist: malloc failed\n");
+            free(it->symbol);
+            free(*ptr);
+            *ptr = NULL;
+            return 0;
+        }
 #if defined(aix4) || defined(aix5) || defined(aix6) || defined(aix7)
         strcpy(it->nl[0].n_name, string);
         it->nl[0].n_name[strlen(string)+1] = '\0';


### PR DESCRIPTION
## Summary

Three `malloc()` calls in `auto_nlist_value()` lacked NULL checks, causing immediate NULL pointer dereferences if memory allocation fails:

- The `autonlist` node allocation result was passed directly to `memset()` without checking
- The `it->symbol` allocation result was passed directly to `strcpy()` without checking  
- The `it->nl[0].n_name` allocation result was used directly by the AIX/FreeBSD9 code paths without checking

On memory exhaustion, any of these will crash the agent with a NULL pointer dereference rather than failing gracefully.

## Fix

Added NULL checks after each `malloc()` call. On failure, already-allocated memory is freed in reverse order before returning, preventing memory leaks.

## Test plan

- [ ] Build on Linux with address sanitizer and verify no regressions
- [ ] Verify behavior under memory pressure (e.g. with `ulimit -v`)
- [ ] Build on AIX/FreeBSD9 to confirm the `nl[0].n_name` path compiles correctly with the new check