### PR TITLE
[Fix]: agent/helpers/table_dataset.c: fix NULL pointer dereference

### DIFF
--- a/agent/helpers/table_dataset.c
+++ b/agent/helpers/table_dataset.c
@@ -499,16 +499,31 @@ netsnmp_table_data_set_create_newrowstash
     newrow_stash   *newrowstash = NULL;
     netsnmp_table_row *newrow   = NULL;
 
-    newrowstash = SNMP_MALLOC_TYPEDEF(newrow_stash);
+    if (table_info == NULL || table_info->indexes == NULL)
+        return NULL;
 
-    if (newrowstash != NULL) {
-        newrowstash->created = 1;
-        newrow = netsnmp_table_data_set_create_row_from_defaults
-            (datatable->default_row);
-        newrow->indexes = snmp_clone_varbind(table_info->indexes);
-        newrowstash->newrow = newrow;
+    newrowstash = SNMP_MALLOC_TYPEDEF(newrow_stash);
+    if (newrowstash == NULL)
+        return NULL;
+
+    newrow = netsnmp_table_data_set_create_row_from_defaults
+        (datatable->default_row);
+    if (newrow == NULL) {
+        SNMP_FREE(newrowstash);
+        return NULL;
     }
 
+    
+    newrow->indexes = snmp_clone_varbind(table_info->indexes);
+    if (newrow->indexes == NULL) {
+        netsnmp_table_dataset_delete_row(newrow);
+        SNMP_FREE(newrowstash);
+        return NULL;
+    }
+    
+
+    newrowstash->created = 1;
+    newrowstash->newrow = newrow;
     return newrowstash;
 }
 
@@ -585,6 +600,11 @@ netsnmp_table_data_set_helper_handler(netsnmp_mib_handler *handler,
                         newrowstash =
                              netsnmp_table_data_set_create_newrowstash(
                                                  datatable, table_info);
+                        if (newrowstash == NULL) {
+                            netsnmp_set_request_error(reqinfo, request,
+                                                      SNMP_ERR_RESOURCEUNAVAILABLE);
+                            continue;
+                        }
                         newrow = newrowstash->newrow;
                     } else if (datatable->rowstatus_column == 0) {
                         /*
@@ -604,10 +624,16 @@ netsnmp_table_data_set_helper_handler(netsnmp_mib_handler *handler,
                     newrowstash = SNMP_MALLOC_TYPEDEF(newrow_stash);
                     if (newrowstash == NULL) {
                         netsnmp_set_request_error(reqinfo, request,
-                                                  SNMP_ERR_GENERR);
+                                                  SNMP_ERR_RESOURCEUNAVAILABLE);
                         continue;
                     }
                     newrow = netsnmp_table_data_set_clone_row(row);
+                    if (newrow == NULL) {
+                        SNMP_FREE(newrowstash);
+                        netsnmp_set_request_error(reqinfo, request,
+                                                  SNMP_ERR_RESOURCEUNAVAILABLE);
+                        continue;
+                    }
                     newrowstash->newrow = newrow;
                 }
                 netsnmp_oid_stash_add_data(stashp, suffix, suffix_len,
@@ -689,6 +715,11 @@ netsnmp_table_data_set_helper_handler(netsnmp_mib_handler *handler,
                     newrowstash =
                              netsnmp_table_data_set_create_newrowstash(
                                                  datatable, table_info);
+                    if (newrowstash == NULL) {
+                        netsnmp_set_request_error(reqinfo, request,
+                                                  SNMP_ERR_RESOURCEUNAVAILABLE);
+                        continue;
+                    }
                     newrow = newrowstash->newrow;
                     row    = newrow;
                     netsnmp_oid_stash_add_data(stashp, suffix, suffix_len,


### PR DESCRIPTION
# Fix NULL Pointer Dereference in `agent/helpers/table_dataset.c`

## Summary

This change fixes a NULL pointer dereference in the `table_dataset` helper.

The root cause is that `netsnmp_table_data_set_create_row_from_defaults()` can
return `NULL` when row allocation fails, but
`netsnmp_table_data_set_create_newrowstash()` dereferences that return value
unconditionally:

```c
newrow->indexes = snmp_clone_varbind(table_info->indexes);
```

In builds that include the old DISMAN-EVENT-MIB implementation, this helper is
reachable from a remote SNMP `SET` request for `mteEventEntryStatus`. Under a
forced row-allocation failure, the unpatched code crashes.

This patch:

- makes `netsnmp_table_data_set_create_newrowstash()` fail cleanly when row
  creation or index cloning fails
- converts the request-path failure into
  `SNMP_ERR_RESOURCEUNAVAILABLE`
- avoids dereferencing a broken row-creation result
- hardens the adjacent cloned-row failure path for consistency

## Fresh Revalidation

I revalidated this issue on a fresh upstream checkout on the following local
baseline:

- Repository: `/home/binary/snmp_bugs/net-snmp`
- Local upstream commit: `bb2110ebd9`
- Runtime version string observed from `snmpd`: `NET-SNMP version 5.10.pre2`

To keep the proof and the fix separate, I created a clean baseline worktree
from the fresh checkout:

```bash
cd /home/binary/snmp_bugs/net-snmp
git worktree add /home/binary/snmp_bugs/net-snmp-id12-baseline HEAD
```

All vulnerability confirmation below was performed against:

- `/home/binary/snmp_bugs/net-snmp-id12-baseline`

All fix validation below was performed against:

- `/home/binary/snmp_bugs/net-snmp`

## Root Cause Analysis

The vulnerable code path is in:

- `/home/binary/snmp_bugs/net-snmp-id12-baseline/agent/helpers/table_dataset.c`

### 1. Row creation is allowed to fail

`netsnmp_table_data_set_create_row_from_defaults()` calls
`netsnmp_create_table_data_row()` and explicitly returns `NULL` if allocation
fails:

- `/home/binary/snmp_bugs/net-snmp-id12-baseline/agent/helpers/table_dataset.c:288`
- `/home/binary/snmp_bugs/net-snmp-id12-baseline/agent/helpers/table_dataset.c:292`
- `/home/binary/snmp_bugs/net-snmp-id12-baseline/agent/helpers/table_dataset.c:293`

Relevant logic:

```c
row = netsnmp_create_table_data_row();
if (!row)
    return NULL;
```

### 2. The caller dereferences the result without checking it

`netsnmp_table_data_set_create_newrowstash()` does not check whether the newly
created row is `NULL` before dereferencing it:

- `/home/binary/snmp_bugs/net-snmp-id12-baseline/agent/helpers/table_dataset.c:494`
- `/home/binary/snmp_bugs/net-snmp-id12-baseline/agent/helpers/table_dataset.c:508`

Relevant logic:

```c
newrow = netsnmp_table_data_set_create_row_from_defaults(datatable->default_row);
newrow->indexes = snmp_clone_varbind(table_info->indexes);
```

That is a straightforward NULL pointer dereference if row allocation fails.

### 3. Request-path callers also assume success

The request handler later assumes `create_newrowstash()` succeeded and directly
uses `newrowstash->newrow`:

- `/home/binary/snmp_bugs/net-snmp-id12-baseline/agent/helpers/table_dataset.c:585`
- `/home/binary/snmp_bugs/net-snmp-id12-baseline/agent/helpers/table_dataset.c:588`
- `/home/binary/snmp_bugs/net-snmp-id12-baseline/agent/helpers/table_dataset.c:689`
- `/home/binary/snmp_bugs/net-snmp-id12-baseline/agent/helpers/table_dataset.c:692`

So a correct fix needs to cover both:

1. the immediate dereference inside `create_newrowstash()`
2. the request-path handling of a failed stash creation

## Why the Build Configuration Matters

The bug is in a generic helper, but remote reachability depends on which DISMAN
event implementation is built.

### Default build

The default fresh build includes the newer `disman/event/...` implementation:

- `/home/binary/snmp_bugs/net-snmp/build-id12-default/agent/mibgroup/mib_module_includes.h:46`
- `/home/binary/snmp_bugs/net-snmp/build-id12-default/agent/mibgroup/mib_module_includes.h:58`

This means a stock default build does not naturally exercise the vulnerable
old-event path through the DISMAN event table.

### Old-event build

The project still documents the older implementation as an optional module:

- `/home/binary/snmp_bugs/net-snmp-id12-baseline/configure.d/config_project_with_enable:956`
- `/home/binary/snmp_bugs/net-snmp-id12-baseline/configure:2008`

Both describe:

```text
disman/old-event-mib   previous implementation of the DISMAN-EVENT-MIB
```

In an old-event build, the event table is implemented using the vulnerable
`table_dataset` helper path:

- `/home/binary/snmp_bugs/net-snmp-id12-baseline/agent/mibgroup/disman/mteEventTable.c:31`
- `/home/binary/snmp_bugs/net-snmp-id12-baseline/agent/mibgroup/disman/mteEventTable.c:36`
- `/home/binary/snmp_bugs/net-snmp-id12-baseline/agent/mibgroup/disman/mteEventTable.c:73`

Important details:

- `table_set->allow_creation = 1;`
- the table is registered through `netsnmp_register_table_data_set(...)`

The MIB definition also allows remote row creation through `RowStatus`:

- `/home/binary/snmp_bugs/net-snmp-id12-baseline/mibs/DISMAN-EVENT-MIB.txt:1264`
- `/home/binary/snmp_bugs/net-snmp-id12-baseline/mibs/DISMAN-EVENT-MIB.txt:1322`

In other words:

- the helper bug exists independently of the MIB module
- the old DISMAN event implementation provides a practical remote request path

## Why Fault Injection Is Needed

This is not a malformed-input parser bug where a single crafted packet always
crashes the process by itself.

The externally supplied SNMP request is used to reach the vulnerable helper
path. The actual crash condition is an allocation failure during new-row
creation.

Specifically, the crash requires:

- `netsnmp_create_table_data_row()` to return `NULL`

That is why the proof uses a small preload hook: not to invent a fake path, but
to deterministically trigger the real error path that already exists in the
code.

So the proof has two separate parts:

1. request-path reachability
2. deterministic confirmation that the failure path crashes

## PoC Files Used

The proof uses the following local PoC files:

- `/home/binary/snmp_bugs/NPD_ID_12/poc/net-snmp-id12/id12_harness.c`
- `/home/binary/snmp_bugs/NPD_ID_12/poc/net-snmp-id12/fail_row_alloc.c`

### `id12_harness.c`

This is a minimal function-level reproducer that:

- creates a small `netsnmp_table_data_set`
- adds a default row template
- constructs table index varbinds
- calls `netsnmp_table_data_set_create_newrowstash()` directly

This proves the helper bug without depending on a particular runtime MIB
configuration.

### `fail_row_alloc.c`

This fault-injection helper overrides `netsnmp_create_table_data_row()` and
forces it to return `NULL`:

```c
netsnmp_table_row *
netsnmp_create_table_data_row(void)
{
    fprintf(stderr, "[fail_row_alloc] forcing netsnmp_create_table_data_row() to return NULL\n");
    return NULL;
}
```

This makes the vulnerable path deterministic and reproducible.

## Detailed Reproduction

### A. Build the vulnerable old-event baseline

```bash
mkdir -p /home/binary/snmp_bugs/net-snmp-id12-baseline/build-id12-oldevent
cd /home/binary/snmp_bugs/net-snmp-id12-baseline/build-id12-oldevent

../configure --with-defaults --disable-embedded-perl --without-rpm --without-pcre \
  --enable-old-features \
  --with-mib-modules='disman/old-event-mib' \
  --with-out-mib-modules='disman/event' \
  --prefix=/home/binary/snmp_bugs/net-snmp-id12-baseline/build-install-id12-oldevent

make -j4
```

This build confirms that the old-event modules are present in the generated
module list, including:

- `/home/binary/snmp_bugs/net-snmp/build-id12-oldevent/agent/mibgroup/mib_module_includes.h:20`

and in the baseline build:

- `/home/binary/snmp_bugs/net-snmp-id12-baseline/build-id12-oldevent/agent/mibgroup/mib_module_includes.h`

### B. Build the function-level harness against the baseline

```bash
cd /home/binary/snmp_bugs/net-snmp-id12-baseline/build-id12-oldevent

./libtool --mode=link $(./net-snmp-config --build-command) \
  -I/home/binary/snmp_bugs/net-snmp-id12-baseline/build-id12-oldevent/include \
  -I/home/binary/snmp_bugs/net-snmp-id12-baseline \
  -I/home/binary/snmp_bugs/net-snmp-id12-baseline/include \
  -I/home/binary/snmp_bugs/net-snmp-id12-baseline/agent/mibgroup \
  -o /home/binary/snmp_bugs/NPD_ID_12/poc/net-snmp-id12/id12_harness_baseline \
  /home/binary/snmp_bugs/NPD_ID_12/poc/net-snmp-id12/id12_harness.c \
  /home/binary/snmp_bugs/net-snmp-id12-baseline/build-id12-oldevent/snmplib/libnetsnmp.la \
  /home/binary/snmp_bugs/net-snmp-id12-baseline/build-id12-oldevent/agent/libnetsnmpagent.la \
  /home/binary/snmp_bugs/net-snmp-id12-baseline/build-id12-oldevent/agent/libnetsnmpmibs.la \
  $(./net-snmp-config --external-libs)
```

### C. Function-level baseline behavior

Normal run:

```bash
env LD_LIBRARY_PATH=/home/binary/snmp_bugs/net-snmp-id12-baseline/build-id12-oldevent/agent/.libs:/home/binary/snmp_bugs/net-snmp-id12-baseline/build-id12-oldevent/agent/helpers/.libs:/home/binary/snmp_bugs/net-snmp-id12-baseline/build-id12-oldevent/snmplib/.libs \
  /home/binary/snmp_bugs/NPD_ID_12/poc/net-snmp-id12/id12_harness_baseline
```

Observed output:

```text
calling netsnmp_table_data_set_create_newrowstash()
returned from netsnmp_table_data_set_create_newrowstash()
EXIT:0
```

Forced allocation failure:

```bash
env LD_LIBRARY_PATH=/home/binary/snmp_bugs/net-snmp-id12-baseline/build-id12-oldevent/agent/.libs:/home/binary/snmp_bugs/net-snmp-id12-baseline/build-id12-oldevent/agent/helpers/.libs:/home/binary/snmp_bugs/net-snmp-id12-baseline/build-id12-oldevent/snmplib/.libs \
  LD_PRELOAD=/home/binary/snmp_bugs/NPD_ID_12/poc/net-snmp-id12/fail_row_alloc_fresh.so \
  /home/binary/snmp_bugs/NPD_ID_12/poc/net-snmp-id12/id12_harness_baseline
```

Observed output:

```text
calling netsnmp_table_data_set_create_newrowstash()
[fail_row_alloc] forcing netsnmp_create_table_data_row() to return NULL
Segmentation fault
EXIT:139
```

This shows that the helper still crashes on the fresh baseline.

### D. `gdb` proof of the NULL dereference

Command:

```bash
env LD_LIBRARY_PATH=/home/binary/snmp_bugs/net-snmp-id12-baseline/build-id12-oldevent/agent/.libs:/home/binary/snmp_bugs/net-snmp-id12-baseline/build-id12-oldevent/agent/helpers/.libs:/home/binary/snmp_bugs/net-snmp-id12-baseline/build-id12-oldevent/snmplib/.libs \
  LD_PRELOAD=/home/binary/snmp_bugs/NPD_ID_12/poc/net-snmp-id12/fail_row_alloc_fresh.so \
  gdb -q -batch -ex run -ex 'frame 0' -ex 'info locals' -ex bt \
  --args /home/binary/snmp_bugs/NPD_ID_12/poc/net-snmp-id12/.libs/id12_harness_baseline
```

Observed result:

```text
Program received signal SIGSEGV, Segmentation fault.
0x00007ffff7f71641 in netsnmp_table_data_set_create_newrowstash (...) at ../../agent/helpers/table_dataset.c:508
508         newrow->indexes = snmp_clone_varbind(table_info->indexes);

newrowstash = 0x555555559c50
newrow = 0x0

#0  netsnmp_table_data_set_create_newrowstash (...) at ../../agent/helpers/table_dataset.c:508
#1  main ()
```

This directly proves the bug:

- the crashing source line is known
- the dereferenced pointer is confirmed to be `NULL`
- the failing function is exactly the helper under analysis

### E. Network reachability through the old-event path

Start the vulnerable baseline agent:

```bash
env LD_LIBRARY_PATH=/home/binary/snmp_bugs/net-snmp-id12-baseline/build-id12-oldevent/agent/.libs:/home/binary/snmp_bugs/net-snmp-id12-baseline/build-id12-oldevent/agent/helpers/.libs:/home/binary/snmp_bugs/net-snmp-id12-baseline/build-id12-oldevent/snmplib/.libs \
  MIBDIRS=/home/binary/snmp_bugs/net-snmp-id12-baseline/mibs \
  MIBS=+DISMAN-EVENT-MIB \
  SNMP_PERSISTENT_DIR=/home/binary/snmp_bugs/NPD_ID_12/poc/net-snmp-id12/persist \
  /home/binary/snmp_bugs/net-snmp-id12-baseline/build-id12-oldevent/agent/.libs/snmpd \
  -Dnetsnmp_table_data_set -f -Lo -C udp:127.0.0.1:3166
```

Send a row-creation request:

```bash
env LD_LIBRARY_PATH=/home/binary/snmp_bugs/net-snmp-id12-baseline/build-id12-oldevent/agent/.libs:/home/binary/snmp_bugs/net-snmp-id12-baseline/build-id12-oldevent/agent/helpers/.libs:/home/binary/snmp_bugs/net-snmp-id12-baseline/build-id12-oldevent/snmplib/.libs \
  MIBDIRS=/home/binary/snmp_bugs/net-snmp-id12-baseline/mibs \
  MIBS=+DISMAN-EVENT-MIB \
  /home/binary/snmp_bugs/net-snmp-id12-baseline/build-id12-oldevent/apps/.libs/snmpset \
  -m +DISMAN-EVENT-MIB -M /home/binary/snmp_bugs/net-snmp-id12-baseline/mibs \
  -v2c -c public 127.0.0.1:3166 \
  .1.3.6.1.2.1.88.1.4.2.1.5.3.111.112.115.105.100.49.50 i 5
```

Observed output:

```text
DISMAN-EVENT-MIB::mteEventEntryStatus."ops".'id12' = INTEGER: createAndWait(5)
```

### Note about the numeric OID

The request OID above is intentionally encoded as:

- `1.3.6.1.2.1.88.1.4.2.1.5` = `mteEventEntryStatus`
- `3.111.112.115` = first index `mteOwner = "ops"`
- `105.100.49.50` = second index `mteEventName = "id12"`

The second index is `IMPLIED`, so it is encoded without a length prefix.

This matters because including an extra length subidentifier changes the index
representation and is not the cleanest way to reproduce the MIB entry.

### F. Network fault-injection reproduction on the baseline

Start the same baseline old-event agent, but preload the row-allocation hook:

```bash
env LD_PRELOAD=/home/binary/snmp_bugs/NPD_ID_12/poc/net-snmp-id12/fail_row_alloc_fresh.so \
  LD_LIBRARY_PATH=/home/binary/snmp_bugs/net-snmp-id12-baseline/build-id12-oldevent/agent/.libs:/home/binary/snmp_bugs/net-snmp-id12-baseline/build-id12-oldevent/agent/helpers/.libs:/home/binary/snmp_bugs/net-snmp-id12-baseline/build-id12-oldevent/snmplib/.libs \
  MIBDIRS=/home/binary/snmp_bugs/net-snmp-id12-baseline/mibs \
  MIBS=+DISMAN-EVENT-MIB \
  SNMP_PERSISTENT_DIR=/home/binary/snmp_bugs/NPD_ID_12/poc/net-snmp-id12/persist \
  /home/binary/snmp_bugs/net-snmp-id12-baseline/build-id12-oldevent/agent/.libs/snmpd \
  -Dnetsnmp_table_data_set -f -Lo -C udp:127.0.0.1:3170
```

Send the same request:

```bash
env LD_LIBRARY_PATH=/home/binary/snmp_bugs/net-snmp-id12-baseline/build-id12-oldevent/agent/.libs:/home/binary/snmp_bugs/net-snmp-id12-baseline/build-id12-oldevent/agent/helpers/.libs:/home/binary/snmp_bugs/net-snmp-id12-baseline/build-id12-oldevent/snmplib/.libs \
  MIBDIRS=/home/binary/snmp_bugs/net-snmp-id12-baseline/mibs \
  MIBS=+DISMAN-EVENT-MIB \
  /home/binary/snmp_bugs/net-snmp-id12-baseline/build-id12-oldevent/apps/.libs/snmpset \
  -m +DISMAN-EVENT-MIB -M /home/binary/snmp_bugs/net-snmp-id12-baseline/mibs \
  -v2c -c public 127.0.0.1:3170 \
  .1.3.6.1.2.1.88.1.4.2.1.5.3.111.112.115.105.100.49.50 i 5
```

Observed result:

```text
snmpd:
netsnmp_table_data_set: handler starting
[fail_row_alloc] forcing netsnmp_create_table_data_row() to return NULL

snmpset:
Timeout: No Response from 127.0.0.1:3170
```

The request-path result by itself is a loss of response. The direct crash proof
comes from the `gdb` evidence above. Taken together, these show that:

- the remote request is sufficient to reach the vulnerable helper path
- forcing row allocation failure on that path reproduces the same crash

## The Patch

The actual code change is limited to:

- `/home/binary/snmp_bugs/net-snmp/agent/helpers/table_dataset.c`

### What changed

1. `netsnmp_table_data_set_create_newrowstash()` now returns `NULL` cleanly if:
   - `newrow_stash` allocation fails
   - `netsnmp_table_data_set_create_row_from_defaults()` returns `NULL`
   - `snmp_clone_varbind(table_info->indexes)` fails

2. The two request-path row-creation call sites now check for a `NULL`
   `newrowstash` and return:

```c
SNMP_ERR_RESOURCEUNAVAILABLE
```

3. The neighboring row-clone failure path is also hardened so that
   `netsnmp_table_data_set_clone_row(row)` returning `NULL` no longer leaves the
   request path in an inconsistent state.

### Why this is the right fix

Only guarding the direct dereference at line 508 would not be sufficient.

The request path also needs to treat a failed stash creation as a real
resource-allocation failure. Otherwise the code would still assume a usable row
or stash later in the transaction.

Returning `SNMP_ERR_RESOURCEUNAVAILABLE` is a better semantic match than a
generic error here because the failure is specifically a resource creation
failure.

## Validation After the Fix

### A. Rebuild the patched tree

Patched default build:

- `/home/binary/snmp_bugs/net-snmp/build-id12-default`

Patched old-event build:

- `/home/binary/snmp_bugs/net-snmp/build-id12-oldevent`

The old-event patched build was rebuilt after the source change with:

```bash
cd /home/binary/snmp_bugs/net-snmp/build-id12-oldevent
make -j4
```

### B. Function-level validation after the fix

Normal run:

```bash
env LD_LIBRARY_PATH=/home/binary/snmp_bugs/net-snmp/build-id12-default/agent/.libs:/home/binary/snmp_bugs/net-snmp/build-id12-default/agent/helpers/.libs:/home/binary/snmp_bugs/net-snmp/build-id12-default/snmplib/.libs \
  /home/binary/snmp_bugs/NPD_ID_12/poc/net-snmp-id12/.libs/id12_harness_fresh
```

Observed:

```text
calling netsnmp_table_data_set_create_newrowstash()
returned from netsnmp_table_data_set_create_newrowstash()
EXIT:0
```

Forced allocation failure after the fix:

```bash
env LD_LIBRARY_PATH=/home/binary/snmp_bugs/net-snmp/build-id12-default/agent/.libs:/home/binary/snmp_bugs/net-snmp/build-id12-default/agent/helpers/.libs:/home/binary/snmp_bugs/net-snmp/build-id12-default/snmplib/.libs \
  LD_PRELOAD=/home/binary/snmp_bugs/NPD_ID_12/poc/net-snmp-id12/fail_row_alloc_fresh.so \
  /home/binary/snmp_bugs/NPD_ID_12/poc/net-snmp-id12/.libs/id12_harness_fresh
```

Observed:

```text
calling netsnmp_table_data_set_create_newrowstash()
[fail_row_alloc] forcing netsnmp_create_table_data_row() to return NULL
returned from netsnmp_table_data_set_create_newrowstash()
EXIT:0
```

So the direct crash is gone.

### C. Network validation after the fix

Start the patched old-event agent with the same preload:

```bash
env LD_PRELOAD=/home/binary/snmp_bugs/NPD_ID_12/poc/net-snmp-id12/fail_row_alloc_fresh.so \
  LD_LIBRARY_PATH=/home/binary/snmp_bugs/net-snmp/build-id12-oldevent/agent/.libs:/home/binary/snmp_bugs/net-snmp/build-id12-oldevent/agent/helpers/.libs:/home/binary/snmp_bugs/net-snmp/build-id12-oldevent/snmplib/.libs \
  MIBDIRS=/home/binary/snmp_bugs/net-snmp/mibs \
  MIBS=+DISMAN-EVENT-MIB \
  SNMP_PERSISTENT_DIR=/home/binary/snmp_bugs/NPD_ID_12/poc/net-snmp-id12/persist \
  /home/binary/snmp_bugs/net-snmp/build-id12-oldevent/agent/.libs/snmpd \
  -Dnetsnmp_table_data_set -f -Lo -C udp:127.0.0.1:3169
```

Send the same request:

```bash
env LD_LIBRARY_PATH=/home/binary/snmp_bugs/net-snmp/build-id12-oldevent/agent/.libs:/home/binary/snmp_bugs/net-snmp/build-id12-oldevent/agent/helpers/.libs:/home/binary/snmp_bugs/net-snmp/build-id12-oldevent/snmplib/.libs \
  MIBDIRS=/home/binary/snmp_bugs/net-snmp/mibs \
  MIBS=+DISMAN-EVENT-MIB \
  /home/binary/snmp_bugs/net-snmp/build-id12-oldevent/apps/.libs/snmpset \
  -m +DISMAN-EVENT-MIB -M /home/binary/snmp_bugs/net-snmp/mibs \
  -v2c -c public 127.0.0.1:3169 \
  .1.3.6.1.2.1.88.1.4.2.1.5.3.111.112.115.105.100.49.50 i 5
```

Observed result:

```text
Error in packet.
Reason: resourceUnavailable (This is likely a out-of-memory failure within the agent)
Failed object: DISMAN-EVENT-MIB::mteEventEntryStatus."ops".'id12'
```

This is the expected post-fix behavior:

- the request still reaches the same logical operation
- the agent no longer crashes
- the failure is reported to the client as a resource allocation failure

## Final Notes

- The bug is still present in the fresh upstream baseline.
- The helper-level proof is deterministic and directly confirmed with `gdb`.
- The old-event request path demonstrates practical remote reachability.
- The fix is small, localized, and preserves expected request semantics by
  returning `SNMP_ERR_RESOURCEUNAVAILABLE`.

## Patch Scope

Only one source file is modified:

- `/home/binary/snmp_bugs/net-snmp/agent/helpers/table_dataset.c`

Current diff summary:

```text
 agent/helpers/table_dataset.c | 40 ++++++++++++++++++++++++++++++++++------
 1 file changed, 34 insertions(+), 6 deletions(-)
```
