### PR TITLE
snmpwalk: call snmp_shutdown() before exiting to release library state

### DIFF
--- a/apps/snmpwalk.c
+++ b/apps/snmpwalk.c
@@ -431,6 +431,7 @@ main(int argc, char *argv[])
 
 out:
     netsnmp_cleanup_session(&session);
+    snmp_shutdown(NETSNMP_APPLICATION_CONFIG_TYPE);
     SOCK_CLEANUP;
     return exitval;
 }


### PR DESCRIPTION
snmpwalk exits without calling snmp_shutdown(), so everything the library allocates during the run (MIB tables, registered config handlers, logging/transport state, etc.) is never released before exit. When built with AddressSanitizer (or run under valgrind), a plain `snmpwalk` invocation reports a large amount of leaked memory coming from library-internal allocations, which makes it hard to spot real leaks in applications embedding libnetsnmp.

This change adds `snmp_shutdown(NETSNMP_APPLICATION_CONFIG_TYPE)` on the `out:` exit path, right after `netsnmp_cleanup_session()`, mirroring what snmptrap.c already does:

```c
out:
    netsnmp_cleanup_session(&session);
    snmp_shutdown(NETSNMP_APPLICATION_CONFIG_TYPE);
    SOCK_CLEANUP;
    return exitval;
```

No functional behavior change; it only frees library state that is otherwise leaked at process exit. Verified with an ASan-instrumented build that the leak reports for snmpwalk disappear.