### PR TITLE
mteTriggerConf.c: Add null check for cp before dereferencing

### DIFF
--- a/agent/mibgroup/disman/event/mteTriggerConf.c
+++ b/agent/mibgroup/disman/event/mteTriggerConf.c
@@ -366,7 +366,7 @@ parse_mteMonitor(const char *token, const char *line)
                          *       (c.f. notificationEvent config)
                          */
             case 'i':
-                if ( *cp == '-' ) {
+                if ( cp && *cp == '-' ) {
                     /* Backwards compatibility - now '-I' */
                     flags &= ~MTE_TRIGGER_FLAG_VWILD;
                     continue;


### PR DESCRIPTION
mteTriggerConf.c: Add null check for cp before dereferencing. Fixes #1112.