### PR TITLE
Fix stack buffer overflows in pass_common SET and hex formatter

### DIFF
--- a/agent/mibgroup/ucd-snmp/pass_common.c
+++ b/agent/mibgroup/ucd-snmp/pass_common.c
@@ -38,9 +38,9 @@ netsnmp_internal_bin2asc(char *p, size_t n)
     int             i, flag = 0;
     char            buffer[SNMP_MAXBUF];
 
-    /* prevent buffer overflow */
-    if ((int)n > (sizeof(buffer) - 1))
-        n = sizeof(buffer) - 1;
+    /* prevent buffer overflow: hex path writes 3 bytes per input byte */
+    if (n > sizeof(buffer) / 3 - 1)
+        n = sizeof(buffer) / 3 - 1;
 
     for (i = 0; i < (int) n; i++) {
         buffer[i] = p[i];
@@ -245,6 +245,8 @@ netsnmp_internal_pass_set_format(char *buf,
                 (int) ((utmp & 0xff)));
         break;
     case ASN_OCTET_STR:
+        if (var_val_len > sizeof(buf2))
+            var_val_len = sizeof(buf2);
         memcpy(buf2, var_val, var_val_len);
         if (var_val_len == 0)
             sprintf(buf, "string \"\"");


### PR DESCRIPTION
## Summary

Fix two stack buffer overflows in the pass/passthrough MIB handler:

1. **`pass_common.c` SET handler** (`netsnmp_internal_pass_set_format`): A `memcpy` at line 253 copies `var_val_len` bytes into a stack buffer `buf2` without checking the length. An SNMP SET with an OCTET STRING value larger than `sizeof(buf2)` overflows the buffer. Add a length cap before the copy.

2. **`pass_common.c` hex formatter** (`netsnmp_internal_bin2asc`): The hex expansion loop writes 3 bytes per input byte back into the caller's buffer. When the input length exceeds `SNMP_MAXBUF / 3`, the formatted output overflows the buffer. Cap the input length so the output fits.

## Testing

Built and verified the fixes compile cleanly. Confirmed the overflow paths are reachable via standard SNMP SET operations.