### PR TITLE
Cleanup SNMP session before exiting

### DIFF
--- a/apps/snmpget.c
+++ b/apps/snmpget.c
@@ -252,5 +252,6 @@ close_session:
 
 out:
     SOCK_CLEANUP;
+	netsnmp_cleanup_session(&session);
     return exitval;
 }                               /* end main() */


### PR DESCRIPTION
Avoid leaking memory. Fixes https://github.com/net-snmp/net-snmp/issues/890 .