### PR TITLE
Fix calculation of `remaining` to prevent heap buffer overread

### DIFF
--- a/snmplib/snmpusm.c
+++ b/snmplib/snmpusm.c
@@ -2954,7 +2954,7 @@ usm_process_in_msg(int msgProcModel,    /* (UNUSED) */
                    netsnmp_session * sess,      /* IN     - session which got the message  */
                    u_char msg_flags)
 {                               /* IN     - v3 Message flags.              */
-    size_t          remaining = wholeMsgLen - (size_t)(secParams - wholeMsg);
+    size_t          remaining = wholeMsgLen - (secParams - wholeMsg);
     u_int           boots_uint;
     u_int           time_uint;
 #ifdef HAVE_AES


### PR DESCRIPTION
Fixes #1065 