### PR TITLE
Check if tclist has already been allocated in parser to avoid a memory leak if we re-initialise

### DIFF
--- a/snmplib/parse.c
+++ b/snmplib/parse.c
@@ -729,6 +729,7 @@ netsnmp_init_mib_internals(void)
 
     memset(nbuckets, 0, sizeof(nbuckets));
     memset(tbuckets, 0, sizeof(tbuckets));
+    free(tclist);
     tc_alloc = TC_INCR;
     tclist = calloc(tc_alloc, sizeof(struct tc));
     build_translation_table();


### PR DESCRIPTION
I am trying to use mib_shutdown() followed by mib_init() to reset the loaded MIB tree without launching a new process.  Most things worked, but I discovered a single memory leak where parse.c allocates memry for tclist.

This PR frees the memory used by tclist if it has previously been allocated.