### PR TITLE
ifXTable: fix null-terminate ifName string in ifName_get in ifXTable.c

### DIFF
--- a/agent/mibgroup/if-mib/ifXTable/ifXTable.c
+++ b/agent/mibgroup/if-mib/ifXTable/ifXTable.c
@@ -428,14 +428,14 @@ ifName_get(ifXTable_rowreq_ctx * rowreq_ctx, char **ifName_val_ptr_ptr,
         /*
          * allocate space for ifName data
          */
-        (*ifName_val_ptr_ptr) = (char*)malloc(tmp_len);
+        (*ifName_val_ptr_ptr) = (char*)malloc(tmp_len + 1);
         if (NULL == (*ifName_val_ptr_ptr)) {
             snmp_log(LOG_ERR, "could not allocate memory\n");
             return MFD_ERROR;
         }
     }
     (*ifName_val_ptr_len_ptr) = tmp_len;
-    memcpy((*ifName_val_ptr_ptr), rowreq_ctx->data.ifName, tmp_len);
+    memcpy((*ifName_val_ptr_ptr), rowreq_ctx->data.ifName, tmp_len + 1);
 
     return MFD_SUCCESS;
 }                               /* ifName_get */


### PR DESCRIPTION
Static analyzer detected string copying without a null terminator in the ifName_get function (line 438).

Issue:
- strlen() returns length excluding the '\0' terminator
- exactly tmp_len bytes were allocated and copied
- resulting buffer was not null-terminated → undefined behavior

Fix:
- allocate tmp_len + 1 bytes via malloc()
- copy tmp_len + 1 bytes via memcpy() to include the '\0' terminator
- *ifName_val_ptr_len_ptr remains tmp_len (per SNMP DisplayString requirements)

Fixes static analyzer warning: 'Copying from string without null termination' The MFD helper will automatically free the allocated memory.

Signed-off-by: Anton Moryakov <ant.v.moryakov@gmail.com>
