### PR TITLE
Limit extension output to 1024 lines to prevent stack-buffer overflow

### DIFF
--- a/agent/mibgroup/agent/extend.c
+++ b/agent/mibgroup/agent/extend.c
@@ -371,7 +371,7 @@ extend_load_cache(netsnmp_cache *cache, void *magic)
         line_buf[ 0 ] = extension->output;
         for (cp=extension->output; *cp; cp++) {
             if (*cp == '\n') {
-				if (extension->numlines >= 1024) {
+				if (extension->numlines >= (sizeof(line_buf) / sizeof(line_buf[0]))) {
 					break;
 				}
                 line_buf[ extension->numlines++ ] = cp+1;

--- a/agent/mibgroup/agent/extend.c
+++ b/agent/mibgroup/agent/extend.c
@@ -371,6 +371,9 @@ extend_load_cache(netsnmp_cache *cache, void *magic)
         line_buf[ 0 ] = extension->output;
         for (cp=extension->output; *cp; cp++) {
             if (*cp == '\n') {
+				if (extension->numlines >= 1024) {
+					break;
+				}
                 line_buf[ extension->numlines++ ] = cp+1;
             }
         }


### PR DESCRIPTION
Prevent stack-buffer overflow if output is more than 1024 lines.