### PR TITLE
snmpTlstmAddrTable.c - Avoid potential NULL deref on addrs_itr

### DIFF
--- a/agent/mibgroup/tlstm-mib/snmpTlstmAddrTable/snmpTlstmAddrTable.c
+++ b/agent/mibgroup/tlstm-mib/snmpTlstmAddrTable/snmpTlstmAddrTable.c
@@ -1381,8 +1381,8 @@ _tlstmAddrTable_save_rows(int majorID, int minorID, void *serverarg,
                 continue;
             _save_addrs(addr, type);
         }
+        ITERATOR_RELEASE(addrs_itr);
     }
-    ITERATOR_RELEASE(addrs_itr);
 
     /*
      * save inactive rows from mib


### PR DESCRIPTION
Fix coverity 85485 - only release iterator if it is set