### PR TITLE
snmplib/sprint_realloc_octet_string.c: fix signedness of multi-byte groups

### DIFF
--- a/snmplib/mib.c
+++ b/snmplib/mib.c
@@ -474,7 +474,7 @@ sprint_realloc_octet_string(u_char ** buf, size_t * buf_len,
 
     if (hint) {
         int             repeat, width = 1;
-        long            value;
+        unsigned long   value;
         char            code = 'd', separ = 0, term = 0, ch, intbuf[32];
 #define HEX2DIGIT_NEED_INIT 3
         char            hex2digit = HEX2DIGIT_NEED_INIT;
@@ -551,7 +551,7 @@ sprint_realloc_octet_string(u_char ** buf, size_t * buf_len,
                     }
                     break;
                 case 'd':
-                    sprintf(intbuf, "%ld", value);
+                    sprintf(intbuf, "%lu", value);
                     if (!snmp_cstrcat
                         (buf, buf_len, out_len, allow_realloc, intbuf)) {
                         return 0;


### PR DESCRIPTION
Fix DISPLAY-HINT 'd' rendering of multi-byte groups on 32-bit-long platforms.

In sprint_realloc_octet_string, byte groups are assembled into a 'long' and printed via "%ld". On platforms where long is 32 bits (e.g. ARM32), any uint32 group with the high bit set is rendered with a negative sign, e.g. NTPTimeStamp's "4d.4d" hint produces "1.-1406017739 seconds" for a fractional whose unsigned value is 2888949557.

Switch the accumulator to 'unsigned long' and the decimal format to "%lu". The hex ('x') branch already uses "%lx", which is the correct conversion for unsigned long; passing a signed long to "%lx" was strictly UB anyway. The octal ('o') branch uses "%lo", which is also for unsigned.

This addresses RADLAN-TIMESYNCHRONIZATION-MIB::rlSntpServerInetOffset display on 32-bit ARM, but applies to every "d"/"x"/"o" display-hint group whose value can exceed INT32_MAX.

Caveat: a hypothetical hint with width > sizeof(long) (e.g. "8d" on a 32-bit-long platform) would still overflow. Real hints are width <= 4.

Patch made in assistance with claude-code using Opus v4.7. Tested and confirmed fixing my issue.

Fixes https://github.com/net-snmp/net-snmp/issues/1085