### PR TITLE
Makefile.in: install the FreeBSD 15 and 16 system headers

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -21,7 +21,7 @@ INCLUDESUBDIRHEADERS= aix.h bsd.h bsdi3.h bsdi4.h bsdi.h cygwin.h \
 	darwin.h dragonfly.h dynix.h \
 	freebsd2.h freebsd3.h freebsd4.h freebsd5.h freebsd6.h \
 	freebsd7.h freebsd8.h freebsd9.h freebsd10.h freebsd11.h \
-	freebsd12.h freebsd13.h freebsd14.h freebsd.h \
+	freebsd12.h freebsd13.h freebsd14.h freebsd15.h freebsd16.h freebsd.h \
 	generic.h \
 	hpux.h irix.h kfreebsd.h linux.h mingw32.h mingw32msvc.h mips.h \
 	netbsd.h nto-qnx6.h osf5.h \


### PR DESCRIPTION
`include/net-snmp/system/freebsd15.h` and `freebsd16.h` are in the source tree
but are not listed in `Makefile.in`'s `INCLUDESUBDIRHEADERS`, which stops at
`freebsd14.h`. They are therefore never installed, while the installed
`net-snmp-config.h` still contains:

```c
#define NETSNMP_SYSTEM_INCLUDE_FILE "net-snmp/system/freebsd15.h"
```

so every compile against the installed headers fails with a missing include.

### How the gap appeared

`freebsd15.h` arrived in 2230933c7 ("Prepare for FreeBSD 15", 2023-09-11) and
`freebsd16.h` in 106cac2f0 (2025-09-11). Neither commit touched `Makefile.in`.

The convention elsewhere is to do both: 7ffa1ced1 ("support openbsd8",
2025-03-08) added `openbsd8.h` and the matching `INCLUDESUBDIRHEADERS` entry in
the same commit, which is why `openbsd8.h` installs correctly today.

This is also not dormant. 44f905318 ("configure: refine freebsd header fallback
to dynamically pick the highest shipped freebsdNN.h", 2026-03-09) made configure
resolve a FreeBSD 17 host to `freebsd16`, so the selection logic actively reaches
for a header that the install list does not carry.

### Verification

The equivalent change has been run on FreeBSD, from two independent directions.

**CI.** The `Alien::SNMP` distribution builds net-snmp 5.9.5.2 from source and
has been applying this fix at build time. Its GitHub Actions matrix runs FreeBSD
13.5, 14.4 and 15.1, and the full matrix on its master branch is green on all
three, 20 jobs of 20. On 15.1 the build log shows the two headers being added to
the install list, and the suite then compiles and links against the installed
headers, which is precisely what fails without this change.

**CPAN Testers.** The release carrying that fix has 10 passing FreeBSD reports
and no failures: seven on 15.0-RELEASE-p5, two on 15.1-RELEASE-p1 and one on
**16.0-CURRENT**, spanning perl 5.14 through 5.45. The previous release, without
it, had 28 FreeBSD reports and no passes.

Two notes on what that does and does not prove. `Alien::SNMP` computes the
missing names at build time rather than hardcoding them, so what ran on FreeBSD
is the same two names reaching the same `INCLUDESUBDIRHEADERS` variable and the
same install rule, against 5.9.5.2 rather than against this branch. And the
static property is checked here directly: after this change every `.h` in
`include/net-snmp/system/` appears in `INCLUDESUBDIRHEADERS`, and every name in
`INCLUDESUBDIRHEADERS` exists in that directory.

### Related

Not a fix for #640, which was about compiling on FreeBSD 15 and was answered by
#690. This is the follow-on gap that #690 left: the header was added, the
install list was not updated.

The same two headers are missing from `INCLUDESUBDIRHEADERS` on `V5-9-patches`.
Happy to open a backport if that is wanted.
