### PR TITLE
Set the MIBDIRS string to NULL on shutdown_mib so it will re-read all MIBS if needed

### DIFF
--- a/snmplib/mib.c
+++ b/snmplib/mib.c
@@ -2875,6 +2875,7 @@ shutdown_mib(void)
         Prefix = NULL;
     SNMP_FREE(confmibs);
     SNMP_FREE(confmibdir);
+    netsnmp_ds_set_string(NETSNMP_DS_LIBRARY_ID, NETSNMP_DS_LIB_MIBDIRS, NULL);
 }
 
 /**


### PR DESCRIPTION
I want to use shutdown_mib() followed by init_mib() to clear the MIB tree in a running process that needs to use MIBs that have conflicting OIDs in different queries.  I discovered that if the NETSNMP_DS_LIB_MIBDIRS string is not NULL, the MIB initialisation function does not re-evaluate the list of MIB directories.

This PR resets the NETSNMP_DS_LIB_MIBDIRS string to NULL as part of the shutdown_mib() function, which makes the second call to init_mib() re-evaluate the MIB directories.

I can't imagine that this would cause any issues with existing code because:
- If the environment variables and config files are not changed, this string will just be set back to the same value as part of the init process
- If someone has change the environment variables, they should expect the init process to use the new environment