### PR TITLE
Fix UAF in expression function evaluation

### DIFF
--- a/agent/mibgroup/disman/expr/expValue.c
+++ b/agent/mibgroup/disman/expr/expValue.c
@@ -320,6 +320,7 @@ netsnmp_variable_list *
 _expValue_evalFunction(netsnmp_variable_list *func) {
     netsnmp_variable_list *params = func->next_variable;
     /* XXX */
+	func->next_variable = params->next_variable;
     params->next_variable = NULL;
     snmp_free_var(params);
     snmp_set_var_typed_integer( func, ASN_INTEGER, 99 );


### PR DESCRIPTION
Fixes Coverity 454601.
`_expValue_evalFunction()` frees `params`, which is `func->next_variable`, but leaves `func->next_variable` pointing at the freed node. The caller immediately reads that pointer via `vp1 = vp->next_variable`.
Relink `func` to `params->next_variable` before detaching and freeing `params`, preserving the apparent linked-list intent and avoiding the dangling pointer.