### PR TITLE
hardware/cpu: fix NULL pointer dereference in CPU initialization

### DIFF
--- a/agent/mibgroup/hardware/cpu/cpu_linux.c
+++ b/agent/mibgroup/hardware/cpu/cpu_linux.c
@@ -40,6 +40,12 @@ void init_cpu_linux( void ) {
     char buf[1024], *cp;
     int  i, n = 0;
     netsnmp_cpu_info *cpu = netsnmp_cpu_get_byIdx( -1, 1 );
+
+    if (!cpu) {
+        snmp_log(LOG_ERR, "%s: failed to allocate overall CPU entry\n",
+                 __func__);
+        return;
+    }
     strcpy(cpu->name, "Overall CPU statistics");
 
     fp = fopen( CPU_FILE, "r" );
@@ -51,6 +57,12 @@ void init_cpu_linux( void ) {
         if ( sscanf( buf, "processor : %d", &i ) == 1)  {
             n++;
             cpu = netsnmp_cpu_get_byIdx( i, 1 );
+            if (!cpu) {
+                snmp_log(LOG_ERR, "%s: failed to allocate per-CPU entry\n",
+                         __func__);
+                fclose(fp);
+                return;
+            }
             cpu->status = 2;  /* running */
             sprintf( cpu->name, "cpu%d", i );
 #if defined(__s390__) || defined(__s390x__)
@@ -63,6 +75,12 @@ void init_cpu_linux( void ) {
             if (sscanf( buf, "processor %d:", &i ) == 1)  {
                 n++;
                 cpu = netsnmp_cpu_get_byIdx( i, 1 );
+                if (!cpu) {
+                    snmp_log(LOG_ERR, "%s: failed to allocate per-CPU entry\n",
+                             __func__);
+                    fclose(fp);
+                    return;
+                }
                 cpu->status = 2;  /* running */
                 sprintf(cpu->name, "cpu%d", i);
                 strlcat(cpu->descr, "An S/390 CPU", sizeof(cpu->descr));

--- a/agent/mibgroup/hardware/cpu/cpu_nlist.c
+++ b/agent/mibgroup/hardware/cpu/cpu_nlist.c
@@ -46,6 +46,12 @@ void init_cpu_nlist( void ) {
     int           model_mib[] = { CTL_HW, HW_MODEL };
     char           descr[ SNMP_MAXBUF ];
     netsnmp_cpu_info     *cpu = netsnmp_cpu_get_byIdx( -1, 1 );
+
+    if (!cpu) {
+        snmp_log(LOG_ERR, "%s: failed to allocate overall CPU entry\n",
+                 __func__);
+        return;
+    }
     strcpy(cpu->name, "Overall CPU statistics");
 
     i = sizeof(n);
@@ -57,6 +63,11 @@ void init_cpu_nlist( void ) {
         n = 1;   /* Single CPU system */
     for ( i=0; i<n; i++ ) {
         cpu = netsnmp_cpu_get_byIdx( i, 1 );
+        if (!cpu) {
+            snmp_log(LOG_ERR, "%s: failed to allocate per-CPU entry\n",
+                     __func__);
+            return;
+        }
         cpu->status = 2;  /* running */
         sprintf(cpu->name, "cpu%d", i);
         sprintf(cpu->descr, "%s", descr);
@@ -72,6 +83,11 @@ int netsnmp_cpu_arch_load( netsnmp_cache *cache, void *magic ) {
     long   cpu_stats[CPUSTATES];
     struct vmmeter mem_stats;
     netsnmp_cpu_info *cpu = netsnmp_cpu_get_byIdx( -1, 0 );
+
+    if (!cpu) {
+        snmp_log(LOG_ERR, "%s: missing overall CPU entry\n", __func__);
+        return -1;
+    }
 
     auto_nlist( CPU_SYMBOL, (char *) cpu_stats, sizeof(cpu_stats));
     auto_nlist( MEM_SYMBOL, (char *)&mem_stats, sizeof(mem_stats));
@@ -101,6 +117,10 @@ int netsnmp_cpu_arch_load( netsnmp_cache *cache, void *magic ) {
 #ifdef PER_CPU_INFO
     for ( i = 0; i < n; i++ ) {
         cpu = netsnmp_cpu_get_byIdx( i, 0 );
+        if (!cpu) {
+            snmp_log(LOG_ERR, "%s: missing per-CPU entry\n", __func__);
+            continue;
+        }
         /* XXX - per-CPU statistics */
     }
 #else


### PR DESCRIPTION
# Fix NULL Pointer Dereference in `hardware/cpu` Backend Initialization

## Summary

This change fixes a NULL pointer dereference in the CPU backend
initialization code.

The original issue is in the `cpu_nlist` backend, where
`netsnmp_cpu_get_byIdx(..., 1)` can return `NULL` on allocation failure and
the result is dereferenced immediately:

```c
netsnmp_cpu_info *cpu = netsnmp_cpu_get_byIdx( -1, 1 );
strcpy(cpu->name, "Overall CPU statistics");
```

On current Linux builds, the same unchecked pattern is also present in
`cpu_linux.c`, and that path is reachable during normal `snmpd` startup.

This patch:

- adds NULL checks after `netsnmp_cpu_get_byIdx(..., 1)` in
  `cpu_linux.c`
- adds the corresponding NULL checks in `cpu_nlist.c`
- hardens the `cpu_nlist` load path against missing CPU entries instead of
  blindly dereferencing them
- turns the failure mode into a logged, clean failure path instead of a
  segmentation fault

## Fresh Revalidation

I revalidated this issue on a fresh upstream checkout at:

- local upstream commit: `bb2110ebd9`
- runtime version observed from `snmpd`: `NET-SNMP version:  5.10.pre2`

To keep the proof and the fix separate, I used:

- a clean baseline worktree for vulnerability confirmation
- a separate fix worktree for patch validation

## Root Cause Analysis

The root cause starts in `agent/mibgroup/hardware/cpu/cpu.c`.

`netsnmp_cpu_get_byIdx()` explicitly allows allocation failure:

```c
cpu = SNMP_MALLOC_TYPEDEF( netsnmp_cpu_info );
if (!cpu) {
    DEBUGMSG(("cpu", "(failed)\n"));
    return NULL;
}
```

That means callers must handle a `NULL` return.

### Original `cpu_nlist` sink

The original candidate is in:

- `agent/mibgroup/hardware/cpu/cpu_nlist.c:48`
- `agent/mibgroup/hardware/cpu/cpu_nlist.c:49`

Relevant logic:

```c
netsnmp_cpu_info *cpu = netsnmp_cpu_get_byIdx( -1, 1 );
strcpy(cpu->name, "Overall CPU statistics");
```

That is a straightforward NULL pointer dereference if CPU entry allocation
fails.

### Active Linux sink

On Linux, the active runtime backend is `cpu_linux` rather than `cpu_nlist`.
The same pattern is present there:

- `agent/mibgroup/hardware/cpu/cpu_linux.c:42`
- `agent/mibgroup/hardware/cpu/cpu_linux.c:43`

```c
netsnmp_cpu_info *cpu = netsnmp_cpu_get_byIdx( -1, 1 );
strcpy(cpu->name, "Overall CPU statistics");
```

So while the original issue was reported against `cpu_nlist`, the same root
cause is still live in current Linux builds.

## Why Fault Injection Is Needed

This is not a malformed-input parser bug where a single crafted packet always
crashes the process by itself.

The crash condition is an allocation failure in
`netsnmp_cpu_get_byIdx(..., 1)`. I used a small `LD_PRELOAD` hook only to
make that real error path deterministic.

So the proof has two parts:

1. the startup path is genuinely reachable in stock `snmpd`
2. the real allocation-failure path crashes without the fix

## Reproduction Summary

I confirmed the bug in two ways:

### 1. Function-level harness

A minimal harness that reproduces the shared sink crashes under forced
allocation failure.

Observed behavior:

```text
calling trigger_id36_like_sink()
[fail_cpu_alloc] forcing calloc(1,8368) in netsnmp_cpu_get_byIdx to return NULL
Segmentation fault
EXIT:139
```

`gdb` on the debug harness shows:

```text
Program received signal SIGSEGV, Segmentation fault.
trigger_id36_like_sink () at .../id36_harness.c:16
16      strcpy(cpu->name, "Overall CPU statistics");

cpu = 0x0
```

### 2. Stock `snmpd` startup on Linux

In the default Linux build, `init_mib_modules()` calls `init_cpu_linux()`
during startup.

Before this patch, with the same allocation-failure hook, stock `snmpd`
crashed during startup.

`gdb` showed:

```text
Program received signal SIGSEGV, Segmentation fault.
init_cpu_linux () at ../../agent/mibgroup/hardware/cpu/cpu_linux.c:43

#0  init_cpu_linux () at ../../agent/mibgroup/hardware/cpu/cpu_linux.c:43
#1  init_mib_modules () at ../agent/mibgroup/mib_module_inits.h:75
#2  main () at ../../agent/snmpd.c:937
```

The faulting machine state also confirmed a null base pointer:

```text
=> 0x... <init_cpu_linux+80>: movl   $0x69747369,0x14(%rax)
rax            0x0
```

## Fix Validation

I validated the patched Linux build with the same `LD_PRELOAD` fault
injection.

Without the patch:

- startup crashed with `SIGSEGV`

With this patch:

- `snmpd` logs the allocation failure
- no segmentation fault occurs
- the process survives until terminated by `timeout`

Observed patched behavior:

```text
init_cpu_linux: failed to allocate overall CPU entry
[fail_cpu_alloc] forcing calloc(1,8368) in netsnmp_cpu_get_byIdx to return NULL
NET-SNMP version 5.10.pre2
Received TERM or STOP signal...  shutting down...
EXIT:124
```

## Scope

This patch intentionally keeps the scope focused on:

- the original `cpu_nlist` issue
- the active `cpu_linux` path that I revalidated locally

I noticed similar unchecked patterns in some other platform-specific CPU
backends as well, but I wanted this PR to stay tightly scoped to the issue I
reproduced and validated end-to-end.

## Impact

This is a real NULL pointer dereference that can crash the agent during CPU
backend initialization.

I would classify it as a low-value issue because:

- it is an allocation-failure / OOM-style path
- it is not a naturally malformed-input remote crash on the tested Linux path
- the original `cpu_nlist` instance is platform-specific

Still, the unchecked dereference is real, and the patch turns it into a clean
failure path instead of a process crash.
