### PR TITLE
AIX doesn't support MSG_DONTWAIT

### DIFF
--- a/snmplib/transports/snmpUDPBaseDomain.c
+++ b/snmplib/transports/snmpUDPBaseDomain.c
@@ -56,6 +56,10 @@
 #include <net-snmp/library/system.h>
 #include <net-snmp/library/snmp_assert.h>
 
+#ifdef _AIX
+#define MSG_DONTWAIT MSG_NONBLOCK
+#endif
+
 #ifndef  MSG_DONTWAIT
 #define MSG_DONTWAIT 0
 #endif

--- a/snmplib/transports/snmpUDPIPv6Domain.c
+++ b/snmplib/transports/snmpUDPIPv6Domain.c
@@ -14,6 +14,10 @@
 
 #ifdef NETSNMP_TRANSPORT_UDPIPV6_DOMAIN
 
+#ifdef _AIX
+#define MSG_DONTWAIT MSG_NONBLOCK
+#endif
+
 #include <stdio.h>
 #include <sys/types.h>
 #include <ctype.h>


### PR DESCRIPTION
When attempting to compile **Net-SNMP** `5.9.5.2`  on AIX , the build fails in `snmplib/transports/snmpUDPIPv6Domain.c` & `snmplib/transports/snmpUDPBaseDomain.c` .

The error occurs because MSG_DONTWAIT is used as a flag for recvmsg() and sendto(). While common on other platforms, MSG_DONTWAIT is not defined in the AIX system socket headers (sys/socket.h).


```

transports/snmpUDPIPv6Domain.c:122:26: error: 'MSG_DONTWAIT' undeclared
  122 |      r = recvmsg(s, &msg, MSG_DONTWAIT);
      |                          ^~~~~~~~~~~~

```

On AIX, the functional equivalent to `MSG_DONTWAIT` is `MSG_NONBLOCK`. By mapping the missing symbol to the AIX-native flag, we preserve the intended non-blocking behavior without requiring structural changes to the code.