### PR TITLE
configure: only install transport headers from the public include tree

### DIFF
--- a/configure
+++ b/configure
@@ -24639,7 +24639,7 @@ while test "x$new_transport_list" != "x"; do
       if test -f "$srcdir/$rel_transport_src"; then
         transport_result_list="$transport_result_list $i"
         transport_src_list="$transport_src $transport_src_list"
-        if test -f "$srcdir/$rel_transport_hdr"; then
+        if test -f "$srcdir/include/net-snmp/library/$transport_hdr"; then
           transport_hdr_list="$transport_hdr $transport_hdr_list"
         fi
         transport_def=`echo $i | $SED 'y/abcdefghijklmnopqrstuvwxyz/ABCDEFGHIJKLMNOPQRSTUVWXYZ/'`

--- a/configure.d/config_modules_transports
+++ b/configure.d/config_modules_transports
@@ -60,7 +60,7 @@ while test "x$new_transport_list" != "x"; do
       if test -f "$srcdir/$rel_transport_src"; then
         transport_result_list="$transport_result_list $i"
         transport_src_list="$transport_src $transport_src_list"
-        if test -f "$srcdir/$rel_transport_hdr"; then
+        if test -f "$srcdir/include/net-snmp/library/$transport_hdr"; then
           transport_hdr_list="$transport_hdr $transport_hdr_list"
         fi
         transport_def=`echo $i | $SED 'y/abcdefghijklmnopqrstuvwxyz/ABCDEFGHIJKLMNOPQRSTUVWXYZ/'`


### PR DESCRIPTION
Fixes #552.

`snmpIPBaseDomain.h` is added to the list of headers to install, but it is not
in the directory the install rule reads from, so `make install` tries to install
a file that does not exist.

### Mechanism

1. `configure.d/config_modules_transports` line 64 appends the bare header name
   to `transport_hdr_list` for every transport whose header is found.
2. Lines 52 to 57 special-case IPBase so that `rel_transport_hdr` points at
   `snmplib/transports/`, where 923cb442bbef moved the header when it was made
   private. The existence test on line 63 therefore passes.
3. `snmplib/Makefile.in` line 99 splices `@transport_hdr_list@` into
   `INSTALLHEADERS`.
4. `Makefile.rules` installs those from `$(top_srcdir)/include/net-snmp/library/`,
   where the header is not.

With GNU make the failure is invisible, because the recipe is a shell `for` loop
whose last command is `echo`. With BSD and Solaris make the recipe runs under
`sh -e` and the build aborts, which is what #552 reports on OpenBSD.

### Why this form of the fix

The narrower fix would be to exclude `IPBase` by name where the list is built.
This form is preferable because it does not encode which transports are private:
it asks whether the header is where the install rule will look for it. A future
transport header that moves out of the public include tree is then handled with
no further change, and this failure mode cannot recur under a different name.

It also leaves working any downstream that currently stages the header into
`include/net-snmp/library/` to get past this, since the test then finds it there.

The `case` block stays as it is, because `rel_transport_hdr` is used again at
line 85 for the `config_require` dependency scan.

### Verification

Two clean 5.9.5.2 trees configured with identical flags, one patched:

* The only difference in the entire generated tree is `snmplib/Makefile`'s
  `INSTALLHEADERS`, which loses `snmpIPBaseDomain.h` and keeps all 13 other
  transport headers.
* IPBase is still built: `transports/snmpIPBaseDomain.lo` appears the same
  number of times in both.
* The configure summary line is byte identical in both, so the `config_require`
  scan is unaffected:
  `transport modules to use...  Callback Unix Alias TCP UDP TCPIPv6 UDPIPv6 IPv4Base SocketBase TCPBase UDPIPv4Base UDPBase IPBase IPv6Base.`

No installed public header includes `snmpIPBaseDomain.h`; it is included only
from `.c` files under `snmplib/transports/`. Nothing downstream loses an include
it could have been using.

### Field evidence from OpenBSD

The `Alien::SNMP` distribution builds net-snmp 5.9.5.2 from source and works
around this by staging the header into `include/net-snmp/library/` before
configure runs. Its current release has **three passing CPAN Testers reports on
OpenBSD 7.8** (perl 5.28.3, 5.38.5 and 5.42.1).

Those are the first OpenBSD passes in that distribution's history. Every prior
OpenBSD report, going back through OpenBSD 6.2 and a dozen releases, is a fail
or an unknown, including one on 7.8 for the release immediately before this
workaround was added. OpenBSD is the platform #552 was filed from, and the
install abort described there is what has to be got past before anything else
can be reached.

### On the `configure` hunk

`configure` is tracked here and practice seems to vary, so I hand-applied the
identical one-line change rather than running autoconf, which would have
produced a large unrelated diff. Happy to drop that hunk if you would rather
regenerate it yourselves.

`V5-9-patches` has the same defect. Happy to open a backport if that is wanted.
