### PR TITLE
Remove duplicate entry from contributors list

### DIFF
--- a/README
+++ b/README
@@ -311,7 +311,6 @@ THANKS
     Martin Oldfield <m@mail.tc>
     Harrie Hazewinkel <harrie@users.sourceforge.net>
     Mark Ferlatte <ferlatte@users.sourceforge.net>
-    Marus Meissner <marcusmeissner@users.sourceforge.net>
     Stephan Wenzer <stephanwenzel@users.sourceforge.net>
     Ron Mevissen <ron.mevissen@eed.ericsson.se>
     T.J. Mather <tjmather@tjmather.com>


### PR DESCRIPTION
"Marus Meissner" in the Thanks list should be "Marcus Meissner" (confirmed by a later duplicate entry "Marcus Meissner" with the same email, so this is clearly a typo/duplicate).