### PR TITLE
snmplib: fix response PDU leak and stale engine ID lengths in rfc5343 probe

### DIFF
--- a/snmplib/snmp_api.c
+++ b/snmplib/snmp_api.c
@@ -1510,8 +1510,11 @@ snmpv3_probe_contextEngineID_rfc5343(struct session_list *slp,
                            response->variables->val_len);
         if (!session->contextEngineID) {
             snmp_log(LOG_ERR, "failed rfc5343 contextEngineID probing: memory allocation failed\n");
+            session->contextEngineIDLen = 0;
+            snmp_free_pdu(response);
             return SNMP_ERR_GENERR;
         }
+        session->contextEngineIDLen = response->variables->val_len;
         
         /* technically there likely isn't a securityEngineID but just
            in case anyone goes looking we might as well have one */
@@ -1521,11 +1524,12 @@ snmpv3_probe_contextEngineID_rfc5343(struct session_list *slp,
                            response->variables->val_len);
         if (!session->securityEngineID) {
             snmp_log(LOG_ERR, "failed rfc5343 securityEngineID probing: memory allocation failed\n");
+            session->securityEngineIDLen = 0;
+            snmp_free_pdu(response);
             return SNMP_ERR_GENERR;
         }
         
-        session->securityEngineIDLen = session->contextEngineIDLen =
-            response->variables->val_len;
+        session->securityEngineIDLen = response->variables->val_len;
         
         if (snmp_get_do_debugging()) {
             size_t i;


### PR DESCRIPTION

## What

`snmpv3_probe_contextEngineID_rfc5343()` in `snmplib/snmp_api.c` has two
problems on the `netsnmp_memdup()` failure paths:

1. The `response` PDU is leaked.
2. `contextEngineIDLen` / `securityEngineIDLen` are left out of sync with the
   pointers they describe.

## Why

Every other exit from this function releases `response` — the early error path
at the top and the normal return at the end — so the two `SNMP_ERR_GENERR`
returns after the memdups were simply missed:

```c
        session->contextEngineID =
            netsnmp_memdup(response->variables->val.string,
                           response->variables->val_len);
        if (!session->contextEngineID) {
            snmp_log(LOG_ERR, "failed rfc5343 contextEngineID probing: memory allocation failed\n");
            return SNMP_ERR_GENERR;      /* response leaked */
        }
```

The length problem is the more interesting one. Both lengths are assigned in a
single statement *after* the second memdup:

```c
        session->securityEngineIDLen = session->contextEngineIDLen =
            response->variables->val_len;
```

If the second memdup fails, the function returns with `contextEngineID` pointing
at a freshly allocated buffer of `val_len` bytes while `contextEngineIDLen` still
holds the length from the previous probe. If that old length is larger, later
code that reads `contextEngineID` for `contextEngineIDLen` bytes runs past the
end of the allocation. On the first path the pointer is NULL while the length is
non-zero.

The function is registered as the TSM security model's `probe_engineid` callback
in `snmplib/snmptsm.c`, so this runs for SSH, TLS and DTLS sessions.

## Changes

- Free the `response` PDU before returning on both failure paths.
- Assign each length immediately after its own `netsnmp_memdup()`, and zero it
  on failure, so the pointer and the length are always updated together.
