### PR TITLE
Don't spam default domain

### DIFF
--- a/snmplib/snmp_api.c
+++ b/snmplib/snmp_api.c
@@ -1783,7 +1783,7 @@ _sess_open(netsnmp_session * in_session)
         } else {
             transport =
                 netsnmp_tdomain_transport_full("snmp", in_session->peername,
-                                               in_session->local_port, "udp,udp6",
+                                               in_session->local_port, NULL,
                                                NULL);
         }
 


### PR DESCRIPTION
Specifying default domains here spams user-configured default domains set via `defDomain` in snmp.conf, rendering the `defDomain` keyword useless for the shipped snmp* tools.

For instance, this fix allows specifying `defDomain snmp udp6 udp` in snmp.conf to set a preference for IPv6 addresses in snmpget, et. al.

The default is still `udp udp6`, as set in _init_snmp, so there is no user visible change out-of-box.

The tcp case is used only by agentx so it does not need the same fix.