### PR TITLE
Fix NULL pointer dereference in VACM config parsing

### DIFF
--- a/snmplib/vacm.c
+++ b/snmplib/vacm.c
@@ -176,8 +176,16 @@ vacm_parse_config_view(const char *token, const char *line)
 
     view.viewStatus = atoi(line);
     line = skip_token_const(line);
+    if (!line) {
+        config_perror("incomplete line");
+        return;
+    }
     view.viewStorageType = atoi(line);
     line = skip_token_const(line);
+    if (!line) {
+        config_perror("incomplete line");
+        return;
+    }
     view.viewType = atoi(line);
     line = skip_token_const(line);
     len = sizeof(view.viewName);
@@ -293,12 +301,28 @@ _vacm_parse_config_access_common(struct vacm_accessEntry **aptr,
 
     access.status = atoi(line);
     line = skip_token_const(line);
+    if (!line) {
+        config_perror("incomplete line");
+        return NULL;
+    }
     access.storageType = atoi(line);
     line = skip_token_const(line);
+    if (!line) {
+        config_perror("incomplete line");
+        return NULL;
+    }
     access.securityModel = atoi(line);
     line = skip_token_const(line);
+    if (!line) {
+        config_perror("incomplete line");
+        return NULL;
+    }
     access.securityLevel = atoi(line);
     line = skip_token_const(line);
+    if (!line) {
+        config_perror("incomplete line");
+        return NULL;
+    }
     access.contextMatch = atoi(line);
     line = skip_token_const(line);
     len  = sizeof(access.groupName);
@@ -365,6 +389,10 @@ vacm_parse_config_auth_access(const char *token, const char *line)
         return;
 
     authtype = atoi(line);
+    if (authtype < 0 || authtype >= VACM_MAX_VIEWS) {
+        config_perror("invalid authtype");
+        return;
+    }
     line = skip_token_const(line);
 
     view = (char *) aptr->views[authtype];
@@ -411,8 +439,16 @@ vacm_parse_config_group(const char *token, const char *line)
 
     group.status = atoi(line);
     line = skip_token_const(line);
+    if (!line) {
+        config_perror("incomplete line");
+        return;
+    }
     group.storageType = atoi(line);
     line = skip_token_const(line);
+    if (!line) {
+        config_perror("incomplete line");
+        return;
+    }
     group.securityModel = atoi(line);
     line = skip_token_const(line);
     len = sizeof(group.securityName);


### PR DESCRIPTION
## Summary

Fixes #1052.

`vacm_parse_config_view()`, `_vacm_parse_config_access_common()`, and `vacm_parse_config_group()` call `atoi()` on the return value of `skip_token_const()` without checking for NULL. When a malformed configuration line has insufficient tokens, `skip_token_const()` returns NULL, and passing it to `atoi()` causes a segmentation fault (CWE-476).

This patch adds NULL checks after each `skip_token_const()` call, returning early with `config_perror()` on malformed input. It also adds bounds validation for `authtype` in `vacm_parse_config_auth_access()` to prevent out-of-bounds array access into the `views[]` array.

## Changes

- **`vacm_parse_config_view()`**: Add NULL checks after `skip_token_const()` (2 sites)
- **`_vacm_parse_config_access_common()`**: Add NULL checks after `skip_token_const()` (4 sites)
- **`vacm_parse_config_group()`**: Add NULL checks after `skip_token_const()` (2 sites)
- **`vacm_parse_config_auth_access()`**: Add bounds check for `authtype` against `VACM_MAX_VIEWS`

## Test

Verified the fix compiles cleanly with `-Wall -Wextra -Werror=declaration-after-statement` and all existing flags. The downstream callers (`read_config_read_octet_string`, `read_config_read_objid_const`) already handle NULL input gracefully, so the final `skip_token_const()` in each sequence does not need an additional check.