### PR TITLE
vacm_conf.c: Validate context length

### DIFF
--- a/agent/mibgroup/mibII/vacm_conf.c
+++ b/agent/mibgroup/mibII/vacm_conf.c
@@ -828,6 +828,7 @@ vacm_create_simple(const char *token, char *confline,
     char            context[SPRINT_MAX_LEN];
     int             ctxprefix = 1;  /* Default to matching all contexts */
     static int      commcount = 0;
+    size_t          ctxlen;
 
     /*
      * init 
@@ -928,7 +929,12 @@ vacm_create_simple(const char *token, char *confline,
      */
     if (cp && *cp) {
         cp = copy_nword(cp, context, sizeof(context));
-        tmp = (context + strlen(context)-1);
+		ctxlen = strlen(context);
+        if (ctxlen == 0) {
+            config_perror("Improper configuration line - if context is specified, it cannot be blank. For an empty context, simply do not specify one instead.");
+            return;
+        }
+        tmp = (context + ctxlen-1);
         if (tmp && *tmp == '*') {
             *tmp = '\0';
             ctxprefix = 1;


### PR DESCRIPTION
Ensure context is not empty to avoid out-of-bound memory access. Fixes #1106.